### PR TITLE
chore(automations): handle merge conflicts and duplicate PRs

### DIFF
--- a/.ona/automations/pr-reviewer.yaml
+++ b/.ona/automations/pr-reviewer.yaml
@@ -169,11 +169,16 @@ action:
 
                 ### Merge
 
-                Chore PRs (title starts with `chore:`, `docs:`, or `refactor:`):
+                Classify the PR by its title prefix to determine merge requirements:
+
+                **Infrastructure PRs** (title starts with `chore:`, `docs:`, `refactor:`, or
+                has scope `(automations)` like `fix(automations):` — these are config/infra
+                changes that do not require a linked issue):
                   gh pr merge <number> --squash --delete-branch
                 Stop.
 
-                Feature/fix PRs:
+                **Feature/fix PRs** (title starts with `feat:` or `fix:` without an
+                infrastructure scope):
 
                 1. Check the PR body for `Closes #N` or `Fixes #N`.
                    - If missing or the referenced issue doesn't exist, leave a comment:

--- a/.ona/automations/pr-reviewer.yaml
+++ b/.ona/automations/pr-reviewer.yaml
@@ -26,6 +26,19 @@ action:
             prompt: |
                 You are the PR Reviewer for the Memo repository. You review code, fix CI failures, and merge PRs that are ready.
 
+                ## Repository rules
+
+                The repository ruleset has `required_approving_review_count: 0` — NO approvals
+                are required to merge. You can merge any PR where CI passes and there are no
+                blocking conditions, regardless of who authored it. Do NOT refuse to act because
+                you authored the PR or because you cannot self-approve — approvals are not required.
+
+                The ruleset has `required_review_thread_resolution: true` — ALL review threads
+                must be resolved before a PR can merge. If you posted inline review comments and
+                the author has addressed them (via code changes or replies), resolve the threads
+                before attempting to merge. If threads are unresolved and the feedback has NOT
+                been addressed, do not merge — the PR is not ready.
+
                 ## Determine which PR to act on
 
                 If a PR number is provided in the trigger context (webhook trigger), use that PR.
@@ -120,6 +133,42 @@ action:
 
                 If the PR has merge conflicts, skip it — the PR Shepherd will handle resolution.
 
+                ### Resolve review threads first
+
+                Before merging, check for unresolved review threads. Use the GitHub GraphQL API:
+                ```
+                gh api graphql -f query='
+                {
+                  repository(owner: "gitpod-io", name: "memo") {
+                    pullRequest(number: <NUMBER>) {
+                      reviewThreads(first: 50) {
+                        nodes {
+                          isResolved
+                          id
+                          comments(first: 3) {
+                            nodes { body author { login } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }'
+                ```
+
+                For each unresolved thread:
+                - Read the original comment and any replies.
+                - Check the current diff to see if the feedback was addressed by a code change.
+                - If addressed: resolve the thread using the GraphQL mutation:
+                  ```
+                  gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THREAD_ID>"}) { thread { isResolved } } }'
+                  ```
+                - If NOT addressed: do not resolve. Do not merge. Leave a comment:
+                  > Unresolved review feedback remains. Addressing the inline comments before merge.
+                  Then attempt to fix the feedback yourself (same approach as CI fixes — small,
+                  targeted changes). Push, then stop. The next run will re-evaluate.
+
+                ### Merge
+
                 Chore PRs (title starts with `chore:`, `docs:`, or `refactor:`):
                   gh pr merge <number> --squash --delete-branch
                 Stop.
@@ -147,3 +196,6 @@ action:
                 - Make unrelated changes while fixing CI.
                 - Force-push or rewrite history on the PR branch.
                 - Merge PRs with open "changes requested" reviews.
+                - Merge PRs with unresolved review threads — resolve them first.
+                - Refuse to act because you authored the PR. Approvals are not required.
+                - Invent constraints not in this prompt (e.g., self-approval rules).

--- a/.ona/automations/pr-reviewer.yaml
+++ b/.ona/automations/pr-reviewer.yaml
@@ -42,11 +42,13 @@ action:
 
                 Read the PR metadata:
 
-                gh pr view <number> --json title,body,isDraft,reviewDecision,statusCheckRollup,labels,reviews
+                gh pr view <number> --json title,body,isDraft,mergeable,reviewDecision,statusCheckRollup,labels,reviews
 
                 Stop immediately (skip this PR) if:
                 - The PR is a draft.
                 - CI checks are still running (status: pending/queued).
+                - The PR has merge conflicts (`mergeable` is `CONFLICTING`). The PR Shepherd
+                  handles conflict resolution — do not attempt to review or merge conflicted PRs.
 
                 Otherwise, take exactly ONE of the following actions based on the PR's current state.
 
@@ -113,7 +115,10 @@ action:
 
                 ## C. CI is passing, ready to merge → Merge
 
-                Requires: all CI checks passing AND no open "changes requested" reviews.
+                Requires: all CI checks passing AND no open "changes requested" reviews
+                AND `mergeable` is not `CONFLICTING`.
+
+                If the PR has merge conflicts, skip it — the PR Shepherd will handle resolution.
 
                 Chore PRs (title starts with `chore:`, `docs:`, or `refactor:`):
                   gh pr merge <number> --squash --delete-branch

--- a/.ona/automations/pr-shepherd.yaml
+++ b/.ona/automations/pr-shepherd.yaml
@@ -1,5 +1,5 @@
 name: PR Shepherd
-description: Finds open PRs that have stalled (no review, failed automation, no activity) and takes action.
+description: Finds open PRs that have stalled, have merge conflicts, or are duplicates, and takes action.
 triggers:
     - context:
         projects:
@@ -14,43 +14,117 @@ action:
     steps:
         - agent:
             prompt: |
-                You are the PR Shepherd. You find open PRs that have stalled and take action.
+                You are the PR Shepherd. You find open PRs that have stalled, have merge conflicts,
+                or are duplicates, and take action.
 
                 PRs can stall when:
                 - The PR Reviewer automation failed to start (infra issue)
                 - CI finished but no review was posted
                 - A review requested changes but nobody followed up
                 - The PR has been open with no activity for too long
+                - The PR has merge conflicts with main
+                - Another PR for the same issue was already merged (duplicate)
 
-                ## Step 1 — Find stalled PRs
+                ## Step 1 — Gather PR data
 
-                List all open, non-draft PRs:
-                  gh pr list --state open --json number,title,createdAt,updatedAt,isDraft,reviewDecision,statusCheckRollup,labels,reviews
+                List all open, non-draft PRs with merge status:
+                  gh pr list --state open --json number,title,body,createdAt,updatedAt,isDraft,mergeable,reviewDecision,statusCheckRollup,labels,reviews,headRefName
 
-                For each non-draft PR, classify its state:
+                For each non-draft PR, run the classifications below IN ORDER. A PR matches the
+                FIRST classification that applies — do not process it again under a later classification.
 
-                **Needs review** — CI passed, no reviews at all, last updated >15 minutes ago.
+                ## Step 2 — Classify and act
+
+                ### Duplicate (linked issue already closed)
+
+                Extract the linked issue number from the PR body (`Closes #N` or `Fixes #N`).
+                If found, check the issue state:
+                  gh issue view <N> --json state,labels --jq '{state: .state, labels: [.labels[].name]}'
+
+                If the issue is closed OR has label `status:done`, this PR is obsolete — another PR
+                already delivered the work.
+
+                Action:
+                1. Leave a comment:
+                   > [shepherd] Closing — issue #N is already closed. This PR is a duplicate.
+                2. Close the PR:
+                   `gh pr close <number>`
+                3. Delete the branch:
+                   `gh pr close <number> --delete-branch` (if not already deleted)
+                4. Move to the next PR.
+
+                ### Duplicate (multiple open PRs for the same issue)
+
+                After processing all PRs above, check if multiple REMAINING open PRs reference the
+                same `Closes #N`. If so, keep the OLDEST PR (lowest number) and flag the newer ones.
+
+                Action on each newer duplicate:
+                1. Leave a comment:
+                   > [shepherd] Duplicate detected — PR #<older> also targets issue #N. Closing this PR in favor of the earlier one.
+                2. Close the PR and delete the branch.
+
+                ### Merge conflict with closed issue
+
+                If `mergeable` is `CONFLICTING` AND the linked issue is closed/done:
+                Already handled by "Duplicate (linked issue already closed)" above. This is a fallback
+                — if somehow missed, close the PR with the same logic.
+
+                ### Merge conflict with open issue
+
+                If `mergeable` is `CONFLICTING` AND the linked issue is still open:
+
+                1. Check if there's already a `[shepherd:conflict]` comment on this PR.
+                2. If no existing conflict comment:
+                   a. Checkout the PR branch and attempt a rebase:
+                      ```
+                      git fetch origin main <branch>
+                      git checkout <branch>
+                      git rebase origin/main
+                      ```
+                   b. If the rebase succeeds cleanly:
+                      - Run `pnpm lint && pnpm typecheck && pnpm test` to verify nothing broke.
+                      - If checks pass: `git push --force-with-lease` and leave a comment:
+                        > [shepherd:conflict] Merge conflict resolved via rebase on main.
+                      - If checks fail: `git rebase --abort`, leave a comment:
+                        > [shepherd:conflict] Rebased on main but checks fail. Needs human attention.
+                        Add label `needs-human`.
+                   c. If the rebase has conflicts:
+                      - `git rebase --abort`
+                      - Leave a comment:
+                        > [shepherd:conflict] This PR has merge conflicts that require manual resolution. Conflicting files: <list files from rebase output>
+                      - Add label `needs-human`.
+                3. If a `[shepherd:conflict]` comment already exists, skip — already handled.
+
+                ### Needs review
+
+                CI passed, no reviews at all, last updated >15 minutes ago.
                 These are PRs where the PR Reviewer likely failed to start.
 
-                **Changes requested but stale** — has a "changes requested" review, last updated
-                >30 minutes ago. The PR Reviewer should have fixed these but didn't.
+                ### Changes requested but stale
 
-                **CI stuck** — checks have been pending/queued for >30 minutes.
+                Has a "changes requested" review, last updated >30 minutes ago.
+                The PR Reviewer should have fixed these but didn't.
 
-                **Ancient** — open for >24 hours with no merge. Something is wrong.
+                ### CI stuck
+
+                Checks have been pending/queued for >30 minutes.
+
+                ### Ancient
+
+                Open for >24 hours with no merge. Something is wrong.
 
                 Skip PRs that:
                 - Are drafts
                 - Were updated in the last 15 minutes (give automations time to act)
-                - Have an approval and passing CI (PR Reviewer will merge these)
+                - Have an approval and passing CI and no merge conflicts (PR Reviewer will merge these)
 
-                ## Step 2 — Take action
+                ## Step 3 — Take action on stalled PRs
 
-                For each stalled PR:
+                For each stalled PR (needs review / changes requested / CI stuck / ancient):
 
                 **Needs review / Changes requested but stale:**
                 1. Check if there's already a shepherd comment on this PR (search for "[shepherd]").
-                   Count existing shepherd comments.
+                   Count existing shepherd comments (exclude [shepherd:conflict] comments).
                 2. If 0 shepherd comments: leave a comment:
                    > [shepherd] This PR appears stalled — no review activity. Re-triggering review.
                    Then make a trivial update to re-trigger the PR Reviewer:
@@ -77,7 +151,7 @@ action:
 
                 ## Do NOT
                 - Act on PRs updated in the last 15 minutes — give other automations time.
-                - Force-push or rewrite history.
-                - Close PRs — only humans close PRs.
-                - Create duplicate shepherd comments — always check for existing [shepherd] comments first.
+                - Create duplicate shepherd comments — always check for existing comments first.
                 - Re-trigger more than once per PR per run.
+                - Attempt to resolve semantic merge conflicts (overlapping changes in the same lines).
+                - Rebase a PR more than once — if a [shepherd:conflict] comment exists, skip it.

--- a/.ona/skills/automation-manager/SKILL.md
+++ b/.ona/skills/automation-manager/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: automation-manager
+description: >-
+  Create, update, and sync Ona automations. Ensures YAML files in
+  .ona/automations/ stay in sync with the live Ona automation registry.
+  Use when creating a new automation, modifying triggers or prompts,
+  deleting an automation, or auditing drift between YAML and live state.
+  Triggers on "create automation", "update automation", "delete automation",
+  "sync automations", "register automation", "automation drift",
+  "add a new automation", "change automation triggers".
+---
+
+# Automation Manager
+
+Automations have two representations that must stay in sync:
+
+1. **YAML file** in `.ona/automations/<name>.yaml` — version-controlled source of truth.
+2. **Live registration** in Ona — the runtime configuration that actually triggers executions.
+
+Editing only the YAML does nothing. Registering only via CLI loses version history.
+Every change must update both.
+
+## Authentication
+
+The environment principal cannot manage automations. Authenticate with the user PAT:
+
+```bash
+ona login --token "$ONA_PAT"
+```
+
+Restore the environment context when done:
+
+```bash
+ona config context use environment
+```
+
+## Creating a new automation
+
+1. Generate the example syntax for reference:
+   ```bash
+   ona ai automation create --example
+   ```
+
+2. Create the YAML file at `.ona/automations/<name>.yaml`. Follow the structure of
+   existing automations in that directory. Required fields: `name`, `description`,
+   `triggers`, `action.limits`, `action.steps`.
+
+3. Register it:
+   ```bash
+   ona login --token "$ONA_PAT"
+   ona ai automation create .ona/automations/<name>.yaml
+   ```
+   The CLI prints the new automation ID.
+
+4. Add the new entry to `references/registry.md` with the YAML filename, name, and ID.
+
+5. Restore context:
+   ```bash
+   ona config context use environment
+   ```
+
+6. Commit both the YAML file and the updated registry.
+
+## Updating an existing automation
+
+1. Look up the automation ID in `references/registry.md`.
+
+2. Edit the YAML file.
+
+3. Push the update to Ona:
+   ```bash
+   ona login --token "$ONA_PAT"
+   ona ai automation update <automation-id> .ona/automations/<name>.yaml
+   ```
+
+4. Verify the update took effect:
+   ```bash
+   ona ai automation get <automation-id> -o json | jq '.[0].spec.triggers'
+   ```
+
+5. Restore context:
+   ```bash
+   ona config context use environment
+   ```
+
+6. Commit the YAML change.
+
+## Deleting an automation
+
+1. Look up the automation ID in `references/registry.md`.
+
+2. Delete from Ona:
+   ```bash
+   ona login --token "$ONA_PAT"
+   ona ai automation delete <automation-id>
+   ```
+
+3. Delete the YAML file.
+
+4. Remove the row from `references/registry.md`.
+
+5. Restore context and commit.
+
+## Auditing drift
+
+Compare YAML files against live registrations to find mismatches.
+
+1. List live automations:
+   ```bash
+   ona login --token "$ONA_PAT"
+   ona ai automation list -o json | jq '[.[] | {id: .id, name: .metadata.name}]'
+   ```
+
+2. List YAML files:
+   ```bash
+   ls .ona/automations/*.yaml
+   ```
+
+3. Check for:
+   - YAML files with no matching live automation (unregistered).
+   - Live automations with no matching YAML file (untracked).
+   - Name mismatches between YAML `name:` field and live `metadata.name`.
+
+4. For each unregistered YAML: run `ona ai automation create`.
+5. For each untracked live automation: either create the YAML or delete the live registration.
+6. Update `references/registry.md` with any changes.
+
+## Trigger design rules
+
+These rules prevent the race conditions that caused duplicate PRs (#45/#46, #40/#41):
+
+- **One trigger type per automation.** Use either cron OR webhook, not both.
+  The cron alone is sufficient — a 10-minute delay after a merge is acceptable.
+- **`maxParallel: 1`** on all automations. This is necessary but not sufficient
+  (the platform has a TOCTOU window during environment startup).
+- **Prompt-level guards** are defense-in-depth, not primary protection. The prompt
+  should check for existing work (open PRs, in-progress labels) but cannot
+  guarantee mutual exclusion.
+
+## YAML structure reference
+
+```yaml
+name: Human-readable name
+description: One-line description of what the automation does.
+triggers:
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: "*/10 * * * *"
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      manual: {}
+action:
+    limits:
+        maxParallel: 1
+        maxTotal: 50
+    steps:
+        - agent:
+            prompt: |
+                Your prompt here.
+```
+
+Trigger types (use only one per automation, plus manual):
+- `time.cronExpression` — cron schedule
+- `pullRequest.events` — webhook events (avoid combining with cron)
+- `manual` — always include for manual runs
+
+## Reference files
+
+- `references/registry.md` — Read when you need to look up an automation ID or check
+  which automations are registered.

--- a/.ona/skills/automation-manager/references/registry.md
+++ b/.ona/skills/automation-manager/references/registry.md
@@ -1,0 +1,24 @@
+# Automation Registry
+
+Mapping between YAML files in `.ona/automations/` and their registered Ona automation IDs.
+
+| YAML File | Automation Name | Ona ID |
+|---|---|---|
+| automation-auditor.yaml | Automation Auditor | 019d8d98-446b-7afb-907a-5b623fb180ad |
+| bug-fixer.yaml | Bug Fixer | 019d8daa-712b-7ad0-b3f2-82d6f9edb8bf |
+| daily-metrics.yaml | Daily Metrics | 019d8d98-3977-772e-b93a-8d94d0878a8f |
+| feature-builder.yaml | Feature Builder | 019d8daa-6efc-76bb-9326-d814d0a17bdf |
+| feature-planner.yaml | Feature Planner | 019d8d97-b2fd-7589-b685-e8373538c552 |
+| incident-responder.yaml | Incident Responder | 019d8db6-f940-78ac-86ce-788536c849ec |
+| performance-monitor.yaml | Performance Monitor | 019d8db6-fb68-7228-9e1f-9bb6719331fc |
+| post-merge-verifier.yaml | Post-Merge Verifier | 019d8db6-fd99-7744-8e92-af4ab899ac57 |
+| pr-reviewer.yaml | PR Reviewer | 019d8dbc-3121-7934-9594-2eddfc588e3f |
+| pr-shepherd.yaml | PR Shepherd | 019d8dcc-adc3-7d23-a2b9-39aa4fbd6463 |
+| tweet-drafter.yaml | Tweet Drafter | 019d8da2-46d3-7493-8bd5-7191a31f47ec |
+| ui-verifier.yaml | UI Verifier | 019d8d99-7474-725b-aa77-0310122b2c64 |
+| weekly-recap.yaml | Weekly Recap | 019d8d98-3e15-762d-a6e8-4ca0ea77acb5 |
+
+## Keeping this file in sync
+
+When you create a new automation, add its row here immediately after `ona ai automation create` returns the ID.
+When you delete an automation, remove its row.


### PR DESCRIPTION
## What

Teach the PR Shepherd to detect and resolve merge conflicts and duplicate PRs. Add a mergeable guard to the PR Reviewer so it doesn't attempt to review or merge conflicted PRs.

## Why

After the duplicate-trigger race was fixed in PR #50, there's still no automation that handles the aftermath: orphaned PRs with merge conflicts, or PRs whose linked issue was already closed by a duplicate. PR #45 sat open with conflicts until manually closed. The PR Shepherd runs every 30 minutes and is the right place for this.

## Changes

**PR Shepherd** — three new classifications (evaluated before the existing stall checks):

| Classification | Condition | Action |
|---|---|---|
| Duplicate (issue closed) | `Closes #N` references a closed issue | Close PR, delete branch |
| Duplicate (multiple open) | Two+ open PRs reference same `Closes #N` | Close newer PR, keep oldest |
| Merge conflict (open issue) | `mergeable: CONFLICTING`, issue still open | Attempt `git rebase origin/main`. If clean + checks pass → force-push. If conflicts or checks fail → `needs-human` label |

**PR Reviewer** — skip PRs where `mergeable` is `CONFLICTING` in both the state-determination step and the merge step. The Shepherd owns conflict resolution.

## Automations already registered

Both automations were updated live via `ona ai automation update` — the fix is active now.