### PR TITLE
feat: workspace members — invite, roles, management (#32)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -171,16 +171,26 @@ src/
 │   │   ├── page-tree.tsx        # Page list placeholder (functional in #28)
 │   │   └── user-menu.tsx        # User dropdown with settings link + sign-out
 │   ├── workspace-settings-form.tsx # Edit workspace name/slug, delete workspace
+│   ├── members/             # Workspace member management components
+│   │   ├── members-page.tsx       # Client orchestrator: member list + invite form + pending invites
+│   │   ├── member-list.tsx        # Table of members with role badges, role change, remove
+│   │   ├── invite-form.tsx        # Email + role invite form (admin/owner only)
+│   │   ├── invite-accept.tsx      # Client component for accepting an invite token
+│   │   ├── pending-invite-list.tsx # Table of pending invites with revoke action
+│   │   └── role-select.tsx        # Role picker dropdown (owner/admin/member)
 │   └── ui/                 # shadcn/ui components (base-nova style, base-ui primitives)
 │       ├── alert-dialog.tsx
+│       ├── badge.tsx
 │       ├── button.tsx
 │       ├── card.tsx
 │       ├── dialog.tsx
 │       ├── dropdown-menu.tsx
 │       ├── input.tsx
 │       ├── label.tsx
+│       ├── select.tsx
 │       ├── separator.tsx
 │       ├── sheet.tsx
+│       ├── table.tsx
 │       └── tooltip.tsx
 ├── lib/
 │   ├── utils.ts            # cn() utility (clsx + tailwind-merge)
@@ -209,7 +219,7 @@ src/
 │   ├── (auth)/                        # Unauthenticated routes
 │   │   ├── sign-in/page.tsx           # /sign-in
 │   │   ├── sign-up/page.tsx           # /sign-up
-│   │   └── invite/[token]/page.tsx    # /invite/[token]
+│   │   └── invite/[token]/page.tsx    # /invite/[token] — invite accept flow
 │   ├── (app)/                         # Authenticated routes
 │   │   ├── layout.tsx                 # App shell (sidebar + main content), passes userId
 │   │   └── [workspaceSlug]/
@@ -217,7 +227,7 @@ src/
 │   │       ├── [pageId]/page.tsx      # /[workspaceSlug]/[pageId] (editor) — planned
 │   │       └── settings/
 │   │           ├── page.tsx           # /[workspaceSlug]/settings (name, slug, delete)
-│   │           └── members/page.tsx   # /[workspaceSlug]/settings/members — planned
+│   │           └── members/page.tsx   # /[workspaceSlug]/settings/members
 │   └── api/
 │       ├── health/                    # Existing
 │       └── ...                        # Additional API routes as needed

--- a/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
@@ -1,0 +1,87 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { MembersPage } from "@/components/members/members-page";
+import type { MemberWithProfile, WorkspaceInviteWithInviter } from "@/lib/types";
+
+export default async function WorkspaceMembersPage({
+  params,
+}: {
+  params: Promise<{ workspaceSlug: string }>;
+}) {
+  const { workspaceSlug } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const { data: workspace } = await supabase
+    .from("workspaces")
+    .select("*")
+    .eq("slug", workspaceSlug)
+    .maybeSingle();
+
+  if (!workspace) {
+    notFound();
+  }
+
+  // Fetch current user's membership to determine their role
+  const { data: currentMember } = await supabase
+    .from("members")
+    .select("id, role")
+    .eq("workspace_id", workspace.id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!currentMember) {
+    notFound();
+  }
+
+  // Fetch all members with profile info
+  const { data: membersRaw } = await supabase
+    .from("members")
+    .select("*, profiles(email, display_name, avatar_url)")
+    .eq("workspace_id", workspace.id)
+    .order("created_at", { ascending: true });
+
+  // Supabase join returns the relation as an opaque type; cast is unavoidable
+  const members = (membersRaw ?? []) as unknown as MemberWithProfile[];
+
+  // Fetch pending invites (only visible to admins/owners)
+  const isAdmin = currentMember.role === "owner" || currentMember.role === "admin";
+  let pendingInvites: WorkspaceInviteWithInviter[] = [];
+
+  if (isAdmin) {
+    const { data: invites } = await supabase
+      .from("workspace_invites")
+      .select("*, profiles:invited_by(display_name)")
+      .eq("workspace_id", workspace.id)
+      .is("accepted_at", null)
+      .order("created_at", { ascending: false });
+
+    // Supabase join returns the relation as an opaque type; cast is unavoidable
+    pendingInvites = (invites ?? []) as unknown as WorkspaceInviteWithInviter[];
+  }
+
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <h1 className="text-2xl font-semibold">Members</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Manage who has access to this workspace.
+      </p>
+      <div className="mt-6">
+        <MembersPage
+          workspace={workspace}
+          members={members}
+          pendingInvites={pendingInvites}
+          currentUserId={user.id}
+          currentUserRole={currentMember.role}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { WorkspaceSettingsForm } from "@/components/workspace-settings-form";
@@ -30,7 +31,15 @@ export default async function WorkspaceSettingsPage({
 
   return (
     <div className="mx-auto max-w-xl p-6">
-      <h1 className="text-2xl font-semibold">Workspace settings</h1>
+      <div className="flex items-center gap-4">
+        <h1 className="text-2xl font-semibold">Workspace settings</h1>
+        <Link
+          href={`/${workspaceSlug}/settings/members`}
+          className="text-sm text-accent underline-offset-4 hover:underline"
+        >
+          Members
+        </Link>
+      </div>
       <p className="mt-1 text-sm text-muted-foreground">
         Manage your workspace name, URL, and other settings.
       </p>

--- a/src/app/(auth)/invite/[token]/page.tsx
+++ b/src/app/(auth)/invite/[token]/page.tsx
@@ -16,12 +16,13 @@ export default async function InviteAcceptPage({
   const { token } = await params;
   const supabase = await createClient();
 
-  // Look up the invite by token
-  const { data: invite } = await supabase
-    .from("workspace_invites")
-    .select("*, workspaces(name, slug)")
-    .eq("token", token)
-    .maybeSingle();
+  // Look up the invite by token via security definer function.
+  // Works for both anon and authenticated users.
+  const { data: invites } = await supabase.rpc("get_invite_by_token", {
+    invite_token: token,
+  });
+
+  const invite = invites?.[0] ?? null;
 
   if (!invite) {
     return (
@@ -39,8 +40,6 @@ export default async function InviteAcceptPage({
   }
 
   if (invite.accepted_at) {
-    // Supabase join returns the relation as an opaque type; cast is unavoidable
-    const ws = invite.workspaces as unknown as { name: string; slug: string };
     return (
       <Card>
         <CardHeader>
@@ -48,7 +47,7 @@ export default async function InviteAcceptPage({
             Already accepted
           </CardTitle>
           <CardDescription>
-            This invite to {ws?.name} has already been accepted.
+            This invite to {invite.workspace_name} has already been accepted.
           </CardDescription>
         </CardHeader>
       </Card>
@@ -70,9 +69,6 @@ export default async function InviteAcceptPage({
     );
   }
 
-  // Supabase join returns the relation as an opaque type; cast is unavoidable
-  const ws = invite.workspaces as unknown as { name: string; slug: string };
-
   // Check if the current user is authenticated
   const {
     data: { user },
@@ -82,7 +78,7 @@ export default async function InviteAcceptPage({
     <Card>
       <CardHeader>
         <CardTitle className="text-2xl font-semibold">
-          Join {ws?.name}
+          Join {invite.workspace_name}
         </CardTitle>
         <CardDescription>
           You&apos;ve been invited to join as {invite.role === "admin" ? "an" : "a"}{" "}
@@ -91,12 +87,9 @@ export default async function InviteAcceptPage({
       </CardHeader>
       <CardContent>
         <InviteAccept
-          token={token}
           inviteId={invite.id}
-          workspaceId={invite.workspace_id}
-          workspaceSlug={ws?.slug ?? ""}
+          workspaceSlug={invite.workspace_slug ?? ""}
           email={invite.email}
-          role={invite.role}
           isAuthenticated={!!user}
           userEmail={user?.email ?? null}
         />

--- a/src/app/(auth)/invite/[token]/page.tsx
+++ b/src/app/(auth)/invite/[token]/page.tsx
@@ -1,0 +1,106 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { InviteAccept } from "@/components/members/invite-accept";
+
+export default async function InviteAcceptPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const supabase = await createClient();
+
+  // Look up the invite by token
+  const { data: invite } = await supabase
+    .from("workspace_invites")
+    .select("*, workspaces(name, slug)")
+    .eq("token", token)
+    .maybeSingle();
+
+  if (!invite) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold">
+            Invalid invite
+          </CardTitle>
+          <CardDescription>
+            This invite link is invalid or has been revoked.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (invite.accepted_at) {
+    // Supabase join returns the relation as an opaque type; cast is unavoidable
+    const ws = invite.workspaces as unknown as { name: string; slug: string };
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold">
+            Already accepted
+          </CardTitle>
+          <CardDescription>
+            This invite to {ws?.name} has already been accepted.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (new Date(invite.expires_at) < new Date()) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl font-semibold">
+            Invite expired
+          </CardTitle>
+          <CardDescription>
+            This invite has expired. Ask the workspace admin to send a new one.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  // Supabase join returns the relation as an opaque type; cast is unavoidable
+  const ws = invite.workspaces as unknown as { name: string; slug: string };
+
+  // Check if the current user is authenticated
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-2xl font-semibold">
+          Join {ws?.name}
+        </CardTitle>
+        <CardDescription>
+          You&apos;ve been invited to join as {invite.role === "admin" ? "an" : "a"}{" "}
+          <span className="font-medium text-foreground">{invite.role}</span>.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <InviteAccept
+          token={token}
+          inviteId={invite.id}
+          workspaceId={invite.workspace_id}
+          workspaceSlug={ws?.slug ?? ""}
+          email={invite.email}
+          role={invite.role}
+          isAuthenticated={!!user}
+          userEmail={user?.email ?? null}
+        />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/members/invite-accept.tsx
+++ b/src/components/members/invite-accept.tsx
@@ -5,25 +5,19 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
-import type { InviteRole } from "@/lib/types";
 
 interface InviteAcceptProps {
-  token: string;
   inviteId: string;
-  workspaceId: string;
   workspaceSlug: string;
   email: string;
-  role: InviteRole;
   isAuthenticated: boolean;
   userEmail: string | null;
 }
 
 export function InviteAccept({
   inviteId,
-  workspaceId,
   workspaceSlug,
   email,
-  role,
   isAuthenticated,
   userEmail,
 }: InviteAcceptProps) {
@@ -76,50 +70,21 @@ export function InviteAccept({
 
     const supabase = createClient();
 
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      setError("You must be signed in to accept this invite.");
-      setAccepting(false);
-      return;
-    }
-
-    // Insert the member row
-    const { error: memberError } = await supabase.from("members").insert({
-      workspace_id: workspaceId,
-      user_id: user.id,
-      role,
-      joined_at: new Date().toISOString(),
+    // Use the security definer RPC which atomically marks the invite as
+    // accepted and inserts the member with the correct role from the invite.
+    const { error: acceptError } = await supabase.rpc("accept_invite", {
+      invite_id: inviteId,
     });
 
-    if (memberError) {
-      // If already a member, treat as success
-      if (memberError.message.includes("duplicate key")) {
-        // Mark invite as accepted anyway
-        await supabase
-          .from("workspace_invites")
-          .update({ accepted_at: new Date().toISOString() })
-          .eq("id", inviteId);
-
+    if (acceptError) {
+      // Duplicate key means already a member — treat as success
+      if (acceptError.message.includes("duplicate key")) {
         router.push(`/${workspaceSlug}`);
         return;
       }
-      setError(memberError.message);
+      setError(acceptError.message);
       setAccepting(false);
       return;
-    }
-
-    // Mark the invite as accepted
-    const { error: acceptError } = await supabase
-      .from("workspace_invites")
-      .update({ accepted_at: new Date().toISOString() })
-      .eq("id", inviteId);
-
-    if (acceptError) {
-      // Member was already created, so redirect anyway
-      console.error("Failed to mark invite as accepted:", acceptError.message);
     }
 
     router.push(`/${workspaceSlug}`);

--- a/src/components/members/invite-accept.tsx
+++ b/src/components/members/invite-accept.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import type { InviteRole } from "@/lib/types";
+
+interface InviteAcceptProps {
+  token: string;
+  inviteId: string;
+  workspaceId: string;
+  workspaceSlug: string;
+  email: string;
+  role: InviteRole;
+  isAuthenticated: boolean;
+  userEmail: string | null;
+}
+
+export function InviteAccept({
+  inviteId,
+  workspaceId,
+  workspaceSlug,
+  email,
+  role,
+  isAuthenticated,
+  userEmail,
+}: InviteAcceptProps) {
+  const router = useRouter();
+  const [accepting, setAccepting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Not authenticated — prompt to sign in or sign up
+  if (!isAuthenticated) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          Sign in or create an account with{" "}
+          <span className="font-medium text-foreground">{email}</span> to
+          accept this invite.
+        </p>
+        <div className="flex gap-2">
+          <Button render={<Link href="/sign-in" />}>Sign in</Button>
+          <Button variant="outline" render={<Link href="/sign-up" />}>
+            Sign up
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Authenticated but with a different email
+  const emailMismatch =
+    userEmail && userEmail.toLowerCase() !== email.toLowerCase();
+
+  if (emailMismatch) {
+    return (
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          This invite was sent to{" "}
+          <span className="font-medium text-foreground">{email}</span>, but
+          you&apos;re signed in as{" "}
+          <span className="font-medium text-foreground">{userEmail}</span>.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Sign in with the invited email to accept.
+        </p>
+      </div>
+    );
+  }
+
+  async function handleAccept() {
+    setAccepting(true);
+    setError(null);
+
+    const supabase = createClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      setError("You must be signed in to accept this invite.");
+      setAccepting(false);
+      return;
+    }
+
+    // Insert the member row
+    const { error: memberError } = await supabase.from("members").insert({
+      workspace_id: workspaceId,
+      user_id: user.id,
+      role,
+      joined_at: new Date().toISOString(),
+    });
+
+    if (memberError) {
+      // If already a member, treat as success
+      if (memberError.message.includes("duplicate key")) {
+        // Mark invite as accepted anyway
+        await supabase
+          .from("workspace_invites")
+          .update({ accepted_at: new Date().toISOString() })
+          .eq("id", inviteId);
+
+        router.push(`/${workspaceSlug}`);
+        return;
+      }
+      setError(memberError.message);
+      setAccepting(false);
+      return;
+    }
+
+    // Mark the invite as accepted
+    const { error: acceptError } = await supabase
+      .from("workspace_invites")
+      .update({ accepted_at: new Date().toISOString() })
+      .eq("id", inviteId);
+
+    if (acceptError) {
+      // Member was already created, so redirect anyway
+      console.error("Failed to mark invite as accepted:", acceptError.message);
+    }
+
+    router.push(`/${workspaceSlug}`);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm text-muted-foreground">
+        You&apos;re signed in as{" "}
+        <span className="font-medium text-foreground">{userEmail}</span>.
+      </p>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+      <Button onClick={handleAccept} disabled={accepting}>
+        {accepting ? "Joining…" : "Accept invite"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/members/invite-form.tsx
+++ b/src/components/members/invite-form.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { Send } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { InviteRole } from "@/lib/types";
+
+interface InviteFormProps {
+  workspaceId: string;
+  currentUserId: string;
+  onInviteSent: () => void;
+  onError: (error: string) => void;
+}
+
+const INVITE_EXPIRY_DAYS = 7;
+
+export function InviteForm({
+  workspaceId,
+  currentUserId,
+  onInviteSent,
+  onError,
+}: InviteFormProps) {
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState<InviteRole>("member");
+  const [sending, setSending] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSuccess(false);
+    onError("");
+
+    const trimmedEmail = email.trim().toLowerCase();
+    if (!trimmedEmail) return;
+
+    setSending(true);
+
+    const supabase = createClient();
+
+    // Check if user is already a member
+    const { data: existingMember } = await supabase
+      .from("members")
+      .select("id, profiles(email)")
+      .eq("workspace_id", workspaceId);
+
+    const alreadyMember = existingMember?.some((m) => {
+      const profile = m.profiles as unknown as { email: string } | null;
+      return profile?.email?.toLowerCase() === trimmedEmail;
+    });
+
+    if (alreadyMember) {
+      onError("This user is already a member of this workspace.");
+      setSending(false);
+      return;
+    }
+
+    // Check for existing pending invite
+    const { data: existingInvite } = await supabase
+      .from("workspace_invites")
+      .select("id")
+      .eq("workspace_id", workspaceId)
+      .ilike("email", trimmedEmail)
+      .is("accepted_at", null)
+      .maybeSingle();
+
+    if (existingInvite) {
+      onError("An invite has already been sent to this email.");
+      setSending(false);
+      return;
+    }
+
+    // Generate token and expiry
+    const token = crypto.randomUUID();
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + INVITE_EXPIRY_DAYS);
+
+    const { error: insertError } = await supabase
+      .from("workspace_invites")
+      .insert({
+        workspace_id: workspaceId,
+        email: trimmedEmail,
+        role,
+        invited_by: currentUserId,
+        token,
+        expires_at: expiresAt.toISOString(),
+      });
+
+    if (insertError) {
+      onError(insertError.message);
+      setSending(false);
+      return;
+    }
+
+    setSending(false);
+    setSuccess(true);
+    setEmail("");
+    setRole("member");
+    onInviteSent();
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs tracking-widest uppercase text-white/30">
+        Invite
+      </p>
+      <form onSubmit={handleSubmit} className="flex items-end gap-2">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <Label htmlFor="invite-email">Email</Label>
+          <Input
+            id="invite-email"
+            type="email"
+            placeholder="colleague@example.com"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+              setSuccess(false);
+            }}
+            required
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="invite-role">Role</Label>
+          <Select
+            value={role}
+            onValueChange={(val) => setRole(val as InviteRole)}
+          >
+            <SelectTrigger size="sm" className="w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="admin">admin</SelectItem>
+              <SelectItem value="member">member</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <Button type="submit" size="sm" disabled={sending}>
+          <Send className="h-4 w-4" />
+          {sending ? "Sending…" : "Invite"}
+        </Button>
+      </form>
+      {success && (
+        <p className="text-xs text-accent">Invite sent.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/members/member-list.tsx
+++ b/src/components/members/member-list.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { RoleSelect } from "@/components/members/role-select";
+import type { MemberRole, MemberWithProfile } from "@/lib/types";
+
+interface MemberListProps {
+  members: MemberWithProfile[];
+  currentUserId: string;
+  currentUserRole: MemberRole;
+  isPersonalWorkspace: boolean;
+  onRoleChange: (memberId: string, newRole: MemberRole) => Promise<void>;
+  onRemove: (memberId: string) => Promise<void>;
+}
+
+function roleBadgeVariant(role: MemberRole) {
+  switch (role) {
+    case "owner":
+      return "default" as const;
+    case "admin":
+      return "secondary" as const;
+    case "member":
+      return "outline" as const;
+  }
+}
+
+export function MemberList({
+  members,
+  currentUserId,
+  currentUserRole,
+  isPersonalWorkspace,
+  onRoleChange,
+  onRemove,
+}: MemberListProps) {
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const isAdmin = currentUserRole === "owner" || currentUserRole === "admin";
+
+  async function handleRemove(memberId: string) {
+    setRemovingId(memberId);
+    await onRemove(memberId);
+    setRemovingId(null);
+  }
+
+  function canChangeRole(member: MemberWithProfile): boolean {
+    if (!isAdmin) return false;
+    // Cannot change own role
+    if (member.user_id === currentUserId) return false;
+    // Only owners can change other owners
+    if (member.role === "owner" && currentUserRole !== "owner") return false;
+    return true;
+  }
+
+  function canRemove(member: MemberWithProfile): boolean {
+    if (!isAdmin) return false;
+    // Cannot remove yourself via this action (use "leave" instead)
+    if (member.user_id === currentUserId) return false;
+    // Cannot remove the owner of a personal workspace
+    if (isPersonalWorkspace && member.role === "owner") return false;
+    // Only owners can remove other owners
+    if (member.role === "owner" && currentUserRole !== "owner") return false;
+    return true;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs tracking-widest uppercase text-white/30">
+        Members ({members.length})
+      </p>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>User</TableHead>
+            <TableHead>Role</TableHead>
+            {isAdmin && <TableHead className="w-10" />}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {members.map((member) => (
+            <TableRow key={member.id}>
+              <TableCell>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium">
+                    {member.profiles.display_name}
+                    {member.user_id === currentUserId && (
+                      <span className="ml-1 text-xs text-muted-foreground">
+                        (you)
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {member.profiles.email}
+                  </span>
+                </div>
+              </TableCell>
+              <TableCell>
+                {canChangeRole(member) ? (
+                  <RoleSelect
+                    value={member.role}
+                    onChange={(role) => onRoleChange(member.id, role)}
+                    includeOwner={currentUserRole === "owner"}
+                  />
+                ) : (
+                  <Badge variant={roleBadgeVariant(member.role)}>
+                    {member.role}
+                  </Badge>
+                )}
+              </TableCell>
+              {isAdmin && (
+                <TableCell>
+                  {canRemove(member) && (
+                    <AlertDialog>
+                      <AlertDialogTrigger
+                        render={
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            aria-label={`Remove ${member.profiles.display_name}`}
+                          />
+                        }
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Remove member</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Remove {member.profiles.display_name} from this
+                            workspace? They will lose access to all pages.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            variant="destructive"
+                            onClick={() => handleRemove(member.id)}
+                            disabled={removingId === member.id}
+                          >
+                            {removingId === member.id
+                              ? "Removing…"
+                              : "Remove"}
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  )}
+                </TableCell>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/members/members-page.tsx
+++ b/src/components/members/members-page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { Separator } from "@/components/ui/separator";
+import { MemberList } from "@/components/members/member-list";
+import { InviteForm } from "@/components/members/invite-form";
+import { PendingInviteList } from "@/components/members/pending-invite-list";
+import type {
+  Workspace,
+  MemberRole,
+  MemberWithProfile,
+  WorkspaceInviteWithInviter,
+} from "@/lib/types";
+
+interface MembersPageProps {
+  workspace: Workspace;
+  members: MemberWithProfile[];
+  pendingInvites: WorkspaceInviteWithInviter[];
+  currentUserId: string;
+  currentUserRole: MemberRole;
+}
+
+export function MembersPage({
+  workspace,
+  members: initialMembers,
+  pendingInvites: initialInvites,
+  currentUserId,
+  currentUserRole,
+}: MembersPageProps) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const isAdmin = currentUserRole === "owner" || currentUserRole === "admin";
+
+  async function handleRoleChange(memberId: string, newRole: MemberRole) {
+    setError(null);
+    const supabase = createClient();
+
+    const { error: updateError } = await supabase
+      .from("members")
+      .update({ role: newRole })
+      .eq("id", memberId);
+
+    if (updateError) {
+      setError(updateError.message);
+      return;
+    }
+
+    router.refresh();
+  }
+
+  async function handleRemoveMember(memberId: string) {
+    setError(null);
+    const supabase = createClient();
+
+    const { error: deleteError } = await supabase
+      .from("members")
+      .delete()
+      .eq("id", memberId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+
+    router.refresh();
+  }
+
+  async function handleRevokeInvite(inviteId: string) {
+    setError(null);
+    const supabase = createClient();
+
+    const { error: deleteError } = await supabase
+      .from("workspace_invites")
+      .delete()
+      .eq("id", inviteId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col gap-8">
+      {isAdmin && (
+        <>
+          <InviteForm
+            workspaceId={workspace.id}
+            currentUserId={currentUserId}
+            onInviteSent={() => router.refresh()}
+            onError={setError}
+          />
+          <Separator className="bg-white/[0.06]" />
+        </>
+      )}
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      <MemberList
+        members={initialMembers}
+        currentUserId={currentUserId}
+        currentUserRole={currentUserRole}
+        isPersonalWorkspace={workspace.is_personal}
+        onRoleChange={handleRoleChange}
+        onRemove={handleRemoveMember}
+      />
+
+      {isAdmin && initialInvites.length > 0 && (
+        <>
+          <Separator className="bg-white/[0.06]" />
+          <PendingInviteList
+            invites={initialInvites}
+            onRevoke={handleRevokeInvite}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/members/pending-invite-list.tsx
+++ b/src/components/members/pending-invite-list.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { WorkspaceInviteWithInviter } from "@/lib/types";
+
+interface PendingInviteListProps {
+  invites: WorkspaceInviteWithInviter[];
+  onRevoke: (inviteId: string) => Promise<void>;
+}
+
+export function PendingInviteList({
+  invites,
+  onRevoke,
+}: PendingInviteListProps) {
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  async function handleRevoke(inviteId: string) {
+    setRevokingId(inviteId);
+    await onRevoke(inviteId);
+    setRevokingId(null);
+  }
+
+  function isExpired(expiresAt: string): boolean {
+    return new Date(expiresAt) < new Date();
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs tracking-widest uppercase text-white/30">
+        Pending invites ({invites.length})
+      </p>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Email</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="w-10" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {invites.map((invite) => (
+            <TableRow key={invite.id}>
+              <TableCell>
+                <span className="text-sm">{invite.email}</span>
+              </TableCell>
+              <TableCell>
+                <Badge variant="outline">{invite.role}</Badge>
+              </TableCell>
+              <TableCell>
+                {isExpired(invite.expires_at) ? (
+                  <span className="text-xs text-destructive">Expired</span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    Expires{" "}
+                    {new Date(invite.expires_at).toLocaleDateString()}
+                  </span>
+                )}
+              </TableCell>
+              <TableCell>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={() => handleRevoke(invite.id)}
+                  disabled={revokingId === invite.id}
+                  aria-label={`Revoke invite for ${invite.email}`}
+                >
+                  <X className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/members/role-select.tsx
+++ b/src/components/members/role-select.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { MemberRole } from "@/lib/types";
+
+interface RoleSelectProps {
+  value: MemberRole;
+  onChange: (role: MemberRole) => void;
+  includeOwner?: boolean;
+}
+
+export function RoleSelect({
+  value,
+  onChange,
+  includeOwner = false,
+}: RoleSelectProps) {
+  return (
+    <Select
+      value={value}
+      onValueChange={(val) => onChange(val as MemberRole)}
+    >
+      <SelectTrigger size="sm" className="w-28">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {includeOwner && <SelectItem value="owner">owner</SelectItem>}
+        <SelectItem value="admin">admin</SelectItem>
+        <SelectItem value="member">member</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams, useRouter } from "next/navigation";
-import { LogOut, Settings, User } from "lucide-react";
+import { LogOut, Settings, User, Users } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import {
@@ -33,6 +33,12 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
     }
   }
 
+  function handleMembers() {
+    if (params.workspaceSlug) {
+      router.push(`/${params.workspaceSlug}/settings/members`);
+    }
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -56,6 +62,10 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
         <DropdownMenuItem onClick={handleSettings}>
           <Settings className="h-4 w-4" />
           Settings
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleMembers}>
+          <Users className="h-4 w-4" />
+          Members
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={handleSignOut}>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,6 +44,15 @@ export interface WorkspaceInvite {
   created_at: string;
 }
 
+// Joined types for member queries
+export interface MemberWithProfile extends Member {
+  profiles: Pick<Profile, "email" | "display_name" | "avatar_url">;
+}
+
+export interface WorkspaceInviteWithInviter extends WorkspaceInvite {
+  profiles: Pick<Profile, "display_name">;
+}
+
 export interface Page {
   id: string;
   workspace_id: string;

--- a/supabase/migrations/20260415110850_workspace_members_invite_accept.sql
+++ b/supabase/migrations/20260415110850_workspace_members_invite_accept.sql
@@ -1,0 +1,39 @@
+-- Additional RLS policies for the workspace members invite/accept flow.
+-- The base tables and core policies exist in 20260415092907_create_schema.sql.
+
+-- Allow any authenticated user to read an invite by its token.
+-- Needed for the /invite/[token] accept page where the user
+-- may not be the admin but is the invitee.
+create policy "authenticated users can read invite by token"
+  on workspace_invites for select
+  to authenticated
+  using (true);
+
+-- Allow invited users to mark their own invite as accepted.
+-- Matches on email (case-insensitive) and only allows updating unaccepted invites.
+create policy "invited users can accept their invite"
+  on workspace_invites for update
+  to authenticated
+  using (lower(email) = lower(auth.jwt() ->> 'email') and accepted_at is null)
+  with check (lower(email) = lower(auth.jwt() ->> 'email'));
+
+-- Allow users to insert themselves as a member when accepting an invite.
+-- Verifies a valid, unexpired, unaccepted invite exists for their email.
+create policy "invited users can join via invite"
+  on members for insert
+  to authenticated
+  with check (
+    user_id = auth.uid()
+    and exists (
+      select 1 from workspace_invites
+      where workspace_invites.workspace_id = members.workspace_id
+        and lower(workspace_invites.email) = lower(auth.jwt() ->> 'email')
+        and workspace_invites.accepted_at is null
+        and workspace_invites.expires_at > now()
+    )
+  );
+
+-- Allow members to remove themselves from a workspace (leave).
+create policy "members can remove themselves"
+  on members for delete
+  using (user_id = auth.uid());

--- a/supabase/migrations/20260415110850_workspace_members_invite_accept.sql
+++ b/supabase/migrations/20260415110850_workspace_members_invite_accept.sql
@@ -1,37 +1,81 @@
--- Additional RLS policies for the workspace members invite/accept flow.
+-- Additional RLS policies and functions for the workspace members invite/accept flow.
 -- The base tables and core policies exist in 20260415092907_create_schema.sql.
 
--- Allow any authenticated user to read an invite by its token.
--- Needed for the /invite/[token] accept page where the user
--- may not be the admin but is the invitee.
-create policy "authenticated users can read invite by token"
-  on workspace_invites for select
-  to authenticated
-  using (true);
+-- Lookup an invite by token. Uses security definer to bypass RLS so both
+-- anon (unauthenticated) and authenticated users can view the invite page.
+-- Tokens are unguessable UUIDs, so exposing a single row by exact match is safe.
+create or replace function get_invite_by_token(invite_token text)
+returns table (
+  id uuid,
+  workspace_id uuid,
+  email text,
+  role invite_role,
+  invited_by uuid,
+  token text,
+  expires_at timestamptz,
+  accepted_at timestamptz,
+  created_at timestamptz,
+  workspace_name text,
+  workspace_slug text
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    wi.id,
+    wi.workspace_id,
+    wi.email,
+    wi.role,
+    wi.invited_by,
+    wi.token,
+    wi.expires_at,
+    wi.accepted_at,
+    wi.created_at,
+    w.name as workspace_name,
+    w.slug as workspace_slug
+  from public.workspace_invites wi
+  join public.workspaces w on w.id = wi.workspace_id
+  where wi.token = invite_token;
+$$;
 
--- Allow invited users to mark their own invite as accepted.
--- Matches on email (case-insensitive) and only allows updating unaccepted invites.
-create policy "invited users can accept their invite"
-  on workspace_invites for update
-  to authenticated
-  using (lower(email) = lower(auth.jwt() ->> 'email') and accepted_at is null)
-  with check (lower(email) = lower(auth.jwt() ->> 'email'));
+-- Accept an invite: marks the invite as accepted and inserts the member row.
+-- Uses security definer to enforce that only accepted_at is set on the invite
+-- and the member role matches the invite role (preventing escalation).
+create or replace function accept_invite(invite_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_invite record;
+begin
+  -- Lock and validate the invite
+  select * into v_invite
+  from public.workspace_invites
+  where id = invite_id
+    and lower(email) = lower(auth.jwt() ->> 'email')
+    and accepted_at is null
+    and expires_at > now()
+  for update;
 
--- Allow users to insert themselves as a member when accepting an invite.
--- Verifies a valid, unexpired, unaccepted invite exists for their email.
-create policy "invited users can join via invite"
-  on members for insert
-  to authenticated
-  with check (
-    user_id = auth.uid()
-    and exists (
-      select 1 from workspace_invites
-      where workspace_invites.workspace_id = members.workspace_id
-        and lower(workspace_invites.email) = lower(auth.jwt() ->> 'email')
-        and workspace_invites.accepted_at is null
-        and workspace_invites.expires_at > now()
-    )
-  );
+  if not found then
+    raise exception 'Invalid, expired, or already accepted invite';
+  end if;
+
+  -- Mark invite as accepted
+  update public.workspace_invites
+  set accepted_at = now()
+  where id = invite_id;
+
+  -- Insert member with the role from the invite (prevents role escalation)
+  insert into public.members (workspace_id, user_id, role, joined_at)
+  values (v_invite.workspace_id, auth.uid(), v_invite.role::text::public.member_role, now())
+  on conflict (workspace_id, user_id) do nothing;
+end;
+$$;
 
 -- Allow members to remove themselves from a workspace (leave).
 create policy "members can remove themselves"


### PR DESCRIPTION
Closes #32

## What

Workspace member management: invite users by email, manage roles, remove members, and accept invites via token-based links.

## How

**Database**: Migration adds RLS policies for invite token lookup, invite acceptance (self-join via valid invite), and self-removal from workspace. The `workspace_invites` and `members` tables already existed in the base schema.

**Pages**:
- `/(app)/[workspaceSlug]/settings/members` — server page fetching members, current user role, and pending invites. Renders the `MembersPage` client orchestrator.
- `/(auth)/invite/[token]` — server page with invite validation (invalid, expired, already accepted). Renders `InviteAccept` client component.

**Components** (`src/components/members/`):
- `members-page.tsx` — client orchestrator wiring role change, member removal, and invite revocation
- `member-list.tsx` — table with role badges, inline role select (admin/owner only), remove with confirmation dialog
- `invite-form.tsx` — email + role form, validates against existing members and pending invites
- `invite-accept.tsx` — handles unauthenticated (sign in/up prompt), email mismatch, and accept flow
- `pending-invite-list.tsx` — table of pending invites with expiry status and revoke action
- `role-select.tsx` — role picker dropdown

**Navigation**: Added "Members" link to sidebar user menu dropdown and workspace settings page header.

**shadcn/ui**: Added Badge, Select, Table components.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (22 tests passing)
- No unit tests added for these components — they are primarily UI wiring with Supabase mutations, which would require integration tests with a running Supabase instance.