### PR TITLE
fix: health endpoint uses machine-readable reason field for env guard (#36)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -132,7 +132,7 @@ if (
   !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 ) {
   // Return a graceful response instead of crashing
-  return NextResponse.json({ status: "ok", db: { connected: false, message: "not configured" } });
+  return NextResponse.json({ status: "ok", db: { connected: false, reason: "not_configured" } });
 }
 ```
 
@@ -224,6 +224,18 @@ export async function GET() {
   let dbStatus = "ok";
   let dbLatency = 0;
 
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  ) {
+    // Supabase is not configured — report as unconfigured rather than down
+    return NextResponse.json({
+      status: "ok",
+      db: { connected: false, latency_ms: 0, reason: "not_configured" },
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   try {
     const supabase = await createClient();
     const { error } = await supabase
@@ -252,6 +264,26 @@ export async function GET() {
 ```
 
 Pattern: wrap in try/catch, return structured JSON with appropriate status codes.
+
+### Guarding Supabase env vars in API routes
+
+API route handlers that use the Supabase client must check that env vars are present
+before calling `createClient()`. The non-null assertion (`!`) on `process.env` values
+does not throw when the value is `undefined` — it silently passes `undefined` to the
+Supabase client, which then throws at request time.
+
+```typescript
+// ✅ Correct — guard before using the client
+if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) {
+  return NextResponse.json({ error: "Supabase not configured" }, { status: 503 });
+}
+const supabase = await createClient();
+
+// ❌ Wrong — createClient() uses non-null assertions that don't protect against undefined
+const supabase = await createClient(); // throws at request time if env vars are missing
+```
+
+The proxy (`src/proxy.ts`) already follows this pattern. All API routes must do the same.
 
 ## Database Migrations
 

--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -32,7 +32,7 @@ describe("GET /api/health", () => {
 
     expect(body.status).toBe("ok");
     expect(body.db.connected).toBe(false);
-    expect(body.db.message).toBe("not configured");
+    expect(body.db.reason).toBe("not_configured");
     expect(mockedCreateClient).not.toHaveBeenCalled();
 
     // Restore
@@ -50,7 +50,7 @@ describe("GET /api/health", () => {
 
     expect(body.status).toBe("ok");
     expect(body.db.connected).toBe(false);
-    expect(body.db.message).toBe("not configured");
+    expect(body.db.reason).toBe("not_configured");
     expect(mockedCreateClient).not.toHaveBeenCalled();
 
     // Restore

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -10,9 +10,10 @@ export async function GET() {
     !process.env.NEXT_PUBLIC_SUPABASE_URL ||
     !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
   ) {
+    // Supabase is not configured — report as unconfigured rather than down
     return NextResponse.json({
       status: "ok",
-      db: { connected: false, latency_ms: 0, message: "not configured" },
+      db: { connected: false, latency_ms: 0, reason: "not_configured" },
       timestamp: new Date().toISOString(),
     });
   }


### PR DESCRIPTION
Closes #36

Supersedes #41 (rebased cleanly onto current main to resolve merge conflicts).

## What

Changes the health endpoint's env var guard response from `message: "not configured"` to `reason: "not_configured"` — a machine-readable snake_case value suitable for programmatic consumption.

## Changes

- `src/app/api/health/route.ts`: `db.message` → `db.reason` with `"not_configured"` value, added explanatory comment
- `src/app/api/health/route.test.ts`: Updated assertions to match new field name
- `.agents/conventions.md`: Added env var guard to API route code example, added "Guarding Supabase env vars" subsection documenting the pattern

## Testing

All 8 tests pass: `pnpm lint && pnpm typecheck && pnpm test`