### PR TITLE
chore: add tweet posting script for autonomous social updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jsdom": "^29.0.2",
     "playwright": "^1.59.1",
     "tailwindcss": "^4",
+    "twitter-api-v2": "^1.29.0",
     "typescript": "^5",
     "vitest": "^4.1.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.2
+      twitter-api-v2:
+        specifier: ^1.29.0
+        version: 1.29.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -3105,6 +3108,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  twitter-api-v2@1.29.0:
+    resolution: {integrity: sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -6594,6 +6600,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  twitter-api-v2@1.29.0: {}
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/tweet.ts
+++ b/scripts/tweet.ts
@@ -1,0 +1,62 @@
+/**
+ * Post a tweet to @swfactory_dev via Twitter API v2.
+ *
+ * Usage: npx tsx scripts/tweet.ts "Your tweet text here"
+ *
+ * Required env vars (OAuth 1.0a User Context):
+ *   TWITTER_CONSUMER_KEY
+ *   TWITTER_SECRET_KEY
+ *   TWITTER_ACCESS_TOKEN
+ *   TWITTER_ACCESS_TOKEN_SECRET
+ */
+
+import { TwitterApi } from "twitter-api-v2";
+
+const text = process.argv[2];
+
+if (!text) {
+  console.error("Usage: npx tsx scripts/tweet.ts <text>");
+  process.exit(1);
+}
+
+if (text.length > 280) {
+  console.error(`Tweet is ${text.length} chars (max 280). Trim it first.`);
+  process.exit(1);
+}
+
+const required = [
+  "TWITTER_CONSUMER_KEY",
+  "TWITTER_SECRET_KEY",
+  "TWITTER_ACCESS_TOKEN",
+  "TWITTER_ACCESS_TOKEN_SECRET",
+] as const;
+
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length) {
+  console.error(`Missing env vars: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+const client = new TwitterApi({
+  appKey: process.env.TWITTER_CONSUMER_KEY!,
+  appSecret: process.env.TWITTER_SECRET_KEY!,
+  accessToken: process.env.TWITTER_ACCESS_TOKEN!,
+  accessSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET!,
+});
+
+async function main() {
+  try {
+    const { data } = await client.v2.tweet(text);
+    const url = `https://x.com/swfactory_dev/status/${data.id}`;
+    console.log(`Posted: ${url}`);
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      console.error(`Failed to post tweet: ${err.message}`);
+    } else {
+      console.error("Failed to post tweet:", err);
+    }
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Adds `scripts/tweet.ts` so the Tweet Drafter automation can post to
[@swfactory_dev](https://x.com/swfactory_dev) autonomously.

## What

- `scripts/tweet.ts` — CLI script that posts a tweet via Twitter API v2 with OAuth 1.0a
- `twitter-api-v2` added as a dev dependency
- Usage: `npx tsx scripts/tweet.ts "Your tweet text"`
- Validates length (≤280 chars) and required env vars before posting

## Env vars required

- `TWITTER_CONSUMER_KEY`
- `TWITTER_SECRET_KEY`
- `TWITTER_ACCESS_TOKEN`
- `TWITTER_ACCESS_TOKEN_SECRET`

All four are already configured as project secrets.

## Tested

Live-tested — successfully posted: https://x.com/swfactory_dev/status/2044145900646256803