### PR TITLE
chore(ci): fix workflow visibility, add migration dry-run, bump to node24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,16 @@
 name: CI
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -3,13 +3,18 @@ name: Deploy Migrations
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - supabase/migrations/**
   workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  deploy:
+  dry-run:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     env:
@@ -18,8 +23,32 @@ jobs:
       SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
+      # supabase/setup-cli@v1 still targets node20; keep FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 until they ship a node24 version
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        run: supabase link --project-ref $SUPABASE_PROJECT_ID
+
+      - name: Dry-run migrations
+        run: supabase db push --dry-run
+
+  deploy:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # supabase/setup-cli@v1 still targets node20; keep FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 until they ship a node24 version
       - uses: supabase/setup-cli@v1
         with:
           version: latest

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "memo",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Motivation

CI checks don't appear in the branch protection status check selector because the `check` job never runs on `main`. The deploy-migrations workflow has no pre-merge validation, and several actions target the deprecated Node.js 20 runtime.

## Changes

**`ci.yml`**
- Add `push: branches: [main]` trigger so the `check` job runs on `main` and populates the status check selector
- Bump `actions/checkout` v4→v6, `actions/setup-node` v4→v6, `pnpm/action-setup` v4→v5 (all node24-native)
- Drop explicit pnpm `version` input — v5 reads from `packageManager` in `package.json`

**`deploy-migrations.yml`**
- Add `dry-run` job on PRs that touch `supabase/migrations/**` — runs `supabase db push --dry-run` to validate migrations before merge
- Gate `deploy` job to `push`/`workflow_dispatch` only
- Bump `actions/checkout` v4→v6
- `supabase/setup-cli@v1` stays at v1 (no node24 version available yet; `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` covers it)

**`package.json`**
- Add `"packageManager": "pnpm@10.32.1"` for `pnpm/action-setup@v5`