### PR TITLE
chore: tweet 3x daily and fix migration timestamp format

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -232,13 +232,38 @@ Pattern: wrap in try/catch, return structured JSON with appropriate status codes
 
 ## Database Migrations
 
+Create migration files manually in `supabase/migrations/` with a UTC timestamp prefix:
+
 ```bash
-supabase migration new <descriptive-name>
-# Creates: supabase/migrations/<timestamp>_<name>.sql
-# Write SQL in that file
-# Always include RLS policies in the same migration
-# Auto-applied on merge to main via Supabase GitHub integration
+# Format: YYYYMMDDHHmmss_<descriptive_name>.sql
+# Use the current UTC time when creating the file.
+# Example (created at 2026-04-14 20:00:00 UTC):
+touch supabase/migrations/20260414200000_add_pages_table.sql
 ```
+
+```sql
+-- supabase/migrations/20260414200000_add_pages_table.sql
+create table pages (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  title text not null default '',
+  created_at timestamptz not null default now()
+);
+
+-- Always include RLS policies in the same migration
+alter table pages enable row level security;
+
+create policy "workspace members can read pages"
+  on pages for select
+  using (workspace_id in (
+    select workspace_id from members where user_id = auth.uid()
+  ));
+```
+
+Rules:
+- Timestamp must be current UTC time — never reuse or backdate timestamps.
+- One migration per logical change (table + its RLS policies together).
+- Auto-applied on merge to main via the deploy-migrations CI workflow.
 
 ## Testing
 

--- a/.ona/automations/bug-fixer.yaml
+++ b/.ona/automations/bug-fixer.yaml
@@ -6,6 +6,7 @@ triggers:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       pullRequest:
+        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
         events:
             - PULL_REQUEST_EVENT_MERGED
     - context:
@@ -98,7 +99,8 @@ action:
                 9. Fix the root cause. Do NOT fix symptoms.
                    - Follow every convention in AGENTS.md without exception.
                    - Add a regression test that would have caught this bug.
-                   - For database changes: create a Supabase migration via `supabase migration new <name>`.
+                   - For database changes: create a migration file in `supabase/migrations/` with a UTC
+                     timestamp prefix: `YYYYMMDDHHmmss_<name>.sql` (use current UTC time).
                 10. Run the full CI check locally: `pnpm lint && pnpm typecheck && pnpm test`
                 11. Fix any errors before proceeding.
 

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -6,6 +6,7 @@ triggers:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       pullRequest:
+        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
         events:
             - PULL_REQUEST_EVENT_MERGED
     - context:
@@ -94,7 +95,9 @@ action:
 
                 Before coding, decide:
                 - **Database**: does this need a new table, new columns, or new RLS policies?
-                  If yes, create the migration first: `supabase migration new <name>`
+                  If yes, create the migration file first in `supabase/migrations/` with a UTC
+                  timestamp prefix: `YYYYMMDDHHmmss_<name>.sql` (e.g. `20260414200000_add_pages_table.sql`).
+                  Use the current UTC time — never reuse or backdate timestamps.
                 - **API**: does this need new API routes? Follow the existing pattern in `src/app/api/`.
                 - **Components**: which existing components can be reused? What new ones are needed?
                   Check `src/components/ui/` (shadcn) before building anything custom.

--- a/.ona/automations/post-merge-verifier.yaml
+++ b/.ona/automations/post-merge-verifier.yaml
@@ -6,6 +6,7 @@ triggers:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       pullRequest:
+        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
         events:
             - PULL_REQUEST_EVENT_MERGED
 action:

--- a/.ona/automations/pr-reviewer.yaml
+++ b/.ona/automations/pr-reviewer.yaml
@@ -6,6 +6,7 @@ triggers:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       pullRequest:
+        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
         events:
             - PULL_REQUEST_EVENT_OPENED
             - PULL_REQUEST_EVENT_UPDATED

--- a/.ona/automations/tweet-drafter.yaml
+++ b/.ona/automations/tweet-drafter.yaml
@@ -1,20 +1,43 @@
 name: Tweet Drafter
-description: Generates a daily social media post and posts it to Twitter/X.
+description: Posts build-in-public updates to @swfactory_dev 3x daily (morning, afternoon, evening UTC).
 triggers:
     - context:
         projects:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       time:
-        cronExpression: 0 17 * * *
+        cronExpression: 0 9 * * *
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: 0 15 * * *
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: 0 21 * * *
 action:
     limits:
         maxParallel: 1
-        maxTotal: 7
+        maxTotal: 21
     steps:
         - agent:
             prompt: |
-                You are the Tweet Drafter. Generate a daily social media post and post it to Twitter/X.
+                You are the Tweet Drafter for @swfactory_dev. You post build-in-public updates
+                about Memo — a Notion-style workspace built entirely by AI agents.
+
+                You run 3 times per day. Each slot has a different angle:
+
+                | Slot | UTC | Angle |
+                |---|---|---|
+                | Morning | 09:00 | What's planned — backlog items, what the agents will work on today |
+                | Afternoon | 15:00 | What shipped — PRs merged, features landed, bugs fixed since morning |
+                | Evening | 21:00 | Stats & reflection — day's numbers, learnings, what surprised us |
+
+                Determine which slot this is by checking the current hour (UTC).
 
                 ## Input
 
@@ -22,26 +45,34 @@ action:
                    If today's metrics file doesn't exist yet, use the most recent one.
                 2. List PRs merged today: gh pr list --state merged --search "merged:YYYY-MM-DD"
                    Read each PR title.
-                3. Read the previous tweet from metrics/daily/ (most recent *-tweet.md) to avoid
-                   repeating the same phrasing.
+                3. List open backlog issues: gh issue list --label "status:backlog" --state open --json number,title
+                4. List in-progress issues: gh issue list --label "status:in-progress" --state open --json number,title
+                5. Read previous tweets from metrics/daily/ (most recent *-tweet.md files) to avoid
+                   repeating the same phrasing or stats.
+
+                ## Day counting
+
+                Day 1 was 2026-04-13 (project setup). Calculate the current day number from that.
 
                 ## Twitter/X (max 280 chars)
 
-                Structure:
-                  [Feature or stat hook] → [1-2 features in user terms] → [1-2 stats] →
-                  Try it: https://memo.software-factory.dev →
+                Structure varies by slot:
+                - Morning: [Day N] → what's on deck → what agents are building → link
+                - Afternoon: [what shipped] → user-facing description → stats → link
+                - Evening: [day's stats] → reflection or learning → link
+
+                Always end with:
+                  https://memo.software-factory.dev
                   Built with @onadev
 
                 Rules:
                 - Describe features as a user would, not a developer.
-                - Use real numbers from the metrics file.
+                - Use real numbers from metrics or PR counts.
                 - Vary the opening — don't always start with "Day N".
                 - No hashtags. Max 2 emoji. No superlatives.
-                - If nothing meaningful shipped today, write about what's in progress.
-
-                ## LinkedIn (3-5 sentences, ~500 chars)
-
-                Longer version of the same update.
+                - If nothing meaningful happened for this slot, write about what's in progress
+                  or share a learning from the build process.
+                - Do NOT repeat content from a tweet posted earlier today.
 
                 ## Post to Twitter/X
 
@@ -52,15 +83,12 @@ action:
 
                 ## Output
 
-                Create a branch: `chore/tweet-YYYY-MM-DD`
+                Create a branch: `chore/tweet-YYYY-MM-DD-<slot>` (slot = morning, afternoon, evening)
 
-                Write to metrics/daily/YYYY-MM-DD-tweet.md:
-                  ## Twitter/X
+                Write to metrics/daily/YYYY-MM-DD-tweet-<slot>.md:
+                  ## Twitter/X (<slot>)
                   <tweet text>
                   Posted: yes/no (error: <if failed>)
 
-                  ## LinkedIn
-                  <longer version>
-
-                Commit: `chore: draft social post YYYY-MM-DD`
+                Commit: `chore: social post YYYY-MM-DD <slot>`
                 Push and open a PR.

--- a/.ona/automations/ui-verifier.yaml
+++ b/.ona/automations/ui-verifier.yaml
@@ -6,6 +6,7 @@ triggers:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       pullRequest:
+        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
         events:
             - PULL_REQUEST_EVENT_MERGED
 action:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ metrics/           → Daily/weekly metrics snapshots
 - Named exports only. No default exports.
 - Conventional commits: `feat|fix|chore|docs|test|refactor(scope): description`
 - PRs with type `feat` or `fix` must reference an issue: `Closes #N`. Chore PRs (metrics, docs, deps) do not require an issue.
-- Database changes require a migration: `supabase migration new <name>`
+- Database changes require a migration file in `supabase/migrations/` with timestamp prefix: `YYYYMMDDHHmmss_<name>.sql` (use current UTC time, e.g. `20260414200000_add_pages_table.sql`)
 - Environment variables: `NEXT_PUBLIC_` prefix only for browser-safe values.
 
 ## Testing

--- a/docs/automations.md
+++ b/docs/automations.md
@@ -401,7 +401,9 @@ Before writing anything, understand the current codebase:
 
 Before coding, decide:
 - **Database**: does this need a new table, new columns, or new RLS policies?
-  If yes, create the migration first: `supabase migration new <name>`
+  If yes, create the migration file first in `supabase/migrations/` with a UTC
+  timestamp prefix: `YYYYMMDDHHmmss_<name>.sql` (e.g. `20260414200000_add_pages_table.sql`).
+  Use the current UTC time — never reuse or backdate timestamps.
 - **API**: does this need new API routes? Follow the existing pattern in `src/app/api/`.
 - **Components**: which existing components can be reused? What new ones are needed?
   Check `src/components/ui/` (shadcn) before building anything custom.
@@ -696,7 +698,8 @@ For infra/config bugs:
 9. Fix the root cause. Do NOT fix symptoms.
    - Follow every convention in AGENTS.md without exception.
    - Add a regression test that would have caught this bug.
-   - For database changes: create a Supabase migration via `supabase migration new <name>`.
+   - For database changes: create a migration file in `supabase/migrations/` with a UTC
+     timestamp prefix: `YYYYMMDDHHmmss_<name>.sql` (use current UTC time).
 10. Run the full CI check locally: `pnpm lint && pnpm typecheck && pnpm test`
 11. Fix any errors before proceeding.
 


### PR DESCRIPTION
Two changes:

## 1. Tweet Drafter → 3x daily

Updated from once daily (5pm UTC) to three slots:

| Slot | UTC | Angle |
|---|---|---|
| Morning | 09:00 | What's planned — backlog items, what agents will work on |
| Afternoon | 15:00 | What shipped — PRs merged, features landed, bugs fixed |
| Evening | 21:00 | Stats & reflection — day's numbers, learnings |

Day counting starts from 2026-04-13 (Day 1 = setup).

## 2. Migration timestamp format

Replaced all `supabase migration new <name>` references with explicit instructions
to create files manually with `YYYYMMDDHHmmss_<name>.sql` format using current UTC
time. The Supabase CLI is not installed in the devcontainer, so agents need to create
migration files directly.

Updated in: `AGENTS.md`, `.agents/conventions.md`, `docs/automations.md`,
`.ona/automations/feature-builder.yaml`, `.ona/automations/bug-fixer.yaml`.

## 3. webhookId added to PR-triggered YAMLs

All 5 PR-triggered automation YAMLs now include `webhookId` so they can be
re-registered from the YAML files without manual webhook binding.

All three registered automations (Tweet Drafter, Feature Builder, Bug Fixer)
have been updated on the Ona platform.