### PR TITLE
feat: app shell — sidebar, layout, workspace context (#25)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -144,7 +144,7 @@ Auto-save: debounce 500ms on editor change → write to Supabase
 src/
 ├── app/                    # Next.js App Router
 │   ├── layout.tsx          # Root layout (JetBrains Mono font, TooltipProvider)
-│   ├── page.tsx            # Landing page
+│   ├── page.tsx            # Landing page (redirects authenticated users to workspace)
 │   ├── manifest.ts         # PWA manifest (name, icons, display mode)
 │   ├── global-error.tsx    # Sentry error boundary
 │   ├── globals.css         # Tailwind v4 theme — dark-only oklch tokens, --radius: 0
@@ -153,7 +153,7 @@ src/
 │   │   ├── sign-in/page.tsx # /sign-in — email/password form
 │   │   └── sign-up/page.tsx # /sign-up — display name + email/password form
 │   ├── (app)/              # Authenticated route group
-│   │   ├── layout.tsx      # Auth guard (redirects to /sign-in if no session), sign-out button
+│   │   ├── layout.tsx      # Auth guard, fetches profile, renders AppShell
 │   │   └── [workspaceSlug]/
 │   │       └── page.tsx    # /[workspaceSlug] — workspace home (placeholder)
 │   └── api/
@@ -162,11 +162,21 @@ src/
 │   ├── auth/
 │   │   ├── oauth-buttons.tsx    # GitHub + Google buttons (disabled, "coming soon" tooltip)
 │   │   └── sign-out-button.tsx  # Sign-out button (clears session, redirects to /sign-in)
+│   ├── sidebar/             # App shell sidebar components
+│   │   ├── app-shell.tsx        # Client wrapper: SidebarProvider + sidebar + main layout
+│   │   ├── app-sidebar.tsx      # Sidebar (desktop: collapsible aside, mobile: Sheet)
+│   │   ├── sidebar-context.tsx  # React context for sidebar open/close state + ⌘+\ shortcut
+│   │   ├── workspace-switcher.tsx # Workspace name display (placeholder — functional in #27)
+│   │   ├── page-tree.tsx        # Page list placeholder (functional in #28)
+│   │   └── user-menu.tsx        # User dropdown with sign-out
 │   └── ui/                 # shadcn/ui components (base-nova style, base-ui primitives)
 │       ├── button.tsx
 │       ├── card.tsx
+│       ├── dropdown-menu.tsx
 │       ├── input.tsx
 │       ├── label.tsx
+│       ├── separator.tsx
+│       ├── sheet.tsx
 │       └── tooltip.tsx
 ├── lib/
 │   ├── utils.ts            # cn() utility (clsx + tailwind-merge)

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,6 +1,6 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { SignOutButton } from "@/components/auth/sign-out-button";
+import { AppShell } from "@/components/sidebar/app-shell";
 
 export default async function AppLayout({
   children,
@@ -16,12 +16,19 @@ export default async function AppLayout({
     redirect("/sign-in");
   }
 
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name, email")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const displayName =
+    profile?.display_name || user.user_metadata?.display_name || "User";
+  const email = profile?.email || user.email || "";
+
   return (
-    <div className="flex min-h-screen flex-col">
-      <header className="flex items-center justify-end border-b border-white/[0.06] px-4 py-2">
-        <SignOutButton />
-      </header>
-      <main className="flex-1">{children}</main>
-    </div>
+    <AppShell displayName={displayName} email={email}>
+      {children}
+    </AppShell>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,60 @@
-export default function Home() {
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export default async function Home() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    // Redirect authenticated users to their first workspace
+    const { data: membership } = await supabase
+      .from("members")
+      .select("workspace_id, workspaces(slug)")
+      .eq("user_id", user.id)
+      .limit(1)
+      .maybeSingle();
+
+    // Supabase types the joined relation based on schema — extract slug safely
+    const workspaces = membership?.workspaces as
+      | { slug: string }
+      | { slug: string }[]
+      | null
+      | undefined;
+    const slug = Array.isArray(workspaces)
+      ? workspaces[0]?.slug
+      : workspaces?.slug;
+    if (slug) {
+      redirect(`/${slug}`);
+    }
+  }
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-8">
       <div className="max-w-2xl text-center space-y-6">
-        <h1 className="text-5xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-          Memo
-        </h1>
-        <p className="text-xl text-zinc-500 dark:text-zinc-400">
+        <h1 className="text-5xl font-bold tracking-tight">Memo</h1>
+        <p className="text-sm text-muted-foreground">
           A Notion-style workspace, built with zero human code.
         </p>
         <div className="flex gap-4 justify-center">
           <a
             href="https://github.com/gitpod-io/memo"
-            className="inline-flex items-center px-4 py-2 rounded-md bg-zinc-900 text-white hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 transition-colors"
+            className="inline-flex items-center px-4 py-2 bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/80"
             target="_blank"
             rel="noopener noreferrer"
           >
             View Source
           </a>
+          <Link
+            href="/sign-in"
+            className="inline-flex items-center px-4 py-2 border border-white/[0.06] text-sm font-medium hover:bg-muted"
+          >
+            Sign In
+          </Link>
         </div>
-        <p className="text-sm text-zinc-400 dark:text-zinc-500 pt-8">
+        <p className="text-xs text-muted-foreground pt-8">
           Every line of code in this repository is written by AI agents.
         </p>
       </div>

--- a/src/components/sidebar/app-shell.tsx
+++ b/src/components/sidebar/app-shell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { SidebarProvider } from "@/components/sidebar/sidebar-context";
+import { AppSidebar, SidebarToggle } from "@/components/sidebar/app-sidebar";
+import type { ReactNode } from "react";
+
+interface AppShellProps {
+  displayName: string;
+  email: string;
+  children: ReactNode;
+}
+
+export function AppShell({ displayName, email, children }: AppShellProps) {
+  const params = useParams<{ workspaceSlug?: string }>();
+  const [workspaceName, setWorkspaceName] = useState("");
+
+  useEffect(() => {
+    if (!params.workspaceSlug) return;
+
+    const supabase = createClient();
+    supabase
+      .from("workspaces")
+      .select("name")
+      .eq("slug", params.workspaceSlug)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (data) setWorkspaceName(data.name);
+      });
+  }, [params.workspaceSlug]);
+
+  return (
+    <SidebarProvider>
+      <div className="flex h-screen overflow-hidden">
+        <AppSidebar
+          workspaceName={workspaceName || "Workspace"}
+          displayName={displayName}
+          email={email}
+        />
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <header className="flex h-10 shrink-0 items-center gap-2 border-b border-white/[0.06] px-4 md:hidden">
+            <SidebarToggle />
+          </header>
+          <main className="flex-1 overflow-y-auto">{children}</main>
+        </div>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Menu } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useSidebar } from "@/components/sidebar/sidebar-context";
+import { WorkspaceSwitcher } from "@/components/sidebar/workspace-switcher";
+import { PageTree } from "@/components/sidebar/page-tree";
+import { UserMenu } from "@/components/sidebar/user-menu";
+
+interface AppSidebarProps {
+  workspaceName: string;
+  displayName: string;
+  email: string;
+}
+
+function SidebarContent({
+  workspaceName,
+  displayName,
+  email,
+}: AppSidebarProps) {
+  return (
+    <div className="flex h-full flex-col gap-2 p-2">
+      <WorkspaceSwitcher workspaceName={workspaceName} />
+      <Separator className="bg-white/[0.06]" />
+      <PageTree />
+      <Separator className="bg-white/[0.06]" />
+      <UserMenu displayName={displayName} email={email} />
+    </div>
+  );
+}
+
+export function AppSidebar(props: AppSidebarProps) {
+  const { open, setOpen, isMobile } = useSidebar();
+
+  if (isMobile) {
+    return (
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTitle className="sr-only">Navigation</SheetTitle>
+        <SheetContent
+          side="left"
+          className="w-60 bg-muted p-0"
+          showCloseButton={false}
+        >
+          <SidebarContent {...props} />
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <aside
+      className="h-full w-60 shrink-0 border-r border-white/[0.06] bg-muted transition-[width,opacity] duration-200 ease-out"
+      style={{
+        width: open ? 240 : 0,
+        opacity: open ? 1 : 0,
+        overflow: "hidden",
+      }}
+    >
+      <SidebarContent {...props} />
+    </aside>
+  );
+}
+
+export function SidebarToggle() {
+  const { toggle, isMobile } = useSidebar();
+
+  if (!isMobile) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      className="shrink-0"
+      onClick={toggle}
+      aria-label="Toggle sidebar"
+    >
+      <Menu className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -41,12 +41,12 @@ export function AppSidebar(props: AppSidebarProps) {
   if (isMobile) {
     return (
       <Sheet open={open} onOpenChange={setOpen}>
-        <SheetTitle className="sr-only">Navigation</SheetTitle>
         <SheetContent
           side="left"
           className="w-60 bg-muted p-0"
           showCloseButton={false}
         >
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
           <SidebarContent {...props} />
         </SheetContent>
       </Sheet>

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { FileText, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function PageTree() {
+  return (
+    <div className="flex flex-1 flex-col gap-1">
+      <p className="px-2 text-xs tracking-widest uppercase text-white/30">
+        Pages
+      </p>
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-center gap-2 px-2 py-1 text-sm text-muted-foreground">
+          <FileText className="h-4 w-4" />
+          <span>No pages yet</span>
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        className="mt-1 w-full justify-start gap-2 px-2 text-muted-foreground"
+        size="sm"
+      >
+        <Plus className="h-4 w-4" />
+        New Page
+      </Button>
+    </div>
+  );
+}

--- a/src/components/sidebar/sidebar-context.tsx
+++ b/src/components/sidebar/sidebar-context.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface SidebarContextValue {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  isMobile: boolean;
+}
+
+const SidebarContext = createContext<SidebarContextValue | null>(null);
+
+const MOBILE_BREAKPOINT = 768;
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(true);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      const mobile = e.matches;
+      setIsMobile(mobile);
+      if (mobile) {
+        setOpen(false);
+      }
+    };
+    onChange(mql);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  const toggle = useCallback(() => setOpen((prev) => !prev), []);
+
+  // ⌘+\ keyboard shortcut to toggle sidebar
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "\\" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        toggle();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggle]);
+
+  return (
+    <SidebarContext.Provider value={{ open, setOpen, toggle, isMobile }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function useSidebar() {
+  const context = useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider");
+  }
+  return context;
+}

--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { LogOut, Settings, User } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface UserMenuProps {
+  displayName: string;
+  email: string;
+}
+
+export function UserMenu({ displayName, email }: UserMenuProps) {
+  const router = useRouter();
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/sign-in");
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            className="w-full justify-start gap-2 px-2"
+            size="sm"
+          />
+        }
+      >
+        <User className="h-4 w-4 shrink-0" />
+        <span className="truncate text-sm">{displayName}</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="start" sideOffset={4}>
+        <div className="px-1.5 py-1">
+          <p className="text-sm font-medium">{displayName}</p>
+          <p className="text-xs text-muted-foreground">{email}</p>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <Settings className="h-4 w-4" />
+          Settings
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleSignOut}>
+          <LogOut className="h-4 w-4" />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/sidebar/workspace-switcher.tsx
+++ b/src/components/sidebar/workspace-switcher.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { ChevronsUpDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface WorkspaceSwitcherProps {
+  workspaceName: string;
+}
+
+export function WorkspaceSwitcher({ workspaceName }: WorkspaceSwitcherProps) {
+  return (
+    <Button
+      variant="ghost"
+      className="w-full justify-between gap-2 px-2"
+      size="sm"
+      aria-label="Switch workspace"
+    >
+      <span className="truncate text-sm font-medium">{workspaceName}</span>
+      <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+    </Button>
+  );
+}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
+  return (
+    <SheetPrimitive.Backdrop
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: SheetPrimitive.Popup.Props & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Popup
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-3 right-3"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Popup>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn(
+        "font-heading text-base font-medium text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: SheetPrimitive.Description.Props) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
Closes #25

## What

Adds the authenticated app shell: a responsive layout with a collapsible sidebar, workspace context from the URL, and the foundational navigation structure. This is the chrome that all product features render inside.

## How

**Layout**: `(app)/layout.tsx` fetches the user profile server-side and passes display name + email to the client-side `AppShell` component, which wraps `SidebarProvider` + sidebar + main content area.

**Sidebar components** (`src/components/sidebar/`):
- `sidebar-context.tsx` — React context managing open/close state, mobile detection (`<768px`), and `⌘+\` keyboard shortcut
- `app-sidebar.tsx` — Desktop: collapsible `<aside>` with 200ms transition. Mobile: shadcn/ui `Sheet` sliding from left
- `workspace-switcher.tsx` — Placeholder button showing workspace name (functional in #27)
- `page-tree.tsx` — Placeholder page list with "New Page" button (functional in #28)
- `user-menu.tsx` — Dropdown menu with user info, settings link, and sign-out

**Root redirect**: `/` now checks auth and redirects authenticated users to their first workspace via a `members` → `workspaces` join query.

**New shadcn/ui components**: `sheet`, `dropdown-menu`, `separator`.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 8/8 tests pass ✅
- No new tests added — sidebar components are layout/styling with no testable logic. User menu sign-out reuses the existing `SignOutButton` pattern.

## Acceptance Criteria Verification

- [x] Route group `(app)/` with shared layout containing sidebar + main content area
- [x] `[workspaceSlug]` dynamic segment resolves the current workspace from the URL
- [x] Sidebar contains: workspace switcher (placeholder), page tree (placeholder), user menu with sign-out
- [x] Sidebar collapses on mobile (<768px) using shadcn/ui Sheet component
- [x] Keyboard shortcut `⌘+\` toggles sidebar visibility
- [x] JetBrains Mono font loaded and applied throughout the app (already in root layout)
- [x] Dark mode only — colors per design spec (already in globals.css)
- [x] Sharp corners on all components (`--radius: 0`) (already in globals.css)
- [x] Root `/` redirects authenticated users to their personal workspace
- [x] Responsive: desktop (≥1024px), tablet (768–1023px), mobile (<768px)