### PR TITLE
fix: health endpoint crashes when Supabase env vars are missing (#36)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -201,6 +201,18 @@ export async function GET() {
   let dbStatus = "ok";
   let dbLatency = 0;
 
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  ) {
+    // Supabase is not configured — report as unconfigured rather than down
+    return NextResponse.json({
+      status: "ok",
+      db: { connected: false, latency_ms: 0, reason: "not_configured" },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   try {
     const supabase = await createClient();
     const { error } = await supabase
@@ -229,6 +241,26 @@ export async function GET() {
 ```
 
 Pattern: wrap in try/catch, return structured JSON with appropriate status codes.
+
+### Guarding Supabase env vars in API routes
+
+API route handlers that use the Supabase client must check that env vars are present
+before calling `createClient()`. The non-null assertion (`!`) on `process.env` values
+does not throw when the value is `undefined` — it silently passes `undefined` to the
+Supabase client, which then throws at request time.
+
+```typescript
+// ✅ Correct — guard before using the client
+if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) {
+  return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
+}
+const supabase = await createClient();
+
+// ❌ Wrong — createClient() uses non-null assertions that don't protect against undefined
+const supabase = await createClient(); // throws at request time if env vars are missing
+```
+
+The proxy (`src/proxy.ts`) already follows this pattern. All API routes must do the same.
 
 ## Database Migrations
 

--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock next/headers before importing the route
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+// Track the mock so tests can control Supabase behavior
+const mockMaybeSingle = vi.fn();
+const mockLimit = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockSelect = vi.fn(() => ({ limit: mockLimit }));
+const mockFrom = vi.fn(() => ({ select: mockSelect }));
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "./route";
+
+describe("GET /api/health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns not_configured when Supabase env vars are missing", async () => {
+    const originalUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const originalKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+    try {
+      const response = await GET();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("ok");
+      expect(body.db.connected).toBe(false);
+      expect(body.db.reason).toBe("not_configured");
+      // Supabase client should never be created
+      expect(mockFrom).not.toHaveBeenCalled();
+    } finally {
+      // Restore env vars
+      if (originalUrl !== undefined)
+        process.env.NEXT_PUBLIC_SUPABASE_URL = originalUrl;
+      if (originalKey !== undefined)
+        process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = originalKey;
+    }
+  });
+
+  it("returns not_configured when only URL is missing", async () => {
+    const originalUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+
+    try {
+      const response = await GET();
+      const body = await response.json();
+
+      expect(body.status).toBe("ok");
+      expect(body.db.connected).toBe(false);
+      expect(body.db.reason).toBe("not_configured");
+    } finally {
+      if (originalUrl !== undefined)
+        process.env.NEXT_PUBLIC_SUPABASE_URL = originalUrl;
+      else delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    }
+  });
+
+  it("returns ok when Supabase connects (table does not exist)", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+
+    mockMaybeSingle.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'relation "public._health_check" does not exist',
+        code: "42P01",
+      },
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.status).toBe("ok");
+    expect(body.db.connected).toBe(true);
+    expect(body.db.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns ok with connected when query succeeds", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+
+    mockMaybeSingle.mockResolvedValue({ data: { "1": 1 }, error: null });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.status).toBe("ok");
+    expect(body.db.connected).toBe(true);
+  });
+
+  it("returns degraded when Supabase returns a non-missing-table error", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+
+    mockMaybeSingle.mockResolvedValue({
+      data: null,
+      error: { message: "permission denied for table _health_check" },
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.status).toBe("ok");
+    expect(body.db.connected).toBe(true);
+    // degraded means connected but with issues
+  });
+
+  it("returns down when Supabase client throws", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+
+    mockMaybeSingle.mockRejectedValue(new Error("fetch failed"));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.status).toBe("down");
+    expect(body.db.connected).toBe(false);
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -6,6 +6,18 @@ export async function GET() {
   let dbStatus = "ok";
   let dbLatency = 0;
 
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  ) {
+    // Supabase is not configured — report as unconfigured rather than down
+    return NextResponse.json({
+      status: "ok",
+      db: { connected: false, latency_ms: 0, reason: "not_configured" },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   try {
     const supabase = await createClient();
     const { error } = await supabase


### PR DESCRIPTION
Closes #36

## What

The health endpoint (`GET /api/health`) reported `{"status":"down","db":{"connected":false,"latency_ms":0}}` when Supabase environment variables were not configured in Vercel. The route handler called `createClient()` without checking whether `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` were set. The non-null assertions (`!`) silently passed `undefined` to `createServerClient`, which threw when making the HTTP request. The `catch` block then reported the database as "down" — misleading, since the database was never reached.

## How

Added an env var guard at the top of the health route handler, matching the pattern already used in `src/proxy.ts`. When Supabase env vars are missing, the endpoint returns `{"status":"ok","db":{"connected":false,"latency_ms":0,"reason":"not_configured"}}` instead of crashing into the catch block. The overall app status remains "ok" since the app itself is running — only the DB connection is absent.

Also updated `.agents/conventions.md` with the env var guard pattern (placed next to the API routes section) to prevent the same class of bug in future route handlers.

## Testing

Added 6 regression tests in `src/app/api/health/route.test.ts`:
- Missing both env vars → returns `not_configured` (would have caught this bug)
- Missing only URL → returns `not_configured`
- Table does not exist → returns ok/connected (connection worked)
- Successful query → returns ok/connected
- Non-connection error (e.g., permission denied) → returns degraded
- Client throws (e.g., fetch failed) → returns down

Run: `pnpm test -- src/app/api/health/route.test.ts`