### PR TITLE
feat: workspace CRUD and workspace switcher (#26)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -155,7 +155,9 @@ src/
 │   ├── (app)/              # Authenticated route group
 │   │   ├── layout.tsx      # Auth guard, fetches profile, renders AppShell
 │   │   └── [workspaceSlug]/
-│   │       └── page.tsx    # /[workspaceSlug] — workspace home (placeholder)
+│   │       ├── page.tsx    # /[workspaceSlug] — workspace home (placeholder)
+│   │       └── settings/
+│   │           └── page.tsx # /[workspaceSlug]/settings — edit name/slug, delete workspace
 │   └── api/
 │       └── health/route.ts # Health check endpoint (DB connectivity)
 ├── components/
@@ -166,12 +168,17 @@ src/
 │   │   ├── app-shell.tsx        # Client wrapper: SidebarProvider + sidebar + main layout
 │   │   ├── app-sidebar.tsx      # Sidebar (desktop: collapsible aside, mobile: Sheet)
 │   │   ├── sidebar-context.tsx  # React context for sidebar open/close state + ⌘+\ shortcut
-│   │   ├── workspace-switcher.tsx # Workspace name display (placeholder — functional in #27)
+│   │   ├── workspace-switcher.tsx # Workspace dropdown: list, switch, create
+│   │   ├── create-workspace-dialog.tsx # Dialog for creating a new workspace
 │   │   ├── page-tree.tsx        # Page list placeholder (functional in #28)
 │   │   └── user-menu.tsx        # User dropdown with sign-out
+│   ├── workspace/           # Workspace feature components
+│   │   └── workspace-settings-form.tsx # Edit name/slug, delete workspace (client)
 │   └── ui/                 # shadcn/ui components (base-nova style, base-ui primitives)
+│       ├── alert-dialog.tsx
 │       ├── button.tsx
 │       ├── card.tsx
+│       ├── dialog.tsx
 │       ├── dropdown-menu.tsx
 │       ├── input.tsx
 │       ├── label.tsx
@@ -181,6 +188,7 @@ src/
 ├── lib/
 │   ├── utils.ts            # cn() utility (clsx + tailwind-merge)
 │   ├── types.ts            # Database entity types
+│   ├── workspace-utils.ts  # Slug generation, validation, workspace constants
 │   └── supabase/
 │       ├── client.ts       # Browser client (createBrowserClient)
 │       ├── server.ts       # Server component client (createServerClient + cookies)

--- a/src/app/(app)/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { WorkspaceSettingsForm } from "@/components/workspace/workspace-settings-form";
+import type { Workspace } from "@/lib/types";
+
+export default async function WorkspaceSettingsPage({
+  params,
+}: {
+  params: Promise<{ workspaceSlug: string }>;
+}) {
+  const { workspaceSlug } = await params;
+  const supabase = await createClient();
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("*")
+    .eq("slug", workspaceSlug)
+    .maybeSingle();
+
+  if (!workspace) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <h1 className="text-2xl font-semibold">Workspace settings</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Manage your workspace name, URL, and other settings.
+      </p>
+      <div className="mt-6">
+        <WorkspaceSettingsForm workspace={workspace as Workspace} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -27,7 +27,7 @@ export default async function AppLayout({
   const email = profile?.email || user.email || "";
 
   return (
-    <AppShell displayName={displayName} email={email}>
+    <AppShell displayName={displayName} email={email} userId={user.id}>
       {children}
     </AppShell>
   );

--- a/src/components/sidebar/app-shell.tsx
+++ b/src/components/sidebar/app-shell.tsx
@@ -1,41 +1,56 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { SidebarProvider } from "@/components/sidebar/sidebar-context";
 import { AppSidebar, SidebarToggle } from "@/components/sidebar/app-sidebar";
+import type { Workspace } from "@/lib/types";
 import type { ReactNode } from "react";
 
 interface AppShellProps {
   displayName: string;
   email: string;
+  userId: string;
   children: ReactNode;
 }
 
-export function AppShell({ displayName, email, children }: AppShellProps) {
+export function AppShell({
+  displayName,
+  email,
+  userId,
+  children,
+}: AppShellProps) {
   const params = useParams<{ workspaceSlug?: string }>();
-  const [workspaceName, setWorkspaceName] = useState("");
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
 
-  useEffect(() => {
-    if (!params.workspaceSlug) return;
-
+  const loadWorkspaces = useCallback(() => {
     const supabase = createClient();
     supabase
-      .from("workspaces")
-      .select("name")
-      .eq("slug", params.workspaceSlug)
-      .maybeSingle()
+      .from("members")
+      .select("workspace_id, workspaces(*)")
+      .eq("user_id", userId)
       .then(({ data }) => {
-        if (data) setWorkspaceName(data.name);
+        if (data) {
+          const ws = data
+            .map((m) => m.workspaces as unknown as Workspace)
+            .filter(Boolean);
+          setWorkspaces(ws);
+        }
       });
-  }, [params.workspaceSlug]);
+  }, [userId]);
+
+  useEffect(() => {
+    loadWorkspaces();
+  }, [loadWorkspaces, params.workspaceSlug]);
 
   return (
     <SidebarProvider>
       <div className="flex h-screen overflow-hidden">
         <AppSidebar
-          workspaceName={workspaceName || "Workspace"}
+          workspaces={workspaces}
+          currentSlug={params.workspaceSlug}
+          userId={userId}
           displayName={displayName}
           email={email}
         />

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -12,21 +12,30 @@ import { useSidebar } from "@/components/sidebar/sidebar-context";
 import { WorkspaceSwitcher } from "@/components/sidebar/workspace-switcher";
 import { PageTree } from "@/components/sidebar/page-tree";
 import { UserMenu } from "@/components/sidebar/user-menu";
+import type { Workspace } from "@/lib/types";
 
 interface AppSidebarProps {
-  workspaceName: string;
+  workspaces: Workspace[];
+  currentSlug: string | undefined;
+  userId: string;
   displayName: string;
   email: string;
 }
 
 function SidebarContent({
-  workspaceName,
+  workspaces,
+  currentSlug,
+  userId,
   displayName,
   email,
 }: AppSidebarProps) {
   return (
     <div className="flex h-full flex-col gap-2 p-2">
-      <WorkspaceSwitcher workspaceName={workspaceName} />
+      <WorkspaceSwitcher
+        workspaces={workspaces}
+        currentSlug={currentSlug}
+        userId={userId}
+      />
       <Separator className="bg-white/[0.06]" />
       <PageTree />
       <Separator className="bg-white/[0.06]" />

--- a/src/components/sidebar/create-workspace-dialog.tsx
+++ b/src/components/sidebar/create-workspace-dialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { generateSlug } from "@/lib/workspace-utils";
+
+interface CreateWorkspaceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userId: string;
+}
+
+export function CreateWorkspaceDialog({
+  open,
+  onOpenChange,
+  userId,
+}: CreateWorkspaceDialogProps) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function handleClose() {
+    setName("");
+    setError(null);
+    onOpenChange(false);
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Name is required.");
+      return;
+    }
+
+    const slug = generateSlug(trimmed);
+    if (!slug) {
+      setError("Name must contain at least one alphanumeric character.");
+      return;
+    }
+
+    setLoading(true);
+    const supabase = createClient();
+
+    // Append a random suffix to ensure slug uniqueness
+    const uniqueSlug = `${slug}-${crypto.randomUUID().slice(0, 6)}`;
+
+    const { data, error: insertError } = await supabase
+      .from("workspaces")
+      .insert({
+        name: trimmed,
+        slug: uniqueSlug,
+        is_personal: false,
+        created_by: userId,
+      })
+      .select("id, slug")
+      .single();
+
+    if (insertError) {
+      // DB trigger returns P0001 when limit is reached
+      if (insertError.message.includes("Workspace limit reached")) {
+        setError("You can create at most 3 workspaces.");
+      } else if (insertError.message.includes("duplicate key")) {
+        setError("A workspace with this slug already exists. Try a different name.");
+      } else {
+        setError(insertError.message);
+      }
+      setLoading(false);
+      return;
+    }
+
+    // Create owner membership for the new workspace
+    await supabase.from("members").insert({
+      workspace_id: data.id,
+      user_id: userId,
+      role: "owner",
+      joined_at: new Date().toISOString(),
+    });
+
+    setLoading(false);
+    handleClose();
+    router.push(`/${data.slug}`);
+    router.refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create workspace</DialogTitle>
+          <DialogDescription>
+            Add a new workspace to organize your pages.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="workspace-name">Name</Label>
+            <Input
+              id="workspace-name"
+              placeholder="My Workspace"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              autoFocus
+              autoComplete="off"
+            />
+            {name.trim() && (
+              <p className="text-xs text-muted-foreground">
+                Slug: {generateSlug(name.trim()) || "—"}
+              </p>
+            )}
+          </div>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading || !name.trim()}>
+              {loading ? "Creating…" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/sidebar/workspace-switcher.tsx
+++ b/src/components/sidebar/workspace-switcher.tsx
@@ -1,22 +1,113 @@
 "use client";
 
-import { ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronsUpDown, Plus, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { CreateWorkspaceDialog } from "@/components/sidebar/create-workspace-dialog";
+import type { Workspace } from "@/lib/types";
+import { MAX_CREATED_WORKSPACES } from "@/lib/workspace-utils";
 
 interface WorkspaceSwitcherProps {
-  workspaceName: string;
+  workspaces: Workspace[];
+  currentSlug: string | undefined;
+  userId: string;
 }
 
-export function WorkspaceSwitcher({ workspaceName }: WorkspaceSwitcherProps) {
+/** Sort workspaces: personal first, then alphabetically by name. */
+function sortWorkspaces(workspaces: Workspace[]): Workspace[] {
+  return [...workspaces].sort((a, b) => {
+    if (a.is_personal && !b.is_personal) return -1;
+    if (!a.is_personal && b.is_personal) return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function WorkspaceSwitcher({
+  workspaces,
+  currentSlug,
+  userId,
+}: WorkspaceSwitcherProps) {
+  const router = useRouter();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const sorted = sortWorkspaces(workspaces);
+  const current = sorted.find((w) => w.slug === currentSlug);
+  const createdCount = workspaces.filter((w) => w.created_by === userId).length;
+  const canCreate = createdCount < MAX_CREATED_WORKSPACES;
+
   return (
-    <Button
-      variant="ghost"
-      className="w-full justify-between gap-2 px-2"
-      size="sm"
-      aria-label="Switch workspace"
-    >
-      <span className="truncate text-sm font-medium">{workspaceName}</span>
-      <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-    </Button>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              className="w-full justify-between gap-2 px-2"
+              size="sm"
+              aria-label="Switch workspace"
+            />
+          }
+        >
+          <span className="truncate text-sm font-medium">
+            {current?.name || "Workspace"}
+          </span>
+          <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="start" sideOffset={4}>
+          {sorted.map((ws) => (
+            <DropdownMenuItem
+              key={ws.id}
+              onClick={() => router.push(`/${ws.slug}`)}
+            >
+              <Check
+                className={`h-4 w-4 ${ws.slug === currentSlug ? "opacity-100" : "opacity-0"}`}
+              />
+              <span className="truncate">{ws.name}</span>
+              {ws.is_personal && (
+                <span className="ml-auto text-xs text-muted-foreground">
+                  Personal
+                </span>
+              )}
+            </DropdownMenuItem>
+          ))}
+          <DropdownMenuSeparator />
+          {current && !current.is_personal && (
+            <>
+              <DropdownMenuItem
+                onClick={() => router.push(`/${current.slug}/settings`)}
+              >
+                <Settings className="h-4 w-4" />
+                Workspace settings
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          <DropdownMenuItem
+            disabled={!canCreate}
+            onClick={() => {
+              if (canCreate) setCreateOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4" />
+            {canCreate
+              ? "Create workspace"
+              : `Limit reached (${MAX_CREATED_WORKSPACES} max)`}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CreateWorkspaceDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        userId={userId}
+      />
+    </>
   );
 }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                variant="ghost"
+                className="absolute top-2 right-2"
+                size="icon-sm"
+              />
+            }
+          >
+            <XIcon
+            />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>
+          Close
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/workspace/workspace-settings-form.tsx
+++ b/src/components/workspace/workspace-settings-form.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Trash2 } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { generateSlug, isValidSlug } from "@/lib/workspace-utils";
+import type { Workspace } from "@/lib/types";
+
+interface WorkspaceSettingsFormProps {
+  workspace: Workspace;
+}
+
+export function WorkspaceSettingsForm({
+  workspace,
+}: WorkspaceSettingsFormProps) {
+  const router = useRouter();
+  const [name, setName] = useState(workspace.name);
+  const [slug, setSlug] = useState(workspace.slug);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const nameChanged = name.trim() !== workspace.name;
+  const slugChanged = slug !== workspace.slug;
+  const hasChanges = nameChanged || slugChanged;
+
+  function handleNameChange(value: string) {
+    setName(value);
+    setSaved(false);
+    // Auto-generate slug from name if slug hasn't been manually edited
+    if (!slugChanged) {
+      setSlug(generateSlug(value));
+    }
+  }
+
+  async function handleSave(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+
+    if (!slug) {
+      setError("Slug is required.");
+      return;
+    }
+
+    if (!isValidSlug(slug)) {
+      setError(
+        "Slug must be 2–48 characters, lowercase alphanumeric and hyphens only."
+      );
+      return;
+    }
+
+    setSaving(true);
+    const supabase = createClient();
+
+    const updates: Record<string, string> = {};
+    if (nameChanged) updates.name = trimmedName;
+    if (slugChanged) updates.slug = slug;
+
+    const { error: updateError } = await supabase
+      .from("workspaces")
+      .update(updates)
+      .eq("id", workspace.id);
+
+    if (updateError) {
+      if (updateError.message.includes("duplicate key")) {
+        setError("This slug is already taken. Choose a different one.");
+      } else {
+        setError(updateError.message);
+      }
+      setSaving(false);
+      return;
+    }
+
+    setSaving(false);
+    setSaved(true);
+
+    // If slug changed, navigate to the new URL
+    if (slugChanged) {
+      router.push(`/${slug}/settings`);
+      router.refresh();
+    } else {
+      router.refresh();
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true);
+    const supabase = createClient();
+
+    const { error: deleteError } = await supabase
+      .from("workspaces")
+      .delete()
+      .eq("id", workspace.id);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      setDeleting(false);
+      setDeleteOpen(false);
+      return;
+    }
+
+    // Navigate to the user's personal workspace
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user) {
+      const { data: membership } = await supabase
+        .from("members")
+        .select("workspace_id, workspaces(slug)")
+        .eq("user_id", user.id)
+        .limit(1)
+        .maybeSingle();
+
+      if (membership?.workspaces) {
+        const ws = membership.workspaces as unknown as { slug: string };
+        router.push(`/${ws.slug}`);
+        router.refresh();
+        return;
+      }
+    }
+
+    router.push("/");
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-8">
+      <form onSubmit={handleSave} className="space-y-4">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="ws-name">Name</Label>
+          <Input
+            id="ws-name"
+            value={name}
+            onChange={(e) => handleNameChange(e.target.value)}
+            placeholder="Workspace name"
+            autoComplete="off"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="ws-slug">Slug</Label>
+          <Input
+            id="ws-slug"
+            value={slug}
+            onChange={(e) => {
+              setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""));
+              setSaved(false);
+            }}
+            placeholder="workspace-slug"
+            autoComplete="off"
+          />
+          <p className="text-xs text-muted-foreground">
+            Used in the URL: /{slug || "…"}
+          </p>
+        </div>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        {saved && (
+          <p className="text-xs text-accent">Settings saved.</p>
+        )}
+        <Button type="submit" disabled={saving || !hasChanges}>
+          {saving ? "Saving…" : "Save changes"}
+        </Button>
+      </form>
+
+      {!workspace.is_personal && (
+        <div className="space-y-3 border-t border-white/[0.06] pt-8">
+          <h2 className="text-sm font-medium text-destructive">Danger zone</h2>
+          <p className="text-xs text-muted-foreground">
+            Deleting this workspace will permanently remove all its pages and
+            members. This action cannot be undone.
+          </p>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => setDeleteOpen(true)}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete workspace
+          </Button>
+
+          <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete workspace</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will permanently delete &ldquo;{workspace.name}&rdquo;
+                  and all its pages and members. This cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel disabled={deleting}>
+                  Cancel
+                </AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  onClick={handleDelete}
+                  disabled={deleting}
+                >
+                  {deleting ? "Deleting…" : "Delete workspace"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      )}
+
+      {workspace.is_personal && (
+        <div className="space-y-3 border-t border-white/[0.06] pt-8">
+          <p className="text-xs text-muted-foreground">
+            This is your personal workspace. It cannot be deleted.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/workspace-utils.test.ts
+++ b/src/lib/workspace-utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { generateSlug, isValidSlug, MAX_CREATED_WORKSPACES } from "./workspace-utils";
+
+describe("generateSlug", () => {
+  it("lowercases and hyphenates", () => {
+    expect(generateSlug("My Workspace")).toBe("my-workspace");
+  });
+
+  it("collapses consecutive hyphens", () => {
+    expect(generateSlug("hello   world")).toBe("hello-world");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(generateSlug("  --test-- ")).toBe("test");
+  });
+
+  it("handles special characters", () => {
+    expect(generateSlug("Café & Résumé!")).toBe("caf-r-sum");
+  });
+
+  it("returns empty string for non-alphanumeric input", () => {
+    expect(generateSlug("---")).toBe("");
+  });
+});
+
+describe("isValidSlug", () => {
+  it("accepts valid slugs", () => {
+    expect(isValidSlug("my-workspace")).toBe(true);
+    expect(isValidSlug("a1")).toBe(true);
+    expect(isValidSlug("test")).toBe(true);
+  });
+
+  it("rejects slugs with leading hyphens", () => {
+    expect(isValidSlug("-bad")).toBe(false);
+  });
+
+  it("rejects slugs with trailing hyphens", () => {
+    expect(isValidSlug("bad-")).toBe(false);
+  });
+
+  it("rejects slugs with uppercase", () => {
+    expect(isValidSlug("Bad")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidSlug("")).toBe(false);
+  });
+
+  it("accepts single character", () => {
+    expect(isValidSlug("a")).toBe(true);
+  });
+});
+
+describe("MAX_CREATED_WORKSPACES", () => {
+  it("is 3", () => {
+    expect(MAX_CREATED_WORKSPACES).toBe(3);
+  });
+});

--- a/src/lib/workspace-utils.ts
+++ b/src/lib/workspace-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Generate a URL-safe slug from a workspace name.
+ * Lowercases, replaces non-alphanumeric chars with hyphens,
+ * collapses consecutive hyphens, and trims leading/trailing hyphens.
+ */
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Validate a workspace slug: lowercase alphanumeric + hyphens,
+ * 2–48 chars, no leading/trailing hyphens.
+ */
+export function isValidSlug(slug: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{0,46}[a-z0-9]$/.test(slug) || /^[a-z0-9]{1,2}$/.test(slug);
+}
+
+/** Max workspaces a user can create (personal + 2 additional). */
+export const MAX_CREATED_WORKSPACES = 3;


### PR DESCRIPTION
Closes #26

## What

Workspace CRUD operations and a functional workspace switcher in the sidebar. Users can create additional workspaces (up to 3 total), switch between them, edit workspace settings, and delete non-personal workspaces.

## How

**Workspace switcher** (`workspace-switcher.tsx`): Dropdown in the sidebar listing all workspaces the user belongs to. Personal workspace listed first, others alphabetically. Includes "Create workspace" button (disabled at limit) and "Workspace settings" link for non-personal workspaces.

**Create workspace dialog** (`create-workspace-dialog.tsx`): Dialog with name input, auto-generated slug with random suffix for uniqueness. Creates workspace + owner membership. Client-side limit check disables the button; server-side DB trigger rejects inserts at ≥3.

**Settings page** (`[workspaceSlug]/settings/page.tsx` + `workspace-settings-form.tsx`): Edit workspace name and slug with validation. Delete non-personal workspaces via AlertDialog confirmation — cascades to all pages and members via DB foreign keys. Personal workspace shows explanation that it cannot be deleted.

**Data flow**: `AppShell` loads all workspaces via members join, passes them to sidebar components. `AppLayout` passes `userId` from the auth guard.

## New dependencies

- shadcn/ui `dialog` and `alert-dialog` components (both use `@base-ui/react` primitives already in the project)

## Testing

- Unit tests for `generateSlug`, `isValidSlug`, `MAX_CREATED_WORKSPACES`
- `pnpm lint && pnpm typecheck && pnpm test` — all pass (20 tests)
- Mobile responsive: sidebar Sheet works with updated workspace switcher