### PR TITLE
docs: add agent knowledge base

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,12 +1,23 @@
 # Agent Knowledge Base
 
 This directory is the system of record for agent context. AGENTS.md in the repo root
-is the entry point — it points here for details.
+is the entry point and routing table — it points here for details.
 
-| File | Purpose | Updated by |
+Agents: start with AGENTS.md, then read the relevant file here before working.
+
+## Contents
+
+| File | Purpose | When to read |
 |---|---|---|
-| `architecture.md` | System architecture, component map, data flow | After structural changes |
-| `conventions.md` | Detailed coding patterns with examples | After new patterns emerge |
-| `quality.md` | Quality grades per domain | Automation Auditor (weekly) |
-| `plans/active/` | Current sprint plans | Feature Planner |
-| `plans/completed/` | Done plans | Moved here when complete |
+| `architecture.md` | System design, data model, component map | Before making structural changes or adding new features |
+| `conventions.md` | Coding patterns with examples | Before writing any new code |
+| `quality.md` | Quality grades per domain, known gaps | When deciding what to improve |
+| `plans/active/` | Current feature plans | Before picking up work |
+| `plans/completed/` | Done plans (context on past decisions) | When you need to understand why something was built a certain way |
+
+## How to update these files
+
+- `architecture.md` — update when adding new system components, changing data model, or making infrastructure decisions
+- `conventions.md` — update when a new coding pattern emerges that should be replicated, or when an anti-pattern is discovered
+- `quality.md` — updated weekly by the Automation Auditor, or manually after significant changes
+- Plans move from `active/` to `completed/` when all issues in the plan are closed

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1,88 +1,85 @@
 # Architecture
 
-## System Overview
+## Overview
 
-Memo is a Notion-style workspace app. The stack is a standard Next.js App Router
-application backed by Supabase for persistence, auth, and realtime.
+Memo is a Notion-style workspace app: block-based editor, nested pages, workspaces,
+real-time collaboration. Built with Next.js 16 on Vercel, Supabase for data and auth,
+Sentry for error tracking.
+
+## System Diagram
 
 ```
-┌─────────────────────────────────────────────┐
-│                  Vercel                      │
-│  ┌───────────────────────────────────────┐   │
-│  │         Next.js 16 (App Router)       │   │
-│  │  ┌─────────┐  ┌──────────┐  ┌──────┐ │   │
-│  │  │  Pages   │  │   API    │  │ Mid- │ │   │
-│  │  │ (RSC +   │  │  Routes  │  │ ware │ │   │
-│  │  │  Client) │  │          │  │      │ │   │
-│  │  └────┬─────┘  └────┬─────┘  └──┬───┘ │   │
-│  │       │              │           │     │   │
-│  │       └──────┬───────┘           │     │   │
-│  │              │                   │     │   │
-│  │     ┌────────▼────────┐          │     │   │
-│  │     │  Supabase SSR   │◄─────────┘     │   │
-│  │     │  (client/server │                │   │
-│  │     │   /proxy)        │                │   │
-│  │     └────────┬────────┘                │   │
-│  └──────────────┼────────────────────────┘   │
-└─────────────────┼────────────────────────────┘
-                  │
-        ┌─────────▼─────────┐
-        │     Supabase      │
-        │  ┌─────────────┐  │
-        │  │ PostgreSQL   │  │
-        │  │ (RLS)        │  │
-        │  ├─────────────┤  │
-        │  │ Auth         │  │
-        │  ├─────────────┤  │
-        │  │ Realtime     │  │
-        │  └─────────────┘  │
-        └───────────────────┘
+Browser
+  ├── Server Components → Supabase server client (read data, cookie-based auth)
+  ├── Client Components → Supabase browser client (mutations, realtime subscriptions)
+  ├── API Routes (/api/*) → server-side logic, health checks
+  └── Proxy (src/proxy.ts) → Supabase session refresh, route protection
+
+Supabase
+  ├── PostgreSQL → workspaces, pages, blocks, members
+  ├── Auth → GitHub/Google OAuth, email/password
+  ├── Realtime → live collaboration (page edits, presence)
+  └── RLS → row-level security per workspace
+
+Sentry → error tracking, source maps, performance monitoring, session replay
+Vercel → hosting, preview deploys per PR, production deploys on merge
 ```
 
 ## Data Model
 
-The core entities follow a workspace → pages → blocks hierarchy:
+```
+workspace
+  ├── has many: members (user_id + role)
+  └── has many: pages
+        ├── belongs to: workspace
+        ├── has one: parent_page (nullable → enables nesting)
+        └── has many: blocks (ordered by position)
+              ├── type: text | heading_1 | heading_2 | heading_3 | bullet_list |
+              │         numbered_list | todo | code | image | divider | callout | toggle
+              └── content: JSON (structure varies by type)
+```
 
-- **Workspace**: top-level container, owns pages and members
-- **Page**: a document within a workspace, supports nesting (parent_id)
-- **Block**: content unit within a page, stored as JSON (Tiptap/BlockNote format)
+## Key Technical Decisions
 
-All tables use Supabase Row Level Security (RLS) to enforce access control.
+| Decision | Choice | Rationale |
+|---|---|---|
+| Editor library | Tiptap or BlockNote (evaluate before building) | Do NOT build a custom editor — this is months of work |
+| Content storage | JSON block tree in PostgreSQL | Flexible, queryable, no HTML parsing needed |
+| Auth | Supabase Auth with RLS | Row-level security at the DB layer, no app-level auth checks needed per query |
+| Realtime | Supabase Realtime subscriptions | Built into the client, no extra infrastructure |
+| Styling | Tailwind v4 + shadcn/ui | No custom CSS, consistent design system |
+| Package manager | pnpm | Strict dependency resolution, faster installs |
+| Session management | Next.js 16 proxy (not middleware) | `src/proxy.ts` with `updateSession` — Next.js 16 convention replacing middleware |
 
-## Key Decisions
+## Request Flow
 
-| Decision | Rationale |
-|---|---|
-| Next.js App Router | Server components by default, streaming, built-in layouts |
-| Supabase (not raw Postgres) | Auth, RLS, Realtime, and JS SDK out of the box |
-| Tiptap or BlockNote for editor | Block-based editing with slash commands, JSON output |
-| JSON block storage | Flexible schema for diverse block types |
-| No ORM | Direct Supabase client calls — simpler, fewer abstractions |
-| Tailwind + shadcn/ui | Consistent design system without custom CSS |
+1. User visits a page → proxy (`src/proxy.ts`) refreshes Supabase session via `updateSession`
+2. Server component renders with data from Supabase server client (`@/lib/supabase/server`)
+3. Client component hydrates, subscribes to Realtime for live updates
+4. User edits a block → client component writes to Supabase → Realtime broadcasts to other users
+5. Errors captured by Sentry (client via `instrumentation-client.ts`, server via `src/instrumentation.ts`)
 
 ## Component Map
 
 ```
 src/
 ├── app/                    # Next.js App Router
-│   ├── layout.tsx          # Root layout (fonts, global styles)
+│   ├── layout.tsx          # Root layout (Geist fonts, global styles)
 │   ├── page.tsx            # Landing page
 │   ├── global-error.tsx    # Sentry error boundary
-│   ├── api/
-│   │   └── health/         # Health check endpoint
-│   └── (auth)/             # Auth routes (future)
-├── components/
-│   └── ui/                 # shadcn/ui primitives
+│   └── api/
+│       └── health/route.ts # Health check endpoint (DB connectivity)
 ├── lib/
 │   └── supabase/
-│       ├── client.ts       # Browser client
-│       ├── server.ts       # Server component client
-│       └── proxy.ts        # Session refresh
-├── proxy.ts                 # Root proxy (Supabase session, Next.js 16 convention)
-└── instrumentation.ts      # Sentry server/edge init
+│       ├── client.ts       # Browser client (createBrowserClient)
+│       ├── server.ts       # Server component client (createServerClient + cookies)
+│       └── proxy.ts        # Session refresh logic (updateSession)
+├── proxy.ts                # Root proxy — calls updateSession, skips static/health routes
+└── instrumentation.ts      # Sentry server/edge init (register + onRequestError)
 ```
 
 ## Observability
 
-- **Sentry**: error tracking, performance monitoring, session replay
-- **Health endpoint**: `/api/health` — checks DB connectivity
+- **Sentry client**: session replay (10% normal, 100% on error), route transition tracking
+- **Sentry server**: PII enabled, local variables, 10% trace sampling in production
+- **Health endpoint**: `GET /api/health` — checks DB connectivity, returns status + latency

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1,23 +1,70 @@
-# Coding Conventions
+# Conventions
 
-## Supabase Server Client (Server Components / Route Handlers)
+Detailed coding patterns for this project. AGENTS.md has the rules — this file has
+the examples. Read this before writing any new code.
+
+## Supabase Usage
+
+### Server Components (reading data)
+
+The server client uses `@supabase/ssr` with the Next.js `cookies()` API. It is async
+because `cookies()` returns a promise in Next.js 16.
 
 ```typescript
-import { createClient } from "@/lib/supabase/server";
+// src/lib/supabase/server.ts
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
 
-export default async function Page() {
-  const supabase = await createClient();
-  const { data, error } = await supabase.from("pages").select("*");
-
-  if (error) {
-    throw error;
-  }
-
-  return <div>{/* render data */}</div>;
+export async function createClient() {
+  const cookieStore = await cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // setAll is called from Server Components where cookies can't be set.
+            // This can be ignored if the proxy refreshes the session.
+          }
+        },
+      },
+    }
+  );
 }
 ```
 
-## Supabase Browser Client (Client Components)
+Usage in a server component or route handler:
+
+```typescript
+const supabase = await createClient();
+const { data, error } = await supabase.from("pages").select("*");
+```
+
+### Client Components (mutations, realtime)
+
+The browser client is synchronous — no `await` needed.
+
+```typescript
+// src/lib/supabase/client.ts
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+  );
+}
+```
+
+Usage in a client component:
 
 ```typescript
 "use client";
@@ -39,47 +86,173 @@ export function PageList() {
 }
 ```
 
-## Component File Naming
+### Proxy (session refresh)
 
-- One component per file
-- Kebab-case filenames: `page-list.tsx`, `workspace-header.tsx`
-- Named exports only: `export function PageList() {}`
-- No default exports (except Next.js pages/layouts which require them)
-
-## API Route Error Handling
+Next.js 16 uses `src/proxy.ts` instead of `src/middleware.ts`. The proxy refreshes
+the Supabase session on every request (except static assets and health checks).
 
 ```typescript
+// src/proxy.ts
+import { updateSession } from "@/lib/supabase/proxy";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function proxy(request: NextRequest) {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  ) {
+    return NextResponse.next();
+  }
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: [
+    "/((?!monitoring|_next/static|_next/image|favicon.ico|api/health|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};
+```
+
+The `updateSession` function in `src/lib/supabase/proxy.ts` creates a server client
+that reads cookies from the request and writes refreshed cookies to the response.
+It calls `supabase.auth.getUser()` to trigger the refresh.
+
+## Component Patterns
+
+### Server Component (default)
+
+Server components are the default. They are async functions with named exports
+(except `page.tsx` and `layout.tsx` which use default exports per Next.js convention).
+
+```typescript
+// src/app/page.tsx — landing page (server component, no "use client")
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-8">
+      <div className="max-w-2xl text-center space-y-6">
+        <h1 className="text-5xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+          Memo
+        </h1>
+        {/* ... */}
+      </div>
+    </main>
+  );
+}
+```
+
+### Client Component (only when needed)
+
+Use `"use client"` only for hooks, event handlers, or browser APIs.
+
+```typescript
+// src/app/global-error.tsx — needs useEffect and Sentry browser SDK
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import NextError from "next/error";
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        <NextError statusCode={0} />
+      </body>
+    </html>
+  );
+}
+```
+
+### When to use which
+
+- Fetching and displaying data → server component
+- Forms, buttons, interactive UI → client component
+- Layout, navigation structure → server component
+- Real-time subscriptions → client component
+
+## File Naming
+
+- Components: `kebab-case.tsx` (e.g., `page-list.tsx`)
+- Utilities: `kebab-case.ts` (e.g., `format-date.ts`)
+- All exports are named exports. No default exports.
+- One component per file.
+- Exception: Next.js pages (`page.tsx`), layouts (`layout.tsx`), and error boundaries
+  (`global-error.tsx`) use default exports as required by the framework.
+
+## API Routes
+
+Route handlers use `NextResponse.json()` with structured error handling:
+
+```typescript
+// src/app/api/health/route.ts
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
 export async function GET() {
+  const start = Date.now();
+  let dbStatus = "ok";
+  let dbLatency = 0;
+
   try {
     const supabase = await createClient();
-    const { data, error } = await supabase.from("pages").select("*");
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
+    const { error } = await supabase
+      .from("_health_check")
+      .select("1")
+      .limit(1)
+      .maybeSingle();
+    dbLatency = Date.now() - start;
+    // Table may not exist yet — that's fine, connection worked if no network error
+    if (error && !error.message.includes("does not exist")) {
+      dbStatus = "degraded";
     }
-
-    return NextResponse.json(data);
   } catch {
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    dbStatus = "down";
+    dbLatency = Date.now() - start;
   }
+
+  const status = dbStatus === "down" ? "down" : "ok";
+
+  return NextResponse.json({
+    status,
+    db: { connected: dbStatus !== "down", latency_ms: dbLatency },
+    timestamp: new Date().toISOString(),
+  });
 }
 ```
+
+Pattern: wrap in try/catch, return structured JSON with appropriate status codes.
 
 ## Database Migrations
 
 ```bash
-# Create a new migration
-supabase migration new add_pages_table
-
-# Edit the generated SQL file in supabase/migrations/
+supabase migration new <descriptive-name>
+# Creates: supabase/migrations/<timestamp>_<name>.sql
+# Write SQL in that file
 # Always include RLS policies in the same migration
+# Auto-applied on merge to main via Supabase GitHub integration
 ```
+
+## Testing
+
+- Unit tests go next to the file they test: `foo.test.ts` alongside `foo.ts`
+- Use Vitest: `import { describe, it, expect } from 'vitest'`
+- API route tests: test the route handler directly
+- Skip tests for components that are just layout/styling with no logic
+- Run before pushing: `pnpm lint && pnpm typecheck && pnpm test`
+
+## Imports
+
+- Use `@/` path alias for all project imports
+- Group imports: external packages → internal modules → types
+- No barrel exports (index.ts re-exports)
 
 ## TypeScript
 
@@ -89,8 +262,7 @@ supabase migration new add_pages_table
 - No `as` casts unless unavoidable (add a comment explaining why)
 - Prefer interfaces for object shapes, types for unions/intersections
 
-## Imports
+## This file evolves
 
-- Use `@/` path alias for all project imports
-- Group imports: external packages → internal modules → types
-- No barrel exports (index.ts re-exports)
+When you discover a new pattern that should be replicated, or an anti-pattern that
+should be avoided, add it here. The Automation Auditor may also propose additions.

--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -1,16 +1,35 @@
-# Quality Status
+# Quality Grades
 
-Last updated: 2026-04-14
+Updated weekly by the Automation Auditor. Tracks code quality per domain.
+
+## Grading Scale
+
+- **A** — Well-tested, clean patterns, no known issues
+- **B** — Functional, minor test gaps or inconsistencies
+- **C** — Works but needs attention — missing tests, unclear patterns
+- **D** — Significant issues — bugs, no tests, inconsistent patterns
+- **-** — Not yet implemented
+
+## Current Grades
 
 | Domain | Grade | Notes |
 |---|---|---|
+| Infrastructure | - | Scaffold complete, not yet graded |
 | Auth | - | Not yet implemented |
+| Workspaces | - | Not yet implemented |
 | Pages | - | Not yet implemented |
 | Editor | - | Not yet implemented |
 | Search | - | Not yet implemented |
 | Realtime | - | Not yet implemented |
-| UI/Design | - | Landing page only |
-| API | - | Health endpoint only |
-| Testing | - | Framework configured, no tests yet |
-| CI/CD | - | Workflow defined, not yet run |
-| Observability | - | Sentry configured, not yet verified |
+| API routes | - | Health endpoint exists |
+| UI components | - | Landing page only |
+
+## Known Gaps
+
+*Project is bootstrapping. No quality gaps identified yet.*
+
+## History
+
+| Date | Change |
+|---|---|
+| 2026-04-14 | Initial quality tracking created |


### PR DESCRIPTION
Adds the `.agents/` directory referenced by AGENTS.md: architecture overview, coding conventions with examples, quality grades, and plan directories. This is the structured knowledge base that all automations read before working.

### Changes

- **`.agents/README.md`** — routing table with "when to read" guidance and update instructions
- **`.agents/architecture.md`** — system diagram, data model, request flow, component map reflecting the actual codebase (proxy pattern, Sentry setup, health endpoint)
- **`.agents/conventions.md`** — real code examples from `src/lib/supabase/`, `src/proxy.ts`, `src/app/api/health/route.ts`, and `src/app/global-error.tsx`
- **`.agents/quality.md`** — grading scale, per-domain grades (all `-` since project is bootstrapping), history table
- **`.agents/plans/active/.gitkeep`** and **`.agents/plans/completed/.gitkeep`** — empty plan directories