### PR TITLE
fix(automations): remove webhook trigger to prevent duplicate work

### DIFF
--- a/.ona/automations/bug-fixer.yaml
+++ b/.ona/automations/bug-fixer.yaml
@@ -5,14 +5,6 @@ triggers:
         projects:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
-      pullRequest:
-        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
-        events:
-            - PULL_REQUEST_EVENT_MERGED
-    - context:
-        projects:
-            projectIds:
-                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       time:
         cronExpression: "*/10 * * * *"
     - context:

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -5,14 +5,6 @@ triggers:
         projects:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
-      pullRequest:
-        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
-        events:
-            - PULL_REQUEST_EVENT_MERGED
-    - context:
-        projects:
-            projectIds:
-                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       time:
         cronExpression: "*/10 * * * *"
     - context:


### PR DESCRIPTION
Closes #55

## What

Remove `PULL_REQUEST_EVENT_MERGED` webhook triggers from Feature Builder and Bug Fixer automations.

## Why

Both automations have two triggers that can fire near-simultaneously:
- `PULL_REQUEST_EVENT_MERGED` webhook (fires on every PR merge)
- `*/10 * * * *` cron (fires every 10 minutes)

When a PR merges close to a cron tick, both triggers spawn separate agent instances. Despite `maxParallel: 1`, both start before either registers as running — a TOCTOU race in the concurrency check. Both agents then read the same issue as `status:backlog` before either writes `status:in-progress`, producing duplicate PRs.

**Observed duplicates:**
- Issue #36 → PRs #40 and #41 (79 seconds apart)
- Issue #26 → PRs #45 and #46 (28 seconds apart)

## Fix

Drop the webhook trigger. The `*/10` cron is sufficient — work is picked up within 10 minutes of a merge. This eliminates the dual-trigger overlap entirely.

## ⚠️ Manual step required

After merging, the automations must be re-registered via the Ona CLI from a **user context** (the environment principal lacks permission):

```bash
# Find the automation IDs
ona ai automation list

# Update both automations
ona ai automation update <feature-builder-id> .ona/automations/feature-builder.yaml
ona ai automation update <bug-fixer-id> .ona/automations/bug-fixer.yaml
```