### PR TITLE
fix: dialog overlay opacity does not match design spec (#47)

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -30,7 +30,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Backdrop
       data-slot="alert-dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/50 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/50 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/src/components/ui/overlay-opacity.test.ts
+++ b/src/components/ui/overlay-opacity.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for issue #47: dialog overlays must use bg-black/50
+ * per the design spec. bg-black/10 is nearly invisible and breaks
+ * the modal focus effect.
+ */
+describe("dialog overlay opacity matches design spec", () => {
+  const uiDir = join(__dirname);
+
+  it("DialogOverlay uses bg-black/50", () => {
+    const source = readFileSync(join(uiDir, "dialog.tsx"), "utf-8");
+    expect(source).toContain("bg-black/50");
+    expect(source).not.toContain("bg-black/10");
+  });
+
+  it("AlertDialogOverlay uses bg-black/50", () => {
+    const source = readFileSync(join(uiDir, "alert-dialog.tsx"), "utf-8");
+    expect(source).toContain("bg-black/50");
+    expect(source).not.toContain("bg-black/10");
+  });
+});


### PR DESCRIPTION
Closes #47

## What
The `DialogOverlay` and `AlertDialogOverlay` components used `bg-black/10` for their backdrop, making the overlay nearly invisible. The design spec requires `bg-black/50` for proper modal focus.

## How
Changed the overlay opacity from `bg-black/10` to `bg-black/50` in both `src/components/ui/dialog.tsx` and `src/components/ui/alert-dialog.tsx`.

## Testing
Added `src/components/ui/overlay-opacity.test.ts` — a source-file regression test that asserts both dialog overlay components contain `bg-black/50` and do not contain `bg-black/10`. All 22 tests pass.