### PR TITLE
docs: finalize product spec, architecture, and design for MVP buildout

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2,24 +2,25 @@
 
 ## Overview
 
-Memo is a Notion-style workspace app: block-based editor, nested pages, workspaces,
-real-time collaboration. Built with Next.js 16 on Vercel, Supabase for data and auth,
-Sentry for error tracking.
+Memo is a Notion-style workspace app: Lexical block editor, nested pages, personal +
+team workspaces, member invitations. Built with Next.js 16 on Vercel, Supabase for
+data and auth, Sentry for error tracking. Realtime collaboration is deferred to post-MVP.
 
 ## System Diagram
 
 ```
 Browser
   ├── Server Components → Supabase server client (read data, cookie-based auth)
-  ├── Client Components → Supabase browser client (mutations, realtime subscriptions)
+  ├── Client Components → Supabase browser client (mutations, Lexical editor)
   ├── API Routes (/api/*) → server-side logic, health checks
   └── Proxy (src/proxy.ts) → Supabase session refresh, route protection
 
 Supabase
-  ├── PostgreSQL → workspaces, pages, blocks, members
-  ├── Auth → GitHub/Google OAuth, email/password
-  ├── Realtime → live collaboration (page edits, presence)
-  └── RLS → row-level security per workspace
+  ├── PostgreSQL → profiles, workspaces, members, workspace_invites, pages
+  ├── Auth → email/password (OAuth deferred — buttons rendered with "coming soon")
+  ├── Storage → image uploads for editor
+  ├── DB Triggers → handle_new_user (profile + personal workspace + owner membership)
+  └── RLS → row-level security per workspace membership
 
 Sentry → error tracking, source maps, performance monitoring, session replay
 Vercel → hosting, preview deploys per PR, production deploys on merge
@@ -29,45 +30,123 @@ Vercel → hosting, preview deploys per PR, production deploys on merge
 
 No database migrations exist yet. The schema below is the planned target model.
 Create migrations in `supabase/migrations/` as features are implemented.
+See `docs/product-spec.md` → Data Model for the full column-level schema.
 
 ```
-workspace
-  ├── has many: members (user_id + role)
+profiles (1:1 with auth.users)
+  └── created automatically on sign-up via handle_new_user trigger
+
+workspaces
+  ├── is_personal: boolean (personal workspace = non-deletable, always listed first)
+  ├── created_by → profiles.id
+  ├── Constraint: max 3 workspaces per user (created_by count, enforced via DB trigger)
+  ├── Constraint: one personal workspace per user (partial unique index)
+  ├── has many: members (user_id + role: owner | admin | member)
+  ├── has many: workspace_invites (email + role + token)
   └── has many: pages
-        ├── belongs to: workspace
-        ├── has one: parent_page (nullable → enables nesting)
-        └── has many: blocks (ordered by position)
-              ├── type: text | heading_1 | heading_2 | heading_3 | bullet_list |
-              │         numbered_list | todo | code | image | divider | callout | toggle
-              └── content: JSON (structure varies by type)
+        ├── parent_id → pages.id (nullable, enables nesting)
+        ├── content: jsonb (Lexical editor state — NOT a separate blocks table)
+        ├── position: integer (ordering among siblings)
+        └── created_by → profiles.id
+
+Sign-up flow (atomic, via DB trigger):
+  1. auth.users row created by Supabase Auth
+  2. handle_new_user trigger fires → creates:
+     a. profiles row
+     b. workspaces row (is_personal = true, name = "{display_name}'s Workspace")
+     c. members row (role = owner)
 ```
 
 ## Key Technical Decisions
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Editor library | Tiptap or BlockNote (evaluate before building) | Do NOT build a custom editor — this is months of work |
-| Content storage | JSON block tree in PostgreSQL | Flexible, queryable, no HTML parsing needed |
-| Auth | Supabase Auth with RLS | Row-level security at the DB layer, no app-level auth checks needed per query |
-| Realtime | Supabase Realtime subscriptions | Built into the client, no extra infrastructure |
+| Editor library | **Lexical** (Meta, MIT) | Full control, MIT license, Meta-backed. Build from lexical-playground reference, adapt to Tailwind + shadcn/ui. |
+| Content storage | Lexical JSON in PostgreSQL `jsonb` | `editorState.toJSON()` stored in `pages.content`. No separate blocks table. |
+| Auth | Supabase Auth — email/password | OAuth (GitHub, Google) deferred to post-MVP. Buttons rendered with "coming soon" tooltip. |
+| Workspace model | Personal + team workspaces | Auto-created personal workspace on sign-up (non-deletable). Max 3 created workspaces per user. Unlimited joined via invite. |
+| Realtime | Deferred to post-MVP | Yjs + Supabase Realtime adds complexity. Ship single-user editing first. |
 | Styling | Tailwind v4 + shadcn/ui | No custom CSS, consistent design system |
 | Package manager | pnpm | Strict dependency resolution, faster installs |
 | Session management | Next.js 16 proxy (not middleware) | `src/proxy.ts` with `updateSession` — Next.js 16 convention replacing middleware |
+| Floating UI | `@floating-ui/react` | Positioning for slash command menu, floating toolbar, link editor (same as Lexical playground) |
+| Image storage | Supabase Storage | Bucket for uploaded images, public URL stored in ImageNode |
+| Full-text search | PostgreSQL `tsvector` + `tsquery` | Generated column or trigger on page title + extracted content text |
+
+## Lexical Editor — Implementation Plan
+
+The Lexical playground (`facebook/lexical/packages/lexical-playground`) is the reference.
+We do NOT fork it. We build a Memo-specific editor using official Lexical packages,
+referencing the playground for patterns. All UI rebuilt with Tailwind + shadcn/ui.
+
+### Official Lexical packages (install from npm)
+
+| Package | Purpose |
+|---|---|
+| `lexical` | Core editor engine |
+| `@lexical/react` | React bindings (LexicalComposer, plugins, hooks) |
+| `@lexical/rich-text` | Headings, quotes, rich text support |
+| `@lexical/list` | Bullet, numbered, and check lists |
+| `@lexical/code` | Code blocks |
+| `@lexical/link` | Link nodes and auto-linking |
+| `@lexical/selection` | Selection utilities |
+| `@lexical/utils` | Shared utilities |
+| `@lexical/markdown` | Markdown import/export transforms |
+| `@lexical/clipboard` | Copy/paste handling |
+
+Pin to a specific version to avoid breaking changes.
+
+### Custom plugins (referencing playground)
+
+| Plugin | Playground reference | Complexity |
+|---|---|---|
+| ComponentPickerPlugin (slash commands) | `plugins/ComponentPickerPlugin` | Medium |
+| DraggableBlockPlugin (drag-and-drop) | `plugins/DraggableBlockPlugin` | High |
+| FloatingTextFormatToolbarPlugin | `plugins/FloatingTextFormatToolbarPlugin` | High |
+| FloatingLinkEditorPlugin | `plugins/FloatingLinkEditorPlugin` | Medium |
+| ImagesExtension | `plugins/ImagesExtension` | High |
+| CodeHighlightExtension | `plugins/CodeHighlightExtension` | Medium |
+| CollapsibleExtension (toggle blocks) | `plugins/CollapsibleExtension` | Medium |
+| ToolbarPlugin (top toolbar) | `plugins/ToolbarPlugin` | High |
+
+### Custom nodes
+
+| Node | Type | Purpose |
+|---|---|---|
+| ImageNode | DecoratorNode | Image display with caption, resize handles |
+| CalloutNode | ElementNode | Callout/alert block with emoji + text |
+| DividerNode | HorizontalRuleNode (`@lexical/extension`) | Horizontal divider |
+
+### Skipped plugins (not needed for MVP)
+
+ExcalidrawPlugin, EquationsPlugin, PollPlugin, FigmaExtension, MentionsPlugin,
+SpeechToTextPlugin, AutocompletePlugin, CommentPlugin, TablePlugin, LayoutPlugin,
+DateTimeExtension, VersionsPlugin.
+
+### Content storage flow
+
+```
+Save: editor.getEditorState().toJSON() → Supabase pages.content (jsonb)
+Load: editor.setEditorState(editor.parseEditorState(json))
+Auto-save: debounce 500ms on editor change → write to Supabase
+```
 
 ## Request Flow
 
 1. User visits a page → proxy (`src/proxy.ts`) refreshes Supabase session via `updateSession`
 2. Server component renders with data from Supabase server client (`@/lib/supabase/server`)
-3. Client component hydrates, subscribes to Realtime for live updates
-4. User edits a block → client component writes to Supabase → Realtime broadcasts to other users
+3. Client component hydrates, initializes Lexical editor with saved content from `pages.content`
+4. User edits content → Lexical editor state changes → debounced auto-save writes `editorState.toJSON()` to Supabase
 5. Errors captured by Sentry (client via `instrumentation-client.ts`, server via `src/instrumentation.ts`)
 
 ## Component Map
 
+Current state (infrastructure only — no product features yet):
+
 ```
 src/
 ├── app/                    # Next.js App Router
-│   ├── layout.tsx          # Root layout (Geist fonts, global styles)
+│   ├── layout.tsx          # Root layout (currently Geist fonts — will switch to JetBrains Mono)
 │   ├── page.tsx            # Landing page
 │   ├── manifest.ts         # PWA manifest (name, icons, display mode)
 │   ├── global-error.tsx    # Sentry error boundary
@@ -86,6 +165,37 @@ Root config files:
 ├── sentry.server.config.ts    # Sentry server SDK config
 ├── sentry.edge.config.ts      # Sentry edge SDK config
 └── sentry.client.config.ts    # Sentry client SDK config
+```
+
+Planned structure (added as features are built):
+
+```
+src/
+├── app/
+│   ├── (auth)/                        # Unauthenticated routes
+│   │   ├── sign-in/page.tsx           # /sign-in
+│   │   ├── sign-up/page.tsx           # /sign-up
+│   │   └── invite/[token]/page.tsx    # /invite/[token]
+│   ├── (app)/                         # Authenticated routes
+│   │   ├── layout.tsx                 # App shell (sidebar + main content)
+│   │   └── [workspaceSlug]/
+│   │       ├── page.tsx               # /[workspaceSlug] (workspace home)
+│   │       ├── [pageId]/page.tsx      # /[workspaceSlug]/[pageId] (editor)
+│   │       └── settings/
+│   │           ├── page.tsx           # /[workspaceSlug]/settings
+│   │           └── members/page.tsx   # /[workspaceSlug]/settings/members
+│   └── api/
+│       ├── health/                    # Existing
+│       └── ...                        # Additional API routes as needed
+├── components/
+│   ├── ui/                 # shadcn/ui components
+│   ├── editor/             # Lexical editor + plugins
+│   ├── sidebar/            # Sidebar, page tree, workspace switcher
+│   └── ...                 # Feature-specific components
+├── lib/
+│   ├── supabase/           # Existing
+│   └── types.ts            # Shared TypeScript types
+└── ...
 ```
 
 ## Observability

--- a/.agents/design.md
+++ b/.agents/design.md
@@ -229,7 +229,7 @@ Each block is a full-width element with consistent vertical spacing.
 ### Toolbar
 
 - Floating toolbar appears on text selection.
-- Items: bold, italic, underline, strikethrough, code, link, color.
+- Items: bold, italic, underline, strikethrough, code, link.
 - Icon-only buttons, 28px square, `gap-0.5`.
 - `bg-popover border border-white/[0.06] shadow-md p-1`. Sharp corners.
 

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -2,33 +2,13 @@
 
 ## Vision
 
-A clean, fast collaborative workspace with block-based editing. Think Notion,
-but minimal and keyboard-first.
+A clean, fast workspace with block-based editing. Think Notion,
+but minimal and keyboard-first. Built entirely via automated agent loops.
 
 ## Target Users
 
 Developers and small teams who want a lightweight workspace for notes,
 documentation, and project planning.
-
-## Scope
-
-### In Scope
-
-- Block-based rich text editor (headings, lists, code, quotes, images)
-- Pages with nested sub-pages
-- Workspaces for organizing content
-- Full-text search across pages
-- Realtime collaboration (cursors, live edits)
-- Dark mode
-- Keyboard shortcuts throughout
-
-### Out of Scope
-
-- Database views / tables (Notion-style databases)
-- Third-party integrations (Slack, GitHub, etc.)
-- AI writing features
-- Offline support
-- Mobile native apps
 
 ## Design Direction
 
@@ -37,26 +17,246 @@ documentation, and project planning.
 - Slash commands for block insertion
 - Clean typography with generous whitespace
 - Smooth transitions, no jarring state changes
+- Dark mode only (see `.agents/design.md` for full visual spec)
+
+## Technical Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Editor | Lexical (Meta, MIT) | Full control, MIT license, Meta-backed. Build from the lexical-playground reference, adapting to Next.js 16 + Tailwind + shadcn/ui. See `.agents/architecture.md` for implementation details. |
+| Content storage | Lexical JSON in PostgreSQL `jsonb` | `editorState.toJSON()` → stored in `pages.content`. On load: `editor.parseEditorState(json)`. |
+| Auth | Supabase Auth (email/password) | OAuth (GitHub, Google) deferred — buttons rendered with "coming soon" tooltip. |
+| Realtime collaboration | Deferred to post-MVP | Yjs + Supabase Realtime adds significant complexity. Ship single-user editing first. |
+| Workspace model | Personal + team workspaces | Every user gets a personal workspace on sign-up. Users can create up to 2 additional workspaces (3 total). Invited workspaces are unlimited. |
+| Access control | Row Level Security (RLS) on all tables | Policies enforce workspace membership for all operations. |
+| Styling | Tailwind v4 + shadcn/ui | No custom CSS. See `.agents/design.md`. |
+
+## Scope
+
+### In Scope (MVP)
+
+1. **Auth** — sign up, sign in, sign out, session management (email/password). GitHub + Google buttons visible but disabled with "coming soon" tooltip.
+2. **Workspaces** — personal workspace auto-created on sign-up (non-deletable, always listed first, named "{display_name}'s Workspace"). Users can create up to 2 additional workspaces (3 total including personal). Workspace settings, workspace switcher.
+3. **Pages** — create, read, update, delete, list. Nested sub-pages (parent/child hierarchy).
+4. **Editor** — Lexical-based block editor with:
+   - Block types: paragraph, heading (1-3), bullet list, numbered list, todo/checklist, code block, blockquote, divider, callout, image
+   - Slash command menu (`/` to insert blocks)
+   - Floating text format toolbar (bold, italic, underline, strikethrough, code, link)
+   - Drag-and-drop block reordering
+   - Keyboard shortcuts
+   - Content stored as Lexical JSON in PostgreSQL via Supabase
+5. **Search** — full-text search across page titles and content within a workspace.
+6. **Import/Export** — Markdown import (create page from .md file) and export (download page as .md).
+7. **Members** — workspace owner/admin can invite users by email, roles (owner, admin, member), remove members. Users can be members of unlimited workspaces via invites.
+8. **App shell** — sidebar with page tree, workspace switcher, search, user menu. Responsive (sidebar collapses on mobile).
+
+### Out of Scope (MVP)
+
+- Realtime collaboration (live cursors, co-editing) — post-MVP via Yjs
+- Database views / tables (Notion-style databases)
+- Third-party integrations (Slack, GitHub, etc.)
+- AI writing features
+- Offline support
+- Mobile native apps
+- Light mode
+- Comments on pages
+- Version history
+- OAuth providers (GitHub, Google) — buttons shown but non-functional
+
+## Data Model
+
+```
+profiles
+  id: uuid (references auth.users.id)
+  email: text
+  display_name: text
+  avatar_url: text (nullable)
+  created_at: timestamptz
+
+workspaces
+  id: uuid (PK)
+  name: text
+  slug: text (unique)
+  is_personal: boolean (default false — true for the auto-created personal workspace)
+  created_by: uuid (references profiles.id)
+  created_at: timestamptz
+  updated_at: timestamptz
+
+  Constraints:
+  - Personal workspaces (is_personal = true): cannot be deleted, always listed first in UI
+  - Workspace creation limit: max 3 workspaces per user where created_by = user.id (enforced via DB function + RLS)
+  - One personal workspace per user: UNIQUE(created_by) WHERE is_personal = true
+
+members
+  id: uuid (PK)
+  workspace_id: uuid (references workspaces.id, on delete cascade)
+  user_id: uuid (references profiles.id, on delete cascade)
+  role: text (owner | admin | member)
+  invited_by: uuid (references profiles.id, nullable)
+  invited_at: timestamptz
+  joined_at: timestamptz (nullable — null means pending invite)
+  created_at: timestamptz
+  UNIQUE(workspace_id, user_id)
+
+workspace_invites
+  id: uuid (PK)
+  workspace_id: uuid (references workspaces.id, on delete cascade)
+  email: text
+  role: text (admin | member)
+  invited_by: uuid (references profiles.id)
+  token: text (unique, for invite link)
+  expires_at: timestamptz
+  accepted_at: timestamptz (nullable)
+  created_at: timestamptz
+
+pages
+  id: uuid (PK)
+  workspace_id: uuid (references workspaces.id, on delete cascade)
+  parent_id: uuid (references pages.id, on delete cascade, nullable)
+  title: text (default '')
+  content: jsonb (Lexical editor state JSON)
+  icon: text (emoji, nullable)
+  position: integer (ordering among siblings)
+  created_by: uuid (references profiles.id)
+  created_at: timestamptz
+  updated_at: timestamptz
+```
+
+All tables have RLS enabled. Policies enforce workspace membership for all operations.
+
+## Feature Priority (Implementation Order)
+
+Each feature maps to one or more GitHub Issues. Phases map to priority labels:
+- **Phase 1** → `priority:1` (foundation — nothing else works without this)
+- **Phase 2** → `priority:2` (core features — the product's value)
+- **Phase 3** → `priority:3` (features and polish)
+
+### Phase 1: Foundation (`priority:1`)
+
+1. **Database schema** — migrations for profiles, workspaces, members, workspace_invites, pages tables with RLS policies. Include `handle_new_user` trigger that creates profile + personal workspace + owner membership atomically on sign-up. _No dependencies._
+2. **Auth flow** — sign up, sign in, sign out pages. Email/password via Supabase Auth. After sign-up, user lands in their personal workspace. GitHub/Google buttons with "coming soon" tooltip. _Depends on: #1 (Database schema)._
+3. **App shell** — authenticated layout with sidebar, workspace context, responsive behavior. JetBrains Mono font. Dark mode only. Sharp corners per design spec. Route groups: `(auth)/` for sign-in/sign-up, `(app)/` for authenticated routes with `[workspaceSlug]/` dynamic segment. _Depends on: #2 (Auth flow)._
+
+### Phase 2: Core Product (`priority:2`)
+
+4. **Workspace CRUD** — create additional workspaces (up to 2 beyond personal, 3 total), workspace settings (name, slug), workspace switcher (personal always first), delete workspace (non-personal only). _Depends on: #3 (App shell)._
+5. **Pages CRUD** — create, list, read, update, delete pages. Sidebar page tree with nesting. Reorder and nest/unnest pages. Route: `(app)/[workspaceSlug]/[pageId]/page.tsx`. _Depends on: #4 (Workspace CRUD)._
+6. **Lexical editor — core** — editor with paragraph, headings, lists, code blocks, blockquotes, divider. Slash command menu (ComponentPickerPlugin). Floating text format toolbar (FloatingTextFormatToolbarPlugin). Floating link editor (FloatingLinkEditorPlugin). Auto-save to Supabase (debounced). _Depends on: #5 (Pages CRUD)._
+7. **Lexical editor — enhancements** — drag-and-drop block reordering (DraggableBlockPlugin), image upload via Supabase Storage (ImagesExtension), callout blocks (CalloutNode), toggle/collapsible blocks (CollapsibleExtension), keyboard shortcuts. _Depends on: #6 (Lexical editor — core)._
+
+### Phase 3: Features (`priority:3`)
+
+8. **Search** — full-text search across page titles and content within a workspace. Search UI in sidebar. PostgreSQL `tsvector`/`tsquery`. _Depends on: #5 (Pages CRUD)._
+9. **Import/Export** — Markdown import (upload .md → create page) and export (page → download .md). Uses `@lexical/markdown` transforms. _Depends on: #6 (Lexical editor — core)._
+10. **Members** — invite users by email, accept invite flow, role management (owner, admin, member), remove members. Only owner/admin can manage members. _Depends on: #4 (Workspace CRUD)._
+
+## Acceptance Criteria
+
+These criteria are used by the Feature Planner to create GitHub Issues and by the Feature Builder to verify implementation.
+
+### Auth
+- [ ] User can sign up with email/password
+- [ ] User can sign in with email/password
+- [ ] User can sign out
+- [ ] Session persists across page reloads (proxy refreshes token)
+- [ ] GitHub and Google buttons are visible but show "coming soon" tooltip on hover/click
+- [ ] On sign-up: profile + personal workspace + owner membership created atomically (DB trigger/function)
+- [ ] After sign-up, user lands in their personal workspace (not a "create workspace" prompt)
+- [ ] Unauthenticated users are redirected to sign-in page
+
+### Workspaces
+- [ ] Personal workspace is auto-created on sign-up, named "{display_name}'s Workspace"
+- [ ] Personal workspace is always listed first in the workspace switcher
+- [ ] Personal workspace cannot be deleted (delete option hidden or disabled with explanation)
+- [ ] User can create up to 2 additional workspaces (3 total including personal)
+- [ ] When workspace limit is reached, "Create workspace" button is disabled with message showing limit
+- [ ] Workspace creation limit is enforced server-side (DB function rejects insert if count ≥ 3)
+- [ ] User can switch between workspaces via sidebar
+- [ ] Workspace settings page (name, slug)
+- [ ] Deleting a non-personal workspace cascades to all pages and members
+- [ ] Users invited to workspaces do not count those toward their creation limit
+
+### Pages
+- [ ] User can create a new page (from sidebar)
+- [ ] Pages appear in sidebar tree with nesting
+- [ ] User can rename a page (inline title editing)
+- [ ] User can delete a page (with confirmation)
+- [ ] User can reorder pages in the sidebar (drag-and-drop or move-to)
+- [ ] User can nest/unnest pages (make sub-page, move to root)
+- [ ] Empty state when workspace has no pages
+
+### Editor
+- [ ] Block types: paragraph, heading 1-3, bullet list, numbered list, todo list, code block, blockquote, divider, callout, image
+- [ ] Slash command menu triggered by `/` — filterable, keyboard navigable
+- [ ] Floating toolbar on text selection — bold, italic, underline, strikethrough, code, link
+- [ ] Drag-and-drop block reordering with visual indicator
+- [ ] Auto-save: content persists to Supabase on change (debounced)
+- [ ] Page loads with saved content restored
+- [ ] Placeholder text in empty blocks ("Type '/' for commands")
+- [ ] Code blocks have syntax highlighting
+- [ ] Images can be uploaded and displayed inline
+- [ ] Keyboard shortcuts: ⌘+B (bold), ⌘+I (italic), ⌘+U (underline), ⌘+K (link), ⌘+Z (undo), ⌘+Shift+Z (redo)
+
+### Search
+- [ ] Search input in sidebar
+- [ ] Results show matching page titles and content snippets
+- [ ] Clicking a result navigates to the page
+- [ ] Search is scoped to the current workspace
+- [ ] Empty state when no results found
+
+### Import/Export
+- [ ] User can export a page as Markdown (.md file download)
+- [ ] User can import a Markdown file to create a new page
+- [ ] Import preserves headings, lists, code blocks, links, images (as URLs)
+
+### Members
+- [ ] Workspace owner or admin can invite users by email
+- [ ] Only owner/admin roles can manage members (member role cannot invite or remove)
+- [ ] Invited user receives an invite (in-app notification or email link)
+- [ ] Invited user can accept and join the workspace (no limit on joined workspaces)
+- [ ] Roles: owner (full control), admin (manage members + pages), member (read/write pages)
+- [ ] Owner/admin can change member roles
+- [ ] Owner/admin can remove members
+- [ ] Member list visible in workspace settings
+- [ ] Personal workspace owner cannot be removed from their own personal workspace
+
+### App Shell
+- [ ] Sidebar: workspace switcher, search, page tree, settings, user menu
+- [ ] Sidebar collapses on mobile (Sheet component)
+- [ ] Responsive: works on desktop (≥1024px), tablet (768-1023px), mobile (<768px)
+- [ ] Keyboard shortcut: ⌘+\ to toggle sidebar
+- [ ] Dark mode only (per design spec)
+- [ ] JetBrains Mono font throughout
+- [ ] Sharp corners on all components (per design spec)
+
+## URL Structure
+
+```
+/sign-in                          → (auth)/sign-in/page.tsx
+/sign-up                          → (auth)/sign-up/page.tsx
+/                                 → redirect to personal workspace
+/[workspaceSlug]                  → (app)/[workspaceSlug]/page.tsx (workspace home / page list)
+/[workspaceSlug]/[pageId]         → (app)/[workspaceSlug]/[pageId]/page.tsx (page editor)
+/[workspaceSlug]/settings         → (app)/[workspaceSlug]/settings/page.tsx (workspace settings)
+/[workspaceSlug]/settings/members → (app)/[workspaceSlug]/settings/members/page.tsx
+/invite/[token]                   → (auth)/invite/[token]/page.tsx (accept workspace invite)
+```
+
+Route groups:
+- `(auth)` — unauthenticated routes (sign-in, sign-up, invite acceptance)
+- `(app)` — authenticated routes with shared layout (sidebar + main content area)
 
 ## Technical Notes
 
-- **Editor**: Tiptap or BlockNote — block-based, outputs JSON
-- **Storage**: Block content stored as JSON in PostgreSQL via Supabase
-- **Auth**: Supabase Auth (email/password, OAuth providers)
-- **Realtime**: Supabase Realtime for live collaboration
-- **Access control**: Row Level Security (RLS) on all tables
+Implementation hints for the Feature Builder. Reference `.agents/architecture.md` for the full system design and `.agents/conventions.md` for coding patterns.
 
-## Feature Priority
-
-Ordered by implementation sequence:
-
-1. **Auth** — sign up, sign in, sign out, session management
-2. **Pages** — create, read, update, delete, list
-3. **Editor** — block-based editing with Tiptap/BlockNote
-4. **Slash commands** — insert blocks via `/` menu
-5. **Nested pages** — parent/child page hierarchy
-6. **Search** — full-text search across page content
-7. **Realtime** — live cursors and collaborative editing
-8. **Import/Export** — Markdown import and export
-9. **Dark mode** — system preference + manual toggle
-10. **Members** — workspace invitations and roles
+- **Lexical packages**: install from npm (`lexical`, `@lexical/react`, `@lexical/rich-text`, `@lexical/list`, `@lexical/code`, `@lexical/link`, `@lexical/selection`, `@lexical/utils`, `@lexical/markdown`, `@lexical/clipboard`). Pin to a specific version to avoid breaking changes.
+- **Lexical playground reference**: build custom plugins (slash commands, drag-and-drop, floating toolbar, images, callouts) referencing `facebook/lexical/packages/lexical-playground/src/plugins/`. Do NOT fork the playground — adapt patterns to Tailwind + shadcn/ui. See `.agents/architecture.md` for the full plugin plan.
+- **Floating UI**: use `@floating-ui/react` for positioning slash command menu, floating toolbar, and link editor.
+- **Image storage**: Supabase Storage bucket for uploaded images. Store the public URL in the ImageNode.
+- **Full-text search**: PostgreSQL `tsvector` + `tsquery` on page title and a text extraction of content JSON. Create a generated column or trigger to maintain the search index.
+- **Auto-save**: debounce editor changes (500ms), write to Supabase. Show save indicator in UI.
+- **Markdown transforms**: `@lexical/markdown` provides `$convertFromMarkdownString` and `$convertToMarkdownString` with configurable transformers.
+- **Personal workspace creation**: Use a Supabase DB trigger on `auth.users` insert (or a `handle_new_user` function) that creates the profile, workspace (`is_personal = true`), and owner membership row atomically.
+- **Workspace creation limit**: Enforce via a PostgreSQL `BEFORE INSERT` trigger on `workspaces` that checks `SELECT count(*) FROM workspaces WHERE created_by = NEW.created_by` and raises an exception if ≥ 3. Also enforce client-side by disabling the "Create workspace" button when the count is reached.
+- **Personal workspace protection**: RLS policy on `workspaces` prevents `DELETE` where `is_personal = true`. The UI hides the delete option for personal workspaces.


### PR DESCRIPTION
## Summary

Finalizes all product documentation so the Feature Planner automation can decompose the spec into GitHub Issues and the Feature Builder can implement them.

## Changes

### `docs/product-spec.md` — complete rewrite
- **Technical Decisions**: Lexical editor (MIT, Meta), email/password auth (OAuth deferred), personal + team workspaces, realtime deferred
- **Scope**: 8 MVP features with explicit in/out boundaries
- **Data Model**: 5 tables (profiles, workspaces, members, workspace_invites, pages) with constraints (personal workspace, 3-workspace limit, RLS)
- **Feature Priority**: 3 phases mapped to `priority:1/2/3` labels with explicit `Depends on #N` chains
- **Acceptance Criteria**: checkboxes for every feature area (auth, workspaces, pages, editor, search, import/export, members, app shell)
- **URL Structure**: all routes mapped to file paths
- **Technical Notes**: implementation hints for the Feature Builder

### `.agents/architecture.md` — major update
- Lexical implementation plan (10 official packages, 8 custom plugins, 3 custom nodes)
- Corrected data model (was blocks-based, now Lexical JSON in `pages.content`)
- Planned route structure with full file paths
- Content storage flow (save/load/auto-save)
- Updated system diagram, request flow, key decisions

### `.agents/design.md` — minor fix
- Removed "color" from floating toolbar items to match product spec acceptance criteria

## Automation alignment

| Automation | Reads | Status |
|---|---|---|
| Feature Planner | `docs/product-spec.md` | ✅ Ready — phases map to priority labels, dependencies are explicit, acceptance criteria in checkbox format |
| Feature Builder | Issue body + `.agents/architecture.md` + `.agents/conventions.md` + `.agents/design.md` | ✅ Ready — architecture has Lexical plan, design has corrected toolbar |
| PR Reviewer | `AGENTS.md` + `.agents/conventions.md` | ✅ No changes needed |