### PR TITLE
fix: use font-semibold on auth page headings per design spec (#38)

### DIFF
--- a/src/app/(auth)/auth-typography.test.ts
+++ b/src/app/(auth)/auth-typography.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for issue #38: auth page headings must use font-semibold
+ * per the design spec. font-bold at text-2xl is incorrect — font-bold is
+ * reserved for the page title in the editor at text-3xl.
+ */
+describe("auth page typography", () => {
+  const authDir = join(__dirname);
+
+  it("sign-in heading uses font-semibold, not font-bold", () => {
+    const source = readFileSync(join(authDir, "sign-in/page.tsx"), "utf-8");
+    const cardTitleMatch = source.match(/CardTitle[^>]*className="([^"]*)"/);
+    expect(cardTitleMatch).not.toBeNull();
+    const classes = cardTitleMatch![1];
+    expect(classes).toContain("font-semibold");
+    expect(classes).not.toContain("font-bold");
+  });
+
+  it("sign-up heading uses font-semibold, not font-bold", () => {
+    const source = readFileSync(join(authDir, "sign-up/page.tsx"), "utf-8");
+    const cardTitleMatch = source.match(/CardTitle[^>]*className="([^"]*)"/);
+    expect(cardTitleMatch).not.toBeNull();
+    const classes = cardTitleMatch![1];
+    expect(classes).toContain("font-semibold");
+    expect(classes).not.toContain("font-bold");
+  });
+});

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -66,7 +66,7 @@ export default function SignInPage() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-2xl font-bold">Sign in to Memo</CardTitle>
+        <CardTitle className="text-2xl font-semibold">Sign in to Memo</CardTitle>
         <CardDescription>
           Enter your email and password to continue.
         </CardDescription>

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -70,7 +70,7 @@ export default function SignUpPage() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-2xl font-bold">Create an account</CardTitle>
+        <CardTitle className="text-2xl font-semibold">Create an account</CardTitle>
         <CardDescription>
           Enter your details to get started with Memo.
         </CardDescription>


### PR DESCRIPTION
Closes #38

## What
The sign-in and sign-up page headings used `font-bold` on their `text-2xl` `CardTitle` elements. The design spec reserves `font-bold` for the page title in the editor at `text-3xl`. Heading 1 (`text-2xl`) must use `font-semibold`.

## How
Changed `font-bold` to `font-semibold` on the `CardTitle` className in both `src/app/(auth)/sign-in/page.tsx` and `src/app/(auth)/sign-up/page.tsx`.

## Testing
Added `src/app/(auth)/auth-typography.test.ts` — a regression test that reads both auth page source files and asserts the `CardTitle` className contains `font-semibold` and does not contain `font-bold`. Run with `pnpm test`.