### PR TITLE
chore(ci): remove paths filter from migration dry-run

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -5,8 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - supabase/migrations/**
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Remove the `paths` filter from the `pull_request` trigger in `deploy-migrations.yml` so the `dry-run` job runs on every PR. This ensures it always produces a check result and can be added as a required status check in the branch ruleset.