### PR TITLE
chore(automations): add cron triggers to close bootstrap and dead-end gaps

### DIFF
--- a/.ona/automations/bug-fixer.yaml
+++ b/.ona/automations/bug-fixer.yaml
@@ -13,6 +13,12 @@ triggers:
         projects:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: "*/10 * * * *"
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       manual: {}
 action:
     limits:

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -13,6 +13,12 @@ triggers:
         projects:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: "*/10 * * * *"
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       manual: {}
 action:
     limits:

--- a/.ona/automations/feature-planner.yaml
+++ b/.ona/automations/feature-planner.yaml
@@ -79,9 +79,9 @@ action:
                 - priority:2 = core features — the product's value (editor, search, realtime)
                 - priority:3 = polish and stretch goals (dark mode, responsive, import/export)
 
-                ## Step 4 — Present the Plan
+                ## Step 4 — Finalize
 
-                After creating all issues, present a summary:
+                After creating all issues, log a summary (do NOT wait for user input — this runs as an unattended automation):
 
                 Total issues created: N
                 By priority: P1: X, P2: Y, P3: Z
@@ -91,11 +91,8 @@ action:
                 2. #M — Title (P1, depends on #N)
                 ...
 
-                Ambiguities / Questions for Human:
-                - [Any unclear requirements]
-                - [Any scope decisions that need input]
-
-                Wait for the user to review before the Feature Builder starts.
+                If there are ambiguities or scope questions, create a GitHub Issue labeled
+                "needs-human" with the questions so a human can address them asynchronously.
 
                 ## Do NOT
                 - Create issues that bundle multiple unrelated changes.

--- a/.ona/automations/pr-reviewer.yaml
+++ b/.ona/automations/pr-reviewer.yaml
@@ -11,6 +11,12 @@ triggers:
             - PULL_REQUEST_EVENT_OPENED
             - PULL_REQUEST_EVENT_UPDATED
             - PULL_REQUEST_EVENT_READY_FOR_REVIEW
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: "*/5 * * * *"
 action:
     limits:
         maxParallel: 1
@@ -20,7 +26,17 @@ action:
             prompt: |
                 You are the PR Reviewer for the Memo repository. You review code, fix CI failures, and merge PRs that are ready.
 
-                The PR number is provided in the trigger context as the pull request that was opened or updated.
+                ## Determine which PR to act on
+
+                If a PR number is provided in the trigger context (webhook trigger), use that PR.
+
+                Otherwise (cron trigger), scan all open non-draft PRs:
+                  gh pr list --state open --json number,isDraft,updatedAt --jq '[.[] | select(.isDraft == false)] | sort_by(.updatedAt) | reverse'
+
+                For each PR, read its metadata and determine if action is needed (see states below).
+                Act on the FIRST PR that needs action, then stop. One PR per run.
+
+                If no PRs need action, stop — do nothing.
 
                 ## Determine PR state
 
@@ -28,7 +44,7 @@ action:
 
                 gh pr view <number> --json title,body,isDraft,reviewDecision,statusCheckRollup,labels,reviews
 
-                Stop immediately if:
+                Stop immediately (skip this PR) if:
                 - The PR is a draft.
                 - CI checks are still running (status: pending/queued).
 

--- a/.ona/automations/tweet-drafter.yaml
+++ b/.ona/automations/tweet-drafter.yaml
@@ -74,7 +74,7 @@ action:
 
                 Always end with:
                   https://memo.software-factory.dev
-                  Built with @onadev
+                  Built with @ona_hq
 
                 Rules:
                 - Describe features as a user would, not a developer.


### PR DESCRIPTION
## What

The automation stack had two structural problems preventing autonomous operation:

1. **Bootstrap gap** — Feature Builder and Bug Fixer only triggered on `PR_MERGED`. With no merged PRs, the backlog sat idle indefinitely.
2. **Dead-end gap** — PR Reviewer only triggered on PR webhook events (`OPENED`, `UPDATED`, `READY_FOR_REVIEW`). Editing a PR body (e.g. adding `Closes #N`) doesn't fire any of these, so PRs stalled after review feedback.

## Changes

| File | Change | Why |
|---|---|---|
| `feature-builder.yaml` | Added `*/10 * * * *` cron trigger | Polls for backlog work every 10 min, unblocking the first feature pick-up |
| `bug-fixer.yaml` | Added `*/10 * * * *` cron trigger | Same bootstrap fix for bug issues |
| `pr-reviewer.yaml` | Added `*/5 * * * *` cron trigger + updated prompt to scan all open PRs on cron | Catches PRs where body edits or label changes were invisible to webhooks |
| `tweet-drafter.yaml` | `@onadev` → `@ona_hq` | Wrong handle in prompt |
| `feature-planner.yaml` | Replaced "Wait for user to review" with autonomous finalization | Automation has no user to wait for — now logs summary and creates `needs-human` issue for ambiguities |

All 5 changes are already live in Ona via `ona ai automation update`.