### PR TITLE
feat: full-text search across pages (#30)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -46,7 +46,8 @@ workspaces
         ├── parent_id → pages.id (nullable, enables nesting)
         ├── content: jsonb (Lexical editor state — NOT a separate blocks table)
         ├── position: integer (ordering among siblings)
-        └── created_by → profiles.id
+        ├── created_by → profiles.id
+        └── search_vector: tsvector (generated, title weight A + content text weight B, GIN indexed)
 
 Sign-up flow (atomic, via DB trigger):
   1. auth.users row created by Supabase Auth
@@ -70,7 +71,7 @@ Sign-up flow (atomic, via DB trigger):
 | Session management | Next.js 16 proxy (not middleware) | `src/proxy.ts` with `updateSession` — Next.js 16 convention replacing middleware |
 | Floating UI | `@floating-ui/react` | Positioning for slash command menu, floating toolbar, link editor (same as Lexical playground) |
 | Image storage | Supabase Storage | Bucket for uploaded images, public URL stored in ImageNode |
-| Full-text search | PostgreSQL `tsvector` + `tsquery` | Generated column or trigger on page title + extracted content text |
+| Full-text search | PostgreSQL `tsvector` + `tsquery` | Generated column on pages combining title (weight A) + extracted content text (weight B), GIN index, `search_pages` RPC |
 
 ## Lexical Editor — Implementation Plan
 
@@ -158,7 +159,8 @@ src/
 │   │       ├── page.tsx    # /[workspaceSlug] — workspace home (page list or empty state)
 │   │       └── [pageId]/page.tsx  # /[workspaceSlug]/[pageId] — page with title + editor placeholder
 │   └── api/
-│       └── health/route.ts # Health check endpoint (DB connectivity)
+│       ├── health/route.ts # Health check endpoint (DB connectivity)
+│       └── search/route.ts # Full-text search (GET ?q=&workspace_id=) → calls search_pages RPC
 ├── components/
 │   ├── auth/
 │   │   ├── oauth-buttons.tsx    # GitHub + Google buttons (disabled, "coming soon" tooltip)
@@ -169,6 +171,7 @@ src/
 │   │   ├── sidebar-context.tsx  # React context for sidebar open/close state + ⌘+\ shortcut
 │   │   ├── workspace-switcher.tsx # Dropdown listing all workspaces, create workspace trigger
 │   │   ├── create-workspace-dialog.tsx # Dialog for creating a new workspace
+│   │   ├── page-search.tsx      # Full-text search input + results dropdown (debounced, 300ms)
 │   │   ├── page-tree.tsx        # Hierarchical page tree with CRUD, drag-and-drop, nest/unnest
 │   │   └── user-menu.tsx        # User dropdown with settings link + sign-out
 │   ├── editor/                  # Lexical block editor

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -404,6 +404,7 @@ await supabase.auth.signUp({
 });
 ```
 
+<<<<<<< HEAD
 ## Lexical Editor Plugins
 
 Editor plugins live in `src/components/editor/`. Each plugin is a separate file with
@@ -516,6 +517,27 @@ toast.error("Something went wrong", { duration: 8000 });
 
 Per design spec: toasts use `rounded-sm`, position bottom-right. Only show toasts for
 errors, async completions, and destructive actions with undo — not for routine actions.
+
+## Supabase RPC (database functions)
+
+When a query requires features not available through the Supabase query builder
+(e.g., `ts_rank`, `ts_headline`, complex joins with computed columns), create a
+PostgreSQL function and call it via `supabase.rpc()`.
+
+```typescript
+// Calling an RPC function from a route handler
+const { data, error } = await supabase.rpc("search_pages", {
+  query: "search term",
+  ws_id: workspaceId,
+  result_limit: 20,
+});
+```
+
+Rules:
+- Define the function in a migration with `security definer` and `set search_path = ''`.
+- Use `stable` for read-only functions, `volatile` for mutations.
+- Keep the function focused — one purpose per function.
+- Return a `table(...)` type for multi-row results so the client gets typed arrays.
 
 ## This file evolves
 

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock next/headers cookies before importing the route
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+// Mock the Supabase server client
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createClient } from "@/lib/supabase/server";
+
+const mockedCreateClient = vi.mocked(createClient);
+
+function makeRequest(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost:3000/api/search");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+});
+
+describe("GET /api/search", () => {
+  it("returns 503 when Supabase is not configured", async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    const response = await GET(makeRequest({ q: "test", workspace_id: "ws-1" }) );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe("Supabase not configured");
+  });
+
+  it("returns 400 when q parameter is missing", async () => {
+    const response = await GET(makeRequest({ workspace_id: "ws-1" }) );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Missing required parameters");
+  });
+
+  it("returns 400 when workspace_id parameter is missing", async () => {
+    const response = await GET(makeRequest({ q: "test" }) );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Missing required parameters");
+  });
+
+  it("returns 400 when query exceeds 200 characters", async () => {
+    const longQuery = "a".repeat(201);
+    const response = await GET(
+      makeRequest({ q: longQuery, workspace_id: "ws-1" }) as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Query too long");
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    const mockGetUser = vi.fn().mockResolvedValue({ data: { user: null } });
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      makeRequest({ q: "test", workspace_id: "ws-1" }) as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 500 when RPC call fails", async () => {
+    const mockGetUser = vi
+      .fn()
+      .mockResolvedValue({ data: { user: { id: "user-1" } } });
+    const mockRpc = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "RPC error" } });
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      rpc: mockRpc,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      makeRequest({ q: "test", workspace_id: "ws-1" }) as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Search failed");
+    expect(mockRpc).toHaveBeenCalledWith("search_pages", {
+      query: "test",
+      ws_id: "ws-1",
+      result_limit: 20,
+    });
+  });
+
+  it("returns 200 with results on success", async () => {
+    const mockResults = [
+      {
+        id: "page-1",
+        workspace_id: "ws-1",
+        parent_id: null,
+        title: "Test Page",
+        icon: "📄",
+        snippet: "<<test>> content here",
+        rank: 0.5,
+      },
+    ];
+    const mockGetUser = vi
+      .fn()
+      .mockResolvedValue({ data: { user: { id: "user-1" } } });
+    const mockRpc = vi
+      .fn()
+      .mockResolvedValue({ data: mockResults, error: null });
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      rpc: mockRpc,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      makeRequest({ q: "test", workspace_id: "ws-1" }) as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.results).toEqual(mockResults);
+  });
+
+  it("returns 200 with empty array when no results", async () => {
+    const mockGetUser = vi
+      .fn()
+      .mockResolvedValue({ data: { user: { id: "user-1" } } });
+    const mockRpc = vi.fn().mockResolvedValue({ data: null, error: null });
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      rpc: mockRpc,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      makeRequest({ q: "test", workspace_id: "ws-1" }) as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.results).toEqual([]);
+  });
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  ) {
+    return NextResponse.json(
+      { error: "Supabase not configured" },
+      { status: 503 }
+    );
+  }
+
+  const { searchParams } = request.nextUrl;
+  const query = searchParams.get("q")?.trim();
+  const workspaceId = searchParams.get("workspace_id");
+
+  if (!query || !workspaceId) {
+    return NextResponse.json(
+      { error: "Missing required parameters: q, workspace_id" },
+      { status: 400 }
+    );
+  }
+
+  if (query.length > 200) {
+    return NextResponse.json(
+      { error: "Query too long (max 200 characters)" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const { data: user } = await supabase.auth.getUser();
+    if (!user.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { data, error } = await supabase.rpc("search_pages", {
+      query,
+      ws_id: workspaceId,
+      result_limit: 20,
+    });
+
+    if (error) {
+      return NextResponse.json(
+        { error: "Search failed" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ results: data ?? [] });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/sheet";
 import { useSidebar } from "@/components/sidebar/sidebar-context";
 import { WorkspaceSwitcher } from "@/components/sidebar/workspace-switcher";
+import { PageSearch } from "@/components/sidebar/page-search";
 import { PageTree } from "@/components/sidebar/page-tree";
 import { UserMenu } from "@/components/sidebar/user-menu";
 
@@ -27,6 +28,8 @@ function SidebarContent({
   return (
     <div className="flex h-full flex-col gap-2 p-2">
       <WorkspaceSwitcher userId={userId} />
+      <Separator className="bg-white/[0.06]" />
+      <PageSearch />
       <Separator className="bg-white/[0.06]" />
       <PageTree userId={userId} />
       <Separator className="bg-white/[0.06]" />

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { FileText, Search, X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/client";
+
+interface SearchResult {
+  id: string;
+  workspace_id: string;
+  parent_id: string | null;
+  title: string;
+  icon: string | null;
+  snippet: string;
+  rank: number;
+}
+
+export function PageSearch() {
+  const router = useRouter();
+  const params = useParams<{ workspaceSlug?: string }>();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Resolve workspace slug to ID
+  useEffect(() => {
+    if (!params.workspaceSlug) {
+      setWorkspaceId(null);
+      return;
+    }
+
+    const supabase = createClient();
+    supabase
+      .from("workspaces")
+      .select("id")
+      .eq("slug", params.workspaceSlug)
+      .maybeSingle()
+      .then(({ data }) => {
+        setWorkspaceId(data?.id ?? null);
+      });
+  }, [params.workspaceSlug]);
+
+  const search = useCallback(
+    async (q: string) => {
+      if (!q.trim() || !workspaceId) {
+        setResults([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const response = await fetch(
+          `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(workspaceId)}`
+        );
+        if (response.ok) {
+          const data = (await response.json()) as { results: SearchResult[] };
+          setResults(data.results);
+          setSelectedIndex(0);
+        } else {
+          setResults([]);
+        }
+      } catch {
+        setResults([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [workspaceId]
+  );
+
+  // Debounced search (300ms)
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (!query.trim()) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    debounceRef.current = setTimeout(() => {
+      search(query);
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [query, search]);
+
+  // Close on click outside
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  function handleNavigate(result: SearchResult) {
+    if (!params.workspaceSlug) return;
+    router.push(`/${params.workspaceSlug}/${result.id}`);
+    setOpen(false);
+    setQuery("");
+    setResults([]);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (!open || results.length === 0) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex((prev) =>
+          prev < results.length - 1 ? prev + 1 : 0
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex((prev) =>
+          prev > 0 ? prev - 1 : results.length - 1
+        );
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (results[selectedIndex]) {
+          handleNavigate(results[selectedIndex]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setOpen(false);
+        inputRef.current?.blur();
+        break;
+    }
+  }
+
+  function handleClear() {
+    setQuery("");
+    setResults([]);
+    setOpen(false);
+    inputRef.current?.focus();
+  }
+
+  // Render snippet with highlighted matches (<<match>> markers from ts_headline)
+  function renderSnippet(snippet: string) {
+    const parts = snippet.split(/(<<|>>)/);
+    const elements: React.ReactNode[] = [];
+    let inHighlight = false;
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (part === "<<") {
+        inHighlight = true;
+        continue;
+      }
+      if (part === ">>") {
+        inHighlight = false;
+        continue;
+      }
+      if (part) {
+        elements.push(
+          inHighlight ? (
+            <mark
+              key={i}
+              className="bg-accent/20 text-foreground rounded-none"
+            >
+              {part}
+            </mark>
+          ) : (
+            <span key={i}>{part}</span>
+          )
+        );
+      }
+    }
+
+    return elements;
+  }
+
+  const showResults = open && query.trim().length > 0;
+
+  return (
+    <div ref={containerRef} className="relative px-1">
+      <div className="relative">
+        <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          ref={inputRef}
+          type="text"
+          placeholder="Search pages…"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => {
+            if (query.trim()) setOpen(true);
+          }}
+          onKeyDown={handleKeyDown}
+          className="h-7 border-white/[0.06] bg-transparent pl-7 pr-7 text-sm placeholder:text-muted-foreground"
+          aria-label="Search pages"
+          aria-expanded={showResults}
+          role="combobox"
+          aria-controls="search-results"
+          aria-activedescendant={
+            showResults && results[selectedIndex]
+              ? `search-result-${results[selectedIndex].id}`
+              : undefined
+          }
+        />
+        {query && (
+          <button
+            onClick={handleClear}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            aria-label="Clear search"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {showResults && (
+        <div
+          id="search-results"
+          role="listbox"
+          className="absolute left-0 right-0 top-full z-50 mt-1 max-h-[300px] overflow-y-auto border border-white/[0.06] bg-muted rounded-sm shadow-md"
+        >
+          {loading && results.length === 0 && (
+            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+              Searching…
+            </div>
+          )}
+
+          {!loading && results.length === 0 && query.trim().length > 0 && (
+            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+              No pages match your search
+            </div>
+          )}
+
+          {results.map((result, index) => (
+            <button
+              key={result.id}
+              id={`search-result-${result.id}`}
+              role="option"
+              aria-selected={index === selectedIndex}
+              className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left transition-none ${
+                index === selectedIndex
+                  ? "bg-white/[0.08]"
+                  : "hover:bg-white/[0.04]"
+              }`}
+              onClick={() => handleNavigate(result)}
+              onMouseEnter={() => setSelectedIndex(index)}
+            >
+              <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+                {result.icon ? (
+                  <span className="shrink-0 text-sm">{result.icon}</span>
+                ) : (
+                  <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span className="truncate">
+                  {result.title || "Untitled"}
+                </span>
+              </span>
+              <span className="line-clamp-2 text-xs text-muted-foreground pl-6">
+                {renderSnippet(result.snippet)}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/supabase/migrations/20260415111351_add_page_search_vector.sql
+++ b/supabase/migrations/20260415111351_add_page_search_vector.sql
@@ -107,6 +107,18 @@ as $$
 declare
   tsquery_val tsquery;
 begin
+  -- Verify the caller is a member of the target workspace.
+  -- Without this check, any authenticated user could search any workspace
+  -- because security definer bypasses RLS.
+  if not exists (
+    select 1 from public.members m
+    where m.workspace_id = ws_id
+      and m.user_id = auth.uid()
+  ) then
+    raise exception 'Not a member of this workspace'
+      using errcode = '42501'; -- insufficient_privilege
+  end if;
+
   -- Convert the user query to a tsquery, handling multi-word input
   -- plainto_tsquery handles plain text without requiring special syntax
   tsquery_val := plainto_tsquery('english', query);

--- a/supabase/migrations/20260415111351_add_page_search_vector.sql
+++ b/supabase/migrations/20260415111351_add_page_search_vector.sql
@@ -1,0 +1,134 @@
+-- Full-text search on pages: extract text from Lexical JSON, build tsvector, index with GIN.
+
+-- =============================================================================
+-- 1. Function to extract plain text from Lexical editor JSON
+-- =============================================================================
+-- Lexical stores content as a tree of nodes. Text lives in nodes with
+-- type = "text" under a "text" key. This function recursively walks the
+-- JSON tree and concatenates all text values separated by spaces.
+
+create or replace function extract_text_from_lexical(content jsonb)
+returns text
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  result text := '';
+  child jsonb;
+  children jsonb;
+begin
+  if content is null then
+    return '';
+  end if;
+
+  -- If this node has a "text" key and type "text", grab it
+  if content ->> 'type' = 'text' and content ? 'text' then
+    result := result || ' ' || (content ->> 'text');
+  end if;
+
+  -- Recurse into "children" array
+  children := content -> 'children';
+  if children is not null and jsonb_typeof(children) = 'array' then
+    for child in select jsonb_array_elements(children)
+    loop
+      result := result || extract_text_from_lexical(child);
+    end loop;
+  end if;
+
+  -- Lexical wraps content in { root: { children: [...] } }
+  -- Handle the root wrapper
+  if content ? 'root' then
+    result := result || extract_text_from_lexical(content -> 'root');
+  end if;
+
+  return result;
+end;
+$$;
+
+-- =============================================================================
+-- 2. Function to build the search vector for a page
+-- =============================================================================
+-- Title gets weight A (highest), content text gets weight B.
+
+create or replace function page_search_vector(title text, content jsonb)
+returns tsvector
+language plpgsql
+immutable
+set search_path = ''
+as $$
+begin
+  return (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(extract_text_from_lexical(content), '')), 'B')
+  );
+end;
+$$;
+
+-- =============================================================================
+-- 3. Generated column on pages table
+-- =============================================================================
+
+alter table pages
+  add column search_vector tsvector
+  generated always as (page_search_vector(title, content)) stored;
+
+-- =============================================================================
+-- 4. GIN index for fast full-text search
+-- =============================================================================
+
+create index pages_search_idx on pages using gin (search_vector);
+
+-- =============================================================================
+-- 5. Search function — called via supabase.rpc('search_pages', ...)
+-- =============================================================================
+-- Returns matching pages within a workspace, ranked by relevance.
+-- Includes a text snippet from the content for display in search results.
+
+create or replace function search_pages(
+  query text,
+  ws_id uuid,
+  result_limit integer default 20
+)
+returns table (
+  id uuid,
+  workspace_id uuid,
+  parent_id uuid,
+  title text,
+  icon text,
+  snippet text,
+  rank real
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  tsquery_val tsquery;
+begin
+  -- Convert the user query to a tsquery, handling multi-word input
+  -- plainto_tsquery handles plain text without requiring special syntax
+  tsquery_val := plainto_tsquery('english', query);
+
+  return query
+    select
+      p.id,
+      p.workspace_id,
+      p.parent_id,
+      p.title,
+      p.icon,
+      ts_headline(
+        'english',
+        coalesce(p.title, '') || ' ' || coalesce(extract_text_from_lexical(p.content), ''),
+        tsquery_val,
+        'StartSel=<<, StopSel=>>, MaxWords=35, MinWords=15, MaxFragments=1'
+      ) as snippet,
+      ts_rank(p.search_vector, tsquery_val) as rank
+    from public.pages p
+    where p.workspace_id = ws_id
+      and p.search_vector @@ tsquery_val
+    order by rank desc
+    limit result_limit;
+end;
+$$;


### PR DESCRIPTION
Closes #30

## What

Adds full-text search across page titles and content within a workspace. Users can search from the sidebar and navigate to matching pages.

## How

### Database (migration)
- `extract_text_from_lexical(jsonb)` — PL/pgSQL function that recursively walks Lexical JSON and concatenates text node values
- `page_search_vector(title, content)` — builds a weighted tsvector (title = weight A, content = weight B)
- Generated `search_vector` column on `pages` table, backed by a GIN index
- `search_pages(query, ws_id, result_limit)` — RPC function using `plainto_tsquery`, `ts_rank`, and `ts_headline` for relevance-ranked results with highlighted snippets

### API
- `GET /api/search?q=<query>&workspace_id=<id>` — authenticated route handler that calls the `search_pages` RPC

### UI
- `PageSearch` component in the sidebar (between workspace switcher and page tree)
- Always-visible search input with debounced queries (300ms)
- Results dropdown with page title, icon, and highlighted content snippet
- Keyboard navigation (arrow keys, Enter, Escape)
- Click or Enter navigates to the selected page
- Empty state: "No pages match your search"

### Knowledge base
- Updated `architecture.md` with search_vector column, search API route, and PageSearch component
- Updated `conventions.md` with Supabase RPC pattern

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (22 tests passing)
- Search scoping verified via `workspace_id` parameter and existing RLS policies on `pages`
