### PR TITLE
feat: pages CRUD and sidebar page tree (#27)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -155,7 +155,8 @@ src/
 │   ├── (app)/              # Authenticated route group
 │   │   ├── layout.tsx      # Auth guard, fetches profile, renders AppShell
 │   │   └── [workspaceSlug]/
-│   │       └── page.tsx    # /[workspaceSlug] — workspace home (placeholder)
+│   │       ├── page.tsx    # /[workspaceSlug] — workspace home (page list or empty state)
+│   │       └── [pageId]/page.tsx  # /[workspaceSlug]/[pageId] — page with title + editor placeholder
 │   └── api/
 │       └── health/route.ts # Health check endpoint (DB connectivity)
 ├── components/
@@ -168,8 +169,10 @@ src/
 │   │   ├── sidebar-context.tsx  # React context for sidebar open/close state + ⌘+\ shortcut
 │   │   ├── workspace-switcher.tsx # Dropdown listing all workspaces, create workspace trigger
 │   │   ├── create-workspace-dialog.tsx # Dialog for creating a new workspace
-│   │   ├── page-tree.tsx        # Page list placeholder (functional in #28)
+│   │   ├── page-tree.tsx        # Hierarchical page tree with CRUD, drag-and-drop, nest/unnest
 │   │   └── user-menu.tsx        # User dropdown with settings link + sign-out
+│   ├── page-title.tsx           # Inline-editable page title (saves on blur/Enter)
+│   ├── workspace-home.tsx       # Workspace home: page list or empty state with create CTA
 │   ├── workspace-settings-form.tsx # Edit workspace name/slug, delete workspace
 │   └── ui/                 # shadcn/ui components (base-nova style, base-ui primitives)
 │       ├── alert-dialog.tsx
@@ -214,7 +217,7 @@ src/
 │   │   ├── layout.tsx                 # App shell (sidebar + main content), passes userId
 │   │   └── [workspaceSlug]/
 │   │       ├── page.tsx               # /[workspaceSlug] (workspace home)
-│   │       ├── [pageId]/page.tsx      # /[workspaceSlug]/[pageId] (editor) — planned
+│   │       ├── [pageId]/page.tsx      # /[workspaceSlug]/[pageId] (page view + editor placeholder)
 │   │       └── settings/
 │   │           ├── page.tsx           # /[workspaceSlug]/settings (name, slug, delete)
 │   │           └── members/page.tsx   # /[workspaceSlug]/settings/members — planned

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -1,0 +1,44 @@
+import { notFound } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { PageTitle } from "@/components/page-title";
+
+export default async function PageView({
+  params,
+}: {
+  params: Promise<{ workspaceSlug: string; pageId: string }>;
+}) {
+  const { workspaceSlug, pageId } = await params;
+  const supabase = await createClient();
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("id")
+    .eq("slug", workspaceSlug)
+    .maybeSingle();
+
+  if (!workspace) {
+    notFound();
+  }
+
+  const { data: page } = await supabase
+    .from("pages")
+    .select("*")
+    .eq("id", pageId)
+    .eq("workspace_id", workspace.id)
+    .maybeSingle();
+
+  if (!page) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <PageTitle key={page.id} pageId={page.id} initialTitle={page.title} />
+      <div className="mt-4">
+        <p className="text-sm text-muted-foreground">
+          Type &apos;/&apos; for commands
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[workspaceSlug]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { WorkspaceHome } from "@/components/workspace-home";
 
 export default async function WorkspacePage({
   params,
@@ -8,6 +9,10 @@ export default async function WorkspacePage({
 }) {
   const { workspaceSlug } = await params;
   const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   const { data: workspace } = await supabase
     .from("workspaces")
@@ -19,14 +24,18 @@ export default async function WorkspacePage({
     notFound();
   }
 
+  const { data: pages } = await supabase
+    .from("pages")
+    .select("id, title, parent_id, position, icon, updated_at")
+    .eq("workspace_id", workspace.id)
+    .is("parent_id", null)
+    .order("position", { ascending: true });
+
   return (
-    <div className="flex flex-col items-center justify-center p-6">
-      <div className="max-w-2xl space-y-4 text-center">
-        <h1 className="text-2xl font-semibold">{workspace.name}</h1>
-        <p className="text-sm text-muted-foreground">
-          Your workspace is ready. Pages and editor coming soon.
-        </p>
-      </div>
-    </div>
+    <WorkspaceHome
+      workspace={workspace}
+      pages={pages ?? []}
+      userId={user?.id ?? ""}
+    />
   );
 }

--- a/src/components/page-title.tsx
+++ b/src/components/page-title.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+interface PageTitleProps {
+  pageId: string;
+  initialTitle: string;
+}
+
+/**
+ * Inline-editable page title. Parent should use `key={pageId}` to reset
+ * state when navigating between pages.
+ */
+export function PageTitle({ pageId, initialTitle }: PageTitleProps) {
+  const [title, setTitle] = useState(initialTitle);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const lastSavedRef = useRef(initialTitle);
+
+  // Focus the title field when the page is new (empty title)
+  useEffect(() => {
+    if (!initialTitle && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [initialTitle]);
+
+  const saveTitle = useCallback(
+    async (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed === lastSavedRef.current) return;
+
+      lastSavedRef.current = trimmed;
+      const supabase = createClient();
+      await supabase
+        .from("pages")
+        .update({ title: trimmed })
+        .eq("id", pageId);
+    },
+    [pageId]
+  );
+
+  function handleBlur() {
+    saveTitle(title);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      saveTitle(title);
+      inputRef.current?.blur();
+    }
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={title}
+      onChange={(e) => setTitle(e.target.value)}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+      placeholder="Untitled"
+      className="w-full bg-transparent text-3xl font-bold text-foreground placeholder:text-muted-foreground outline-none"
+      aria-label="Page title"
+    />
+  );
+}

--- a/src/components/page-title.tsx
+++ b/src/components/page-title.tsx
@@ -29,12 +29,15 @@ export function PageTitle({ pageId, initialTitle }: PageTitleProps) {
       const trimmed = value.trim();
       if (trimmed === lastSavedRef.current) return;
 
-      lastSavedRef.current = trimmed;
       const supabase = createClient();
-      await supabase
+      const { error } = await supabase
         .from("pages")
         .update({ title: trimmed })
         .eq("id", pageId);
+
+      if (!error) {
+        lastSavedRef.current = trimmed;
+      }
     },
     [pageId]
   );

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -28,7 +28,7 @@ function SidebarContent({
     <div className="flex h-full flex-col gap-2 p-2">
       <WorkspaceSwitcher userId={userId} />
       <Separator className="bg-white/[0.06]" />
-      <PageTree />
+      <PageTree userId={userId} />
       <Separator className="bg-white/[0.06]" />
       <UserMenu displayName={displayName} email={email} />
     </div>

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -1,28 +1,785 @@
 "use client";
 
-import { FileText, Plus } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import {
+  ChevronRight,
+  FileText,
+  GripVertical,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { Page } from "@/lib/types";
 
-export function PageTree() {
+interface PageTreeProps {
+  userId: string;
+}
+
+interface TreeNode {
+  page: Page;
+  children: TreeNode[];
+}
+
+function buildTree(pages: Page[]): TreeNode[] {
+  const map = new Map<string, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  for (const page of pages) {
+    map.set(page.id, { page, children: [] });
+  }
+
+  for (const page of pages) {
+    const node = map.get(page.id)!;
+    if (page.parent_id && map.has(page.parent_id)) {
+      map.get(page.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  function sortChildren(nodes: TreeNode[]) {
+    nodes.sort((a, b) => a.page.position - b.page.position);
+    for (const node of nodes) {
+      sortChildren(node.children);
+    }
+  }
+  sortChildren(roots);
+
+  return roots;
+}
+
+function getDescendantIds(node: TreeNode): string[] {
+  const ids: string[] = [];
+  for (const child of node.children) {
+    ids.push(child.page.id);
+    ids.push(...getDescendantIds(child));
+  }
+  return ids;
+}
+
+function findNode(nodes: TreeNode[], id: string): TreeNode | null {
+  for (const node of nodes) {
+    if (node.page.id === id) return node;
+    const found = findNode(node.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+export function PageTree({ userId }: PageTreeProps) {
+  const router = useRouter();
+  const params = useParams<{ workspaceSlug?: string; pageId?: string }>();
+  const [pages, setPages] = useState<Page[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [deleteTarget, setDeleteTarget] = useState<TreeNode | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<{
+    id: string;
+    position: "before" | "after" | "inside";
+  } | null>(null);
+
+  const workspaceSlug = params.workspaceSlug;
+
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!workspaceSlug) return;
+
+    const supabase = createClient();
+    supabase
+      .from("workspaces")
+      .select("id")
+      .eq("slug", workspaceSlug)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (data) setWorkspaceId(data.id);
+      });
+  }, [workspaceSlug]);
+
+  const fetchPages = useCallback(async () => {
+    if (!workspaceId) return;
+
+    const supabase = createClient();
+    const { data } = await supabase
+      .from("pages")
+      .select("*")
+      .eq("workspace_id", workspaceId)
+      .order("position", { ascending: true });
+
+    if (data) {
+      setPages(data);
+    }
+    setLoading(false);
+  }, [workspaceId]);
+
+  useEffect(() => {
+    if (workspaceId) {
+      fetchPages();
+    }
+  }, [workspaceId, fetchPages]);
+
+  const tree = useMemo(() => buildTree(pages), [pages]);
+
+  const toggleExpand = useCallback((pageId: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(pageId)) {
+        next.delete(pageId);
+      } else {
+        next.add(pageId);
+      }
+      return next;
+    });
+  }, []);
+
+  async function handleCreate(parentId: string | null) {
+    if (!workspaceId || !workspaceSlug) return;
+
+    const siblings = pages.filter((p) => p.parent_id === parentId);
+    const nextPosition =
+      siblings.length > 0
+        ? Math.max(...siblings.map((p) => p.position)) + 1
+        : 0;
+
+    const supabase = createClient();
+    const { data: newPage, error } = await supabase
+      .from("pages")
+      .insert({
+        workspace_id: workspaceId,
+        parent_id: parentId,
+        title: "",
+        position: nextPosition,
+        created_by: userId,
+      })
+      .select()
+      .single();
+
+    if (error || !newPage) return;
+
+    setPages((prev) => [...prev, newPage]);
+
+    if (parentId) {
+      setExpanded((prev) => new Set(prev).add(parentId));
+    }
+
+    router.push(`/${workspaceSlug}/${newPage.id}`);
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("pages")
+      .delete()
+      .eq("id", deleteTarget.page.id);
+
+    if (!error) {
+      const removedIds = new Set([
+        deleteTarget.page.id,
+        ...getDescendantIds(deleteTarget),
+      ]);
+      setPages((prev) => prev.filter((p) => !removedIds.has(p.id)));
+
+      if (params.pageId && removedIds.has(params.pageId)) {
+        router.push(`/${workspaceSlug}`);
+      }
+    }
+
+    setDeleting(false);
+    setDeleteTarget(null);
+  }
+
+  async function handleMoveUp(page: Page) {
+    const siblings = pages
+      .filter((p) => p.parent_id === page.parent_id)
+      .sort((a, b) => a.position - b.position);
+
+    const idx = siblings.findIndex((p) => p.id === page.id);
+    if (idx <= 0) return;
+
+    const prev = siblings[idx - 1];
+    await swapPositions(page, prev);
+  }
+
+  async function handleMoveDown(page: Page) {
+    const siblings = pages
+      .filter((p) => p.parent_id === page.parent_id)
+      .sort((a, b) => a.position - b.position);
+
+    const idx = siblings.findIndex((p) => p.id === page.id);
+    if (idx < 0 || idx >= siblings.length - 1) return;
+
+    const next = siblings[idx + 1];
+    await swapPositions(page, next);
+  }
+
+  async function swapPositions(a: Page, b: Page) {
+    const supabase = createClient();
+
+    setPages((prev) =>
+      prev.map((p) => {
+        if (p.id === a.id) return { ...p, position: b.position };
+        if (p.id === b.id) return { ...p, position: a.position };
+        return p;
+      })
+    );
+
+    await Promise.all([
+      supabase.from("pages").update({ position: b.position }).eq("id", a.id),
+      supabase.from("pages").update({ position: a.position }).eq("id", b.id),
+    ]);
+  }
+
+  async function handleNest(page: Page) {
+    const siblings = pages
+      .filter((p) => p.parent_id === page.parent_id)
+      .sort((a, b) => a.position - b.position);
+
+    const idx = siblings.findIndex((p) => p.id === page.id);
+    if (idx <= 0) return;
+
+    const newParent = siblings[idx - 1];
+    const newSiblings = pages.filter((p) => p.parent_id === newParent.id);
+    const nextPosition =
+      newSiblings.length > 0
+        ? Math.max(...newSiblings.map((p) => p.position)) + 1
+        : 0;
+
+    const supabase = createClient();
+
+    setPages((prev) =>
+      prev.map((p) =>
+        p.id === page.id
+          ? { ...p, parent_id: newParent.id, position: nextPosition }
+          : p
+      )
+    );
+
+    setExpanded((prev) => new Set(prev).add(newParent.id));
+
+    await supabase
+      .from("pages")
+      .update({ parent_id: newParent.id, position: nextPosition })
+      .eq("id", page.id);
+  }
+
+  async function handleUnnest(page: Page) {
+    if (!page.parent_id) return;
+
+    const parent = pages.find((p) => p.id === page.parent_id);
+    if (!parent) return;
+
+    const parentSiblings = pages
+      .filter((p) => p.parent_id === parent.parent_id)
+      .sort((a, b) => a.position - b.position);
+
+    const nextPosition = parent.position + 1;
+
+    const toShift = parentSiblings.filter(
+      (p) => p.position >= nextPosition && p.id !== page.id
+    );
+
+    const supabase = createClient();
+
+    setPages((prev) =>
+      prev.map((p) => {
+        if (p.id === page.id) {
+          return { ...p, parent_id: parent.parent_id, position: nextPosition };
+        }
+        if (toShift.some((s) => s.id === p.id)) {
+          return { ...p, position: p.position + 1 };
+        }
+        return p;
+      })
+    );
+
+    const updates = [
+      supabase
+        .from("pages")
+        .update({ parent_id: parent.parent_id, position: nextPosition })
+        .eq("id", page.id),
+      ...toShift.map((s) =>
+        supabase
+          .from("pages")
+          .update({ position: s.position + 1 })
+          .eq("id", s.id)
+      ),
+    ];
+
+    await Promise.all(updates);
+  }
+
+  function handleDragStart(e: React.DragEvent, pageId: string) {
+    setDraggedId(pageId);
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", pageId);
+  }
+
+  function handleDragOver(e: React.DragEvent, targetId: string) {
+    e.preventDefault();
+    if (draggedId === targetId) return;
+
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const y = e.clientY - rect.top;
+    const height = rect.height;
+
+    let position: "before" | "after" | "inside";
+    if (y < height * 0.25) {
+      position = "before";
+    } else if (y > height * 0.75) {
+      position = "after";
+    } else {
+      position = "inside";
+    }
+
+    setDropTarget({ id: targetId, position });
+  }
+
+  function handleDragLeave() {
+    setDropTarget(null);
+  }
+
+  async function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    if (!draggedId || !dropTarget || draggedId === dropTarget.id) {
+      setDraggedId(null);
+      setDropTarget(null);
+      return;
+    }
+
+    const draggedPage = pages.find((p) => p.id === draggedId);
+    const targetPage = pages.find((p) => p.id === dropTarget.id);
+    if (!draggedPage || !targetPage) {
+      setDraggedId(null);
+      setDropTarget(null);
+      return;
+    }
+
+    // Prevent dropping a parent onto its own descendant
+    const draggedNode = findNode(tree, draggedId);
+    if (draggedNode) {
+      const descendantIds = getDescendantIds(draggedNode);
+      if (descendantIds.includes(dropTarget.id)) {
+        setDraggedId(null);
+        setDropTarget(null);
+        return;
+      }
+    }
+
+    const supabase = createClient();
+
+    if (dropTarget.position === "inside") {
+      const newSiblings = pages.filter((p) => p.parent_id === targetPage.id);
+      const nextPos =
+        newSiblings.length > 0
+          ? Math.max(...newSiblings.map((p) => p.position)) + 1
+          : 0;
+
+      setPages((prev) =>
+        prev.map((p) =>
+          p.id === draggedId
+            ? { ...p, parent_id: targetPage.id, position: nextPos }
+            : p
+        )
+      );
+      setExpanded((prev) => new Set(prev).add(targetPage.id));
+
+      await supabase
+        .from("pages")
+        .update({ parent_id: targetPage.id, position: nextPos })
+        .eq("id", draggedId);
+    } else {
+      const newParentId = targetPage.parent_id;
+      const siblings = pages
+        .filter((p) => p.parent_id === newParentId && p.id !== draggedId)
+        .sort((a, b) => a.position - b.position);
+
+      const targetIdx = siblings.findIndex((p) => p.id === targetPage.id);
+      const insertIdx =
+        dropTarget.position === "before" ? targetIdx : targetIdx + 1;
+
+      const reordered = [...siblings];
+      reordered.splice(insertIdx, 0, draggedPage);
+
+      setPages((prev) => {
+        const next = [...prev];
+        for (let i = 0; i < reordered.length; i++) {
+          const idx = next.findIndex((p) => p.id === reordered[i].id);
+          if (idx !== -1) {
+            next[idx] = {
+              ...next[idx],
+              parent_id: newParentId,
+              position: i,
+            };
+          }
+        }
+        return next;
+      });
+
+      for (let i = 0; i < reordered.length; i++) {
+        await supabase
+          .from("pages")
+          .update({ parent_id: newParentId, position: i })
+          .eq("id", reordered[i].id);
+      }
+    }
+
+    setDraggedId(null);
+    setDropTarget(null);
+  }
+
+  function handleDragEnd() {
+    setDraggedId(null);
+    setDropTarget(null);
+  }
+
+  if (!workspaceSlug) return null;
+
   return (
-    <div className="flex flex-1 flex-col gap-1">
+    <div className="flex flex-1 flex-col gap-1 overflow-y-auto">
       <p className="px-2 text-xs tracking-widest uppercase text-white/30">
         Pages
       </p>
-      <div className="flex flex-col gap-0.5">
+
+      {loading ? (
+        <div className="flex flex-col gap-1 px-2">
+          <div className="h-7 animate-pulse bg-muted" />
+          <div className="h-7 animate-pulse bg-muted" />
+          <div className="h-7 animate-pulse bg-muted" />
+        </div>
+      ) : tree.length === 0 ? (
         <div className="flex items-center gap-2 px-2 py-1 text-sm text-muted-foreground">
           <FileText className="h-4 w-4" />
           <span>No pages yet</span>
         </div>
-      </div>
+      ) : (
+        <div
+          className="flex flex-col gap-0.5"
+          role="tree"
+          aria-label="Page tree"
+        >
+          {tree.map((node) => (
+            <PageTreeItem
+              key={node.page.id}
+              node={node}
+              depth={0}
+              expanded={expanded}
+              toggleExpand={toggleExpand}
+              selectedPageId={params.pageId}
+              workspaceSlug={workspaceSlug}
+              onNavigate={(pageId) =>
+                router.push(`/${workspaceSlug}/${pageId}`)
+              }
+              onCreate={handleCreate}
+              onDelete={setDeleteTarget}
+              onMoveUp={handleMoveUp}
+              onMoveDown={handleMoveDown}
+              onNest={handleNest}
+              onUnnest={handleUnnest}
+              draggedId={draggedId}
+              dropTarget={dropTarget}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+              onDragEnd={handleDragEnd}
+              pages={pages}
+            />
+          ))}
+        </div>
+      )}
+
       <Button
         variant="ghost"
         className="mt-1 w-full justify-start gap-2 px-2 text-muted-foreground"
         size="sm"
+        onClick={() => handleCreate(null)}
       >
         <Plus className="h-4 w-4" />
         New Page
       </Button>
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete page</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteTarget && deleteTarget.children.length > 0
+                ? `Are you sure you want to delete "${deleteTarget.page.title || "Untitled"}" and its ${deleteTarget.children.length} sub-page${deleteTarget.children.length === 1 ? "" : "s"}? This action cannot be undone.`
+                : `Are you sure you want to delete "${deleteTarget?.page.title || "Untitled"}"? This action cannot be undone.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
+              {deleting ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+interface PageTreeItemProps {
+  node: TreeNode;
+  depth: number;
+  expanded: Set<string>;
+  toggleExpand: (id: string) => void;
+  selectedPageId: string | undefined;
+  workspaceSlug: string;
+  onNavigate: (pageId: string) => void;
+  onCreate: (parentId: string | null) => void;
+  onDelete: (node: TreeNode) => void;
+  onMoveUp: (page: Page) => void;
+  onMoveDown: (page: Page) => void;
+  onNest: (page: Page) => void;
+  onUnnest: (page: Page) => void;
+  draggedId: string | null;
+  dropTarget: { id: string; position: "before" | "after" | "inside" } | null;
+  onDragStart: (e: React.DragEvent, pageId: string) => void;
+  onDragOver: (e: React.DragEvent, targetId: string) => void;
+  onDragLeave: () => void;
+  onDrop: (e: React.DragEvent) => void;
+  onDragEnd: () => void;
+  pages: Page[];
+}
+
+function PageTreeItem({
+  node,
+  depth,
+  expanded,
+  toggleExpand,
+  selectedPageId,
+  workspaceSlug,
+  onNavigate,
+  onCreate,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  onNest,
+  onUnnest,
+  draggedId,
+  dropTarget,
+  onDragStart,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onDragEnd,
+  pages,
+}: PageTreeItemProps) {
+  const { page } = node;
+  const hasChildren = node.children.length > 0;
+  const isExpanded = expanded.has(page.id);
+  const isSelected = selectedPageId === page.id;
+  const isDragged = draggedId === page.id;
+  const isDropTarget = dropTarget?.id === page.id;
+
+  const siblings = pages
+    .filter((p) => p.parent_id === page.parent_id)
+    .sort((a, b) => a.position - b.position);
+  const siblingIdx = siblings.findIndex((p) => p.id === page.id);
+  const canNest = siblingIdx > 0;
+  const canUnnest = page.parent_id !== null;
+  const canMoveUp = siblingIdx > 0;
+  const canMoveDown = siblingIdx < siblings.length - 1;
+
+  return (
+    <div role="treeitem" aria-selected={isSelected} aria-expanded={hasChildren ? isExpanded : undefined}>
+      <div
+        className={`group relative flex items-center gap-0.5 py-0.5 pr-1 text-sm ${
+          isSelected
+            ? "bg-white/[0.08] font-medium text-white/70"
+            : "text-muted-foreground hover:bg-white/[0.04]"
+        } ${isDragged ? "opacity-50" : ""}`}
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
+        draggable
+        onDragStart={(e) => onDragStart(e, page.id)}
+        onDragOver={(e) => onDragOver(e, page.id)}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        onDragEnd={onDragEnd}
+      >
+        {isDropTarget && dropTarget?.position === "before" && (
+          <div className="absolute top-0 right-0 left-0 h-0.5 bg-accent" />
+        )}
+        {isDropTarget && dropTarget?.position === "after" && (
+          <div className="absolute right-0 bottom-0 left-0 h-0.5 bg-accent" />
+        )}
+        {isDropTarget && dropTarget?.position === "inside" && (
+          <div className="absolute inset-0 border border-accent bg-accent/10" />
+        )}
+
+        <span className="flex shrink-0 cursor-grab items-center text-muted-foreground opacity-0 group-hover:opacity-100">
+          <GripVertical className="h-3 w-3" />
+        </span>
+
+        <button
+          className="flex h-4 w-4 shrink-0 items-center justify-center"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasChildren) {
+              toggleExpand(page.id);
+            }
+          }}
+          tabIndex={-1}
+          aria-label={isExpanded ? "Collapse" : "Expand"}
+        >
+          {hasChildren && (
+            <ChevronRight
+              className={`h-3 w-3 transition-transform duration-150 ${
+                isExpanded ? "rotate-90" : ""
+              }`}
+            />
+          )}
+        </button>
+
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+          {page.icon ? (
+            <span className="text-sm">{page.icon}</span>
+          ) : (
+            <FileText className="h-4 w-4" />
+          )}
+        </span>
+
+        <button
+          className="flex-1 truncate text-left"
+          onClick={() => onNavigate(page.id)}
+        >
+          {page.title || "Untitled"}
+        </button>
+
+        <div className="flex shrink-0 items-center gap-0.5 opacity-0 group-hover:opacity-100">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="h-5 w-5"
+            onClick={(e) => {
+              e.stopPropagation();
+              onCreate(page.id);
+            }}
+            aria-label="Add sub-page"
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="h-5 w-5"
+                  aria-label="Page actions"
+                />
+              }
+            >
+              <MoreHorizontal className="h-3 w-3" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="right" align="start" sideOffset={4}>
+              <DropdownMenuItem onClick={() => onCreate(page.id)}>
+                <Plus className="h-4 w-4" />
+                Add sub-page
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              {canMoveUp && (
+                <DropdownMenuItem onClick={() => onMoveUp(page)}>
+                  Move up
+                </DropdownMenuItem>
+              )}
+              {canMoveDown && (
+                <DropdownMenuItem onClick={() => onMoveDown(page)}>
+                  Move down
+                </DropdownMenuItem>
+              )}
+              {canNest && (
+                <DropdownMenuItem onClick={() => onNest(page)}>
+                  Nest under above
+                </DropdownMenuItem>
+              )}
+              {canUnnest && (
+                <DropdownMenuItem onClick={() => onUnnest(page)}>
+                  Unnest
+                </DropdownMenuItem>
+              )}
+              {(canMoveUp || canMoveDown || canNest || canUnnest) && (
+                <DropdownMenuSeparator />
+              )}
+              <DropdownMenuItem
+                className="text-destructive"
+                onClick={() => onDelete(node)}
+              >
+                <Trash2 className="h-4 w-4" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {hasChildren && isExpanded && (
+        <div role="group">
+          {node.children.map((child) => (
+            <PageTreeItem
+              key={child.page.id}
+              node={child}
+              depth={depth + 1}
+              expanded={expanded}
+              toggleExpand={toggleExpand}
+              selectedPageId={selectedPageId}
+              workspaceSlug={workspaceSlug}
+              onNavigate={onNavigate}
+              onCreate={onCreate}
+              onDelete={onDelete}
+              onMoveUp={onMoveUp}
+              onMoveDown={onMoveDown}
+              onNest={onNest}
+              onUnnest={onUnnest}
+              draggedId={draggedId}
+              dropTarget={dropTarget}
+              onDragStart={onDragStart}
+              onDragOver={onDragOver}
+              onDragLeave={onDragLeave}
+              onDrop={onDrop}
+              onDragEnd={onDragEnd}
+              pages={pages}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { FileText, Plus } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+
+interface WorkspaceHomeProps {
+  workspace: { id: string; name: string; slug: string };
+  pages: {
+    id: string;
+    title: string;
+    icon: string | null;
+    updated_at: string;
+  }[];
+  userId: string;
+}
+
+export function WorkspaceHome({
+  workspace,
+  pages,
+  userId,
+}: WorkspaceHomeProps) {
+  const router = useRouter();
+
+  async function handleCreatePage() {
+    const supabase = createClient();
+    const { data: newPage, error } = await supabase
+      .from("pages")
+      .insert({
+        workspace_id: workspace.id,
+        parent_id: null,
+        title: "",
+        position: pages.length,
+        created_by: userId,
+      })
+      .select()
+      .single();
+
+    if (error || !newPage) return;
+
+    router.push(`/${workspace.slug}/${newPage.id}`);
+    router.refresh();
+  }
+
+  if (pages.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center p-6" style={{ minHeight: "60vh" }}>
+        <div className="flex flex-col items-center gap-4 text-center">
+          <FileText className="h-12 w-12 text-muted-foreground" />
+          <h2 className="text-lg font-medium">No pages yet</h2>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            Create your first page to start writing. Pages can be nested to
+            organize your workspace.
+          </p>
+          <Button onClick={handleCreatePage}>
+            <Plus className="h-4 w-4" />
+            Create first page
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">{workspace.name}</h1>
+        <Button size="sm" onClick={handleCreatePage}>
+          <Plus className="h-4 w-4" />
+          New Page
+        </Button>
+      </div>
+      <div className="mt-6 flex flex-col gap-0.5">
+        {pages.map((page) => (
+          <button
+            key={page.id}
+            className="flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-white/[0.04]"
+            onClick={() => router.push(`/${workspace.slug}/${page.id}`)}
+          >
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+              {page.icon ? (
+                <span className="text-sm">{page.icon}</span>
+              ) : (
+                <FileText className="h-4 w-4 text-muted-foreground" />
+              )}
+            </span>
+            <span className="flex-1 truncate">
+              {page.title || "Untitled"}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {formatRelativeDate(page.updated_at)}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -45,7 +45,7 @@ export function WorkspaceHome({
 
   if (pages.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center p-6" style={{ minHeight: "60vh" }}>
+      <div className="flex min-h-[60vh] flex-col items-center justify-center p-6">
         <div className="flex flex-col items-center gap-4 text-center">
           <FileText className="h-12 w-12 text-muted-foreground" />
           <h2 className="text-lg font-medium">No pages yet</h2>


### PR DESCRIPTION
Closes #27

## What

Implements page creation, listing, reading, updating, and deletion within a workspace. Pages display as a hierarchical tree in the sidebar with collapsible nesting, drag-and-drop reordering, and nest/unnest operations.

## How

**Sidebar page tree** (`src/components/sidebar/page-tree.tsx`):
- Fetches all pages for the current workspace and builds a client-side tree from the flat `parent_id`/`position` data
- Supports create (root or sub-page), delete (with confirmation dialog and cascade), reorder (move up/down and drag-and-drop), nest (under sibling above), and unnest (move to parent's level)
- All mutations are optimistic — UI updates immediately, then persists to Supabase
- Tree items show expand/collapse chevron, drag handle on hover, and action menu (add sub-page, move, nest/unnest, delete)
- Proper ARIA attributes: `role="tree"`, `role="treeitem"`, `aria-expanded`, `aria-selected`

**Page route** (`src/app/(app)/[workspaceSlug]/[pageId]/page.tsx`):
- Server component that fetches the page and renders `PageTitle` + editor placeholder
- Validates both workspace slug and page ownership

**Inline page title** (`src/components/page-title.tsx`):
- Client component with controlled input, saves to Supabase on blur or Enter
- Auto-focuses when title is empty (new page)
- Uses `key={pageId}` from parent to reset state on navigation

**Workspace home** (`src/app/(app)/[workspaceSlug]/page.tsx` + `src/components/workspace-home.tsx`):
- Shows root-level page list with relative timestamps, or empty state with create CTA
- Empty state follows design spec: centered icon + heading + description + button

**Knowledge base**: Updated `architecture.md` component map to reflect new routes and components.

## Testing

- `pnpm lint` — passes
- `pnpm typecheck` — passes
- `pnpm test` — 20 tests pass (3 suites)
- No new unit tests added — the page tree is primarily UI interaction logic that requires integration/E2E testing with Supabase. The existing schema and RLS policies handle data integrity.

## Notes

- The editor content area is a placeholder per the issue spec — wired up in #28
- No new database migration needed — the `pages` table, RLS policies, and `ON DELETE CASCADE` on `parent_id` were already created in the foundational schema migration