### PR TITLE
chore(automations): prevent duplicate work on in-progress issues

### DIFF
--- a/.ona/automations/bug-fixer.yaml
+++ b/.ona/automations/bug-fixer.yaml
@@ -51,15 +51,20 @@ action:
 
                 2. Find the next bug to fix. Query in priority order:
                    ```
-                   gh issue list --label "bug" --label "priority:1" --state open --json number,title,body,labels \
+                   gh issue list --label "bug" --label "status:backlog" --label "priority:1" --state open --json number,title,body,labels \
                      --jq '[.[] | select(.labels | map(.name) | contains(["needs-human"]) | not)] | sort_by(.number) | .[0]'
                    ```
-                   If no priority:1 bugs, try priority:2, then priority:3, then any open bug with no priority label:
+                   If no priority:1 bugs, try priority:2, then priority:3, then any open bug with
+                   `status:backlog` and no priority label:
                    ```
-                   gh issue list --label "bug" --state open --json number,title,body,labels \
-                     --jq '[.[] | select(.labels | map(.name) | (contains(["needs-human"]) or contains(["status:in-progress"]) or contains(["status:in-review"]) or contains(["status:done"])) | not)] | sort_by(.number) | .[0]'
+                   gh issue list --label "bug" --label "status:backlog" --state open --json number,title,body,labels \
+                     --jq '[.[] | select(.labels | map(.name) | contains(["needs-human"]) | not)] | sort_by(.number) | .[0]'
                    ```
                    If no eligible bug issues, stop — do nothing. This is expected, not a failure.
+
+                   CRITICAL: Only pick issues labeled `status:backlog`. NEVER pick up an issue that is
+                   `status:in-progress`, `status:in-review`, or `status:done` — even if it appears
+                   stalled, abandoned, or has no PR. Another automation or human owns it.
 
                 3. Check if the issue already has an open linked PR. Use two checks (GitHub search has indexing lag):
                    a) Check for a branch matching the naming convention:

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -66,10 +66,17 @@ action:
                    If no priority:1 issues, try priority:2, then priority:3.
                    If no backlog issues at all, stop — do nothing. This is expected, not a failure.
 
+                   CRITICAL: Only pick issues labeled `status:backlog`. NEVER pick up an issue that is
+                   `status:in-progress`, `status:in-review`, or `status:done` — even if it appears
+                   stalled, abandoned, or has no PR. Another automation or human owns it. If every
+                   backlog issue has unsatisfied dependencies, stop. Do NOT rationalize picking up
+                   a non-backlog issue.
+
                 4. Read the issue body. Check the "Dependencies" section.
                    For each dependency (e.g., "Depends on #N"), check:
-                   gh issue view N --json state --jq '.state'
-                   If any dependency is still open, skip this issue and try the next one.
+                   gh issue view N --json state,labels --jq '{state: .state, labels: [.labels[].name]}'
+                   A dependency is satisfied when its state is "closed" OR it has label "status:done".
+                   If any dependency is not satisfied, skip this issue and try the next one.
                    If no issues have satisfied dependencies, stop — do nothing.
 
                 ## Implementation


### PR DESCRIPTION
Feature Builder and Bug Fixer could rationalize picking up issues already marked `status:in-progress` when all backlog items had unsatisfied dependencies. A scheduled Feature Builder was observed attempting to work on #23 while another builder already had it in progress.

## Changes

**Feature Builder** (`feature-builder.yaml`):
- Added explicit `CRITICAL` instruction forbidding non-backlog issue pickup
- Dependency check now accepts `status:done` label as satisfied (not just GitHub closed state)

**Bug Fixer** (`bug-fixer.yaml`):
- Added `--label "status:backlog"` to all priority-specific queries (previously only the fallback query filtered by status)
- Added same `CRITICAL` instruction

Both automations already updated live via `ona ai automation update`.