### PR TITLE
chore(automations): add status:backlog label to bug issue creation

### DIFF
--- a/.ona/automations/incident-responder.yaml
+++ b/.ona/automations/incident-responder.yaml
@@ -48,8 +48,8 @@ action:
                    - Title: fix: <description>
                    - Body: Sentry issue link, root cause analysis, what was fixed, test added.
                      Must include `Closes #N` referencing a GitHub issue. If no GitHub issue exists
-                     for this error, create one first with label `bug`.
-                   - Labels: bug
+                     for this error, create one first with labels `bug`, `status:backlog`.
+                   - Labels: bug, status:backlog
                 9. Use update_issue to mark the Sentry issue as resolved.
 
                 ## Low-severity

--- a/.ona/automations/post-merge-verifier.yaml
+++ b/.ona/automations/post-merge-verifier.yaml
@@ -118,7 +118,7 @@ action:
                 1. Create a GitHub Issue:
                    - Title: `bug: UI regression after PR #<number> — <first failure>`
                    - Body: list all failures, include the PR number and title for context
-                   - Labels: `bug`, `priority:1`
+                   - Labels: `bug`, `priority:1`, `status:backlog`
                 2. Comment on the merged PR:
                    > ❌ Post-merge verification failed. See #<new-issue-number>.
 

--- a/.ona/automations/ui-verifier.yaml
+++ b/.ona/automations/ui-verifier.yaml
@@ -94,7 +94,7 @@ action:
                   1. Create a GitHub Issue:
                      - Title: `bug: UI does not match design spec after PR #<number>`
                      - Body: list each violation with the file, line, what's wrong, and what the design spec says
-                     - Labels: `bug`, `priority:2`
+                     - Labels: `bug`, `priority:2`, `status:backlog`
                   2. Comment on the merged PR:
                      > ⚠️ UI verification found design spec violations. See #<issue-number>.
 


### PR DESCRIPTION
Post-Merge Verifier, UI Verifier, and Incident Responder created bug issues without `status:backlog`. The Bug Fixer requires this label to pick up work (added in #35), so these issues were invisible to it.

This is why #36 was not picked up — it had `bug` + `priority:1` but no `status:backlog`.

## Changes

| File | Fix |
|---|---|
| `post-merge-verifier.yaml` | `bug, priority:1` → `bug, priority:1, status:backlog` |
| `ui-verifier.yaml` | `bug, priority:2` → `bug, priority:2, status:backlog` |
| `incident-responder.yaml` | `bug` → `bug, status:backlog` (critical/high path) |

Also added `status:backlog` to #36 directly so the Bug Fixer picks it up on its next cycle.

All three automations already updated live via `ona ai automation update`.