### PR TITLE
chore(metrics): use cumulative totals in snapshots, deltas for tweets

### DIFF
--- a/.ona/automations/daily-metrics.yaml
+++ b/.ona/automations/daily-metrics.yaml
@@ -18,7 +18,7 @@ action:
 
                 ## Data Collection (on latest main)
 
-                1. Lines of code: run `npx cloc src/ --json`. Extract total and by-language.
+                1. Lines of code: run `npx cloc src/ supabase/migrations/ --json`. Extract total and by-language.
                 2. File count: count files in src/ excluding node_modules, .next, test files.
                 3. PRs today: use gh pr list to count opened and merged today, and currently open.
                 4. Test coverage: run `pnpm test -- --coverage --reporter=json` and extract percentage.
@@ -34,16 +34,31 @@ action:
                 Create `metrics/daily/YYYY-MM-DD.json`:
                 {
                   "date": "YYYY-MM-DD",
+                  "day_number": N,
                   "loc": { "total": N, "delta": N, "by_language": { "TypeScript": N } },
                   "files": { "total": N, "delta": N },
-                  "prs": { "opened_today": N, "merged_today": N, "currently_open": N },
-                  "commits_today": N,
+                  "prs": { "total": N, "delta": N, "currently_open": N },
+                  "commits": { "total": N, "delta": N },
                   "test_coverage_pct": N,
                   "ci_pass_rate_pct": N,
                   "issues": { "backlog": N, "in_progress": N, "in_review": N, "done": N },
                   "human_minutes": null,
                   "agent_minutes": null
                 }
+
+                Day 1 was 2026-04-13. Calculate day_number from that.
+
+                All top-level numeric fields are CUMULATIVE TOTALS, not daily counts:
+                - loc.total: total lines of code in src/ right now
+                - files.total: total files in src/ right now
+                - prs.total: total PRs merged since project start (gh pr list --state merged --json mergedAt | count all)
+                - commits.total: total commits on main (git rev-list --count HEAD)
+
+                The "delta" field is today's change vs yesterday's total:
+                - loc.delta = loc.total - yesterday's loc.total
+                - files.delta = files.total - yesterday's files.total
+                - prs.delta = PRs merged today only
+                - commits.delta = commits made today only
 
                 For delta fields, read yesterday's file from metrics/daily/. If none exists, delta = total.
                 human_minutes and agent_minutes are null — filled manually.

--- a/.ona/automations/tweet-drafter.yaml
+++ b/.ona/automations/tweet-drafter.yaml
@@ -50,6 +50,17 @@ action:
                 5. Read previous tweets from metrics/daily/ (most recent *-tweet.md files) to avoid
                    repeating the same phrasing or stats.
 
+                ## Metrics usage in tweets
+
+                The metrics JSON contains both cumulative totals and daily deltas.
+                In tweets, use the DAILY DELTA numbers (the "delta" fields) for progress updates:
+                - prs.delta for "N PRs merged today"
+                - commits.delta for "N commits today"
+                - loc.delta for "N lines added today"
+
+                You may reference totals for milestone-style tweets (e.g., "500 total LOC"),
+                but day-to-day progress tweets should use deltas.
+
                 ## Day counting
 
                 Day 1 was 2026-04-13 (project setup). Calculate the current day number from that.

--- a/metrics/daily/2026-04-14.json
+++ b/metrics/daily/2026-04-14.json
@@ -1,9 +1,10 @@
 {
   "date": "2026-04-14",
+  "day_number": 2,
   "loc": { "total": 217, "delta": 217, "by_language": { "TypeScript": 212, "CSS": 5 } },
   "files": { "total": 15, "delta": 15 },
-  "prs": { "opened_today": 14, "merged_today": 14, "currently_open": 0 },
-  "commits_today": 37,
+  "prs": { "total": 14, "delta": 14, "currently_open": 0 },
+  "commits": { "total": 37, "delta": 37 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 0 },


### PR DESCRIPTION
Metrics snapshots now store cumulative totals instead of daily-only counts. Tweets use the delta fields for daily progress numbers.

### Changes

- **daily-metrics.yaml**: Schema uses `prs.total`/`prs.delta` and `commits.total`/`commits.delta` instead of `opened_today`/`merged_today`/`commits_today`. Added `day_number`. `cloc` now includes `supabase/migrations/`.
- **tweet-drafter.yaml**: Added guidance to use `delta` fields for progress tweets and `total` fields for milestone tweets.
- **2026-04-14.json**: Migrated to new schema (totals = deltas since it was day 2 with no prior data).