### PR TITLE
feat: Lexical editor — drag-and-drop, images, callouts, collapsible blocks (#29)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -98,24 +98,28 @@ Pin to a specific version to avoid breaking changes.
 
 ### Custom plugins (referencing playground)
 
-| Plugin | Playground reference | Complexity |
+| Plugin | Playground reference | Status |
 |---|---|---|
-| ComponentPickerPlugin (slash commands) | `plugins/ComponentPickerPlugin` | Medium |
-| DraggableBlockPlugin (drag-and-drop) | `plugins/DraggableBlockPlugin` | High |
-| FloatingTextFormatToolbarPlugin | `plugins/FloatingTextFormatToolbarPlugin` | High |
-| FloatingLinkEditorPlugin | `plugins/FloatingLinkEditorPlugin` | Medium |
-| ImagesExtension | `plugins/ImagesExtension` | High |
-| CodeHighlightExtension | `plugins/CodeHighlightExtension` | Medium |
-| CollapsibleExtension (toggle blocks) | `plugins/CollapsibleExtension` | Medium |
-| ToolbarPlugin (top toolbar) | `plugins/ToolbarPlugin` | High |
+| SlashCommandPlugin (slash commands) | `plugins/ComponentPickerPlugin` | ✅ Implemented |
+| DraggableBlockPlugin (drag-and-drop) | `plugins/DraggableBlockPlugin` | ✅ Implemented |
+| FloatingToolbarPlugin | `plugins/FloatingTextFormatToolbarPlugin` | ✅ Implemented |
+| FloatingLinkEditorPlugin | `plugins/FloatingLinkEditorPlugin` | ✅ Implemented |
+| ImagePlugin | `plugins/ImagesExtension` | ✅ Implemented |
+| CodeHighlightPlugin | `plugins/CodeHighlightExtension` | ✅ Implemented |
+| CalloutPlugin | N/A (custom) | ✅ Implemented |
+| CollapsiblePlugin (toggle blocks) | `plugins/CollapsibleExtension` | ✅ Implemented |
+| ToolbarPlugin (top toolbar) | `plugins/ToolbarPlugin` | Deferred |
 
 ### Custom nodes
 
-| Node | Type | Purpose |
-|---|---|---|
-| ImageNode | DecoratorNode | Image display with caption, resize handles |
-| CalloutNode | ElementNode | Callout/alert block with emoji + text |
-| DividerNode | HorizontalRuleNode (`@lexical/extension`) | Horizontal divider |
+| Node | Type | Purpose | Status |
+|---|---|---|---|
+| ImageNode | DecoratorNode | Image display with caption | ✅ Implemented |
+| CalloutNode | ElementNode | Callout/alert block with emoji + colored bg | ✅ Implemented |
+| CollapsibleContainerNode | ElementNode | `<details>` wrapper for toggle blocks | ✅ Implemented |
+| CollapsibleTitleNode | ElementNode | `<summary>` title for toggle blocks | ✅ Implemented |
+| CollapsibleContentNode | ElementNode | Content area for toggle blocks | ✅ Implemented |
+| DividerNode | HorizontalRuleNode (`@lexical/react`) | Horizontal divider | ✅ Built-in |
 
 ### Skipped plugins (not needed for MVP)
 
@@ -177,11 +181,18 @@ src/
 │   ├── editor/                  # Lexical block editor
 │   │   ├── editor.tsx               # Main editor: LexicalComposer, plugins, auto-save to Supabase
 │   │   ├── theme.ts                 # EditorThemeClasses mapping Lexical nodes to Tailwind classes
-│   │   ├── slash-command-plugin.tsx  # "/" typeahead: paragraph, h1-h3, lists, code, quote, divider
+│   │   ├── slash-command-plugin.tsx  # "/" typeahead: paragraph, h1-h3, lists, code, quote, divider, image, callout, toggle
 │   │   ├── floating-toolbar-plugin.tsx # Selection toolbar: bold, italic, underline, strikethrough, code, link
 │   │   ├── floating-link-editor-plugin.tsx # Link preview/edit/remove popover (⌘+K)
 │   │   ├── code-highlight-plugin.tsx # Registers Prism-based syntax highlighting for code blocks
-│   │   └── markdown-utils.ts        # Markdown ↔ Lexical conversion (export/import/download/parse)
+│   │   ├── markdown-utils.ts        # Markdown ↔ Lexical conversion (export/import/download/parse)
+│   │   ├── draggable-block-plugin.tsx # Drag handle + drop indicator for block reordering
+│   │   ├── image-node.tsx           # ImageNode (DecoratorNode) with caption support
+│   │   ├── image-plugin.tsx         # Image upload to Supabase Storage, file drop handling
+│   │   ├── callout-node.tsx         # CalloutNode (ElementNode) with emoji + variant
+│   │   ├── callout-plugin.tsx       # Callout insert command + emoji rendering
+│   │   ├── collapsible-node.tsx     # CollapsibleContainer/Title/Content nodes (<details>/<summary>)
+│   │   └── collapsible-plugin.tsx   # Collapsible insert command + toggle handling
 │   ├── page-title.tsx           # Inline-editable page title (saves on blur/Enter)
 │   ├── page-view-client.tsx     # Client wrapper for page view (holds editor ref, renders title + menu + editor)
 │   ├── page-menu.tsx            # Page "..." dropdown: export as markdown, import markdown

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -467,6 +467,46 @@ Content auto-saves via debounced `OnChangePlugin`. The save flow:
 3. Add a `SlashCommandOption` entry in `slash-command-plugin.tsx`
 4. If the block needs a Lexical plugin (e.g., `ListPlugin`), add it inside `<LexicalComposer>`
 
+### Custom node pattern (ElementNode)
+
+Custom block nodes extend `ElementNode`. Each node file exports the class, a `$create*`
+factory, and a `$is*` type guard. Nodes must implement `exportJSON()` and `importJSON()`
+for persistence. Use `$applyNodeReplacement` in factory functions.
+
+```typescript
+export class MyNode extends ElementNode {
+  static getType(): string { return "my-node"; }
+  static clone(node: MyNode): MyNode { /* ... */ }
+  static importJSON(serialized: SerializedMyNode): MyNode { /* ... */ }
+  exportJSON(): SerializedMyNode { /* ... */ }
+  createDOM(): HTMLElement { /* ... */ }
+  updateDOM(): boolean { return false; }
+}
+
+export function $createMyNode(): MyNode {
+  return $applyNodeReplacement(new MyNode());
+}
+
+export function $isMyNode(node: LexicalNode | null | undefined): node is MyNode {
+  return node instanceof MyNode;
+}
+```
+
+### Custom node pattern (DecoratorNode)
+
+DecoratorNodes render React components via `decorate()`. Used for rich blocks like
+images that need interactive UI. The component receives the editor instance and node
+key for updates.
+
+### Custom plugin + command pattern
+
+Each custom block type has a paired plugin file that:
+1. Defines an `INSERT_*_COMMAND` via `createCommand()`
+2. Registers the command handler in a `useEffect`
+3. Optionally uses `registerMutationListener` for DOM-level behavior (e.g., emoji rendering)
+
+The slash command menu imports the command and dispatches it on selection.
+
 ### Lexical package versions
 
 All `@lexical/*` packages are pinned to the same version (currently 0.31.0).

--- a/src/components/editor/callout-node.tsx
+++ b/src/components/editor/callout-node.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import type {
+  DOMExportOutput,
+  LexicalNode,
+  NodeKey,
+  RangeSelection,
+  SerializedElementNode,
+  Spread,
+} from "lexical";
+import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  ElementNode,
+} from "lexical";
+
+export type CalloutVariant = "info" | "warning" | "success" | "error";
+
+export type SerializedCalloutNode = Spread<
+  {
+    emoji: string;
+    variant: CalloutVariant;
+  },
+  SerializedElementNode
+>;
+
+const VARIANT_CLASSES: Record<CalloutVariant, string> = {
+  info: "bg-muted",
+  warning: "bg-muted",
+  success: "bg-muted",
+  error: "bg-muted",
+};
+
+export class CalloutNode extends ElementNode {
+  __emoji: string;
+  __variant: CalloutVariant;
+
+  static getType(): string {
+    return "callout";
+  }
+
+  static clone(node: CalloutNode): CalloutNode {
+    return new CalloutNode(node.__emoji, node.__variant, node.__key);
+  }
+
+  static importJSON(serializedNode: SerializedCalloutNode): CalloutNode {
+    const node = $createCalloutNode(
+      serializedNode.emoji,
+      serializedNode.variant
+    );
+    return node;
+  }
+
+  constructor(emoji?: string, variant?: CalloutVariant, key?: NodeKey) {
+    super(key);
+    this.__emoji = emoji ?? "💡";
+    this.__variant = variant ?? "info";
+  }
+
+  exportJSON(): SerializedCalloutNode {
+    return {
+      ...super.exportJSON(),
+      type: "callout",
+      version: 1,
+      emoji: this.__emoji,
+      variant: this.__variant,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    const div = document.createElement("div");
+    div.className = `mt-3 flex gap-3 p-4 text-sm ${VARIANT_CLASSES[this.__variant]}`;
+    return div;
+  }
+
+  updateDOM(prevNode: CalloutNode, dom: HTMLElement): boolean {
+    if (prevNode.__variant !== this.__variant) {
+      dom.className = `mt-3 flex gap-3 p-4 text-sm ${VARIANT_CLASSES[this.__variant]}`;
+    }
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("div");
+    element.className = "callout";
+    element.setAttribute("data-variant", this.__variant);
+    element.setAttribute("data-emoji", this.__emoji);
+    return { element };
+  }
+
+  getEmoji(): string {
+    return this.getLatest().__emoji;
+  }
+
+  setEmoji(emoji: string): void {
+    const writable = this.getWritable();
+    writable.__emoji = emoji;
+  }
+
+  getVariant(): CalloutVariant {
+    return this.getLatest().__variant;
+  }
+
+  setVariant(variant: CalloutVariant): void {
+    const writable = this.getWritable();
+    writable.__variant = variant;
+  }
+
+  // Callout blocks can contain inline content (text, links, etc.)
+  // but not other block-level elements
+  canInsertTextBefore(): boolean {
+    return true;
+  }
+
+  canInsertTextAfter(): boolean {
+    return true;
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  collapseAtStart(): boolean {
+    const paragraph = $createParagraphNode();
+    const children = this.getChildren();
+    children.forEach((child) => paragraph.append(child));
+    this.replace(paragraph);
+    return true;
+  }
+
+  insertNewAfter(
+    _selection: RangeSelection,
+    restoreSelection?: boolean
+  ): LexicalNode {
+    const paragraph = $createParagraphNode();
+    this.insertAfter(paragraph, restoreSelection);
+    return paragraph;
+  }
+}
+
+export function $createCalloutNode(
+  emoji?: string,
+  variant?: CalloutVariant
+): CalloutNode {
+  return $applyNodeReplacement(new CalloutNode(emoji, variant));
+}
+
+export function $isCalloutNode(
+  node: LexicalNode | null | undefined
+): node is CalloutNode {
+  return node instanceof CalloutNode;
+}

--- a/src/components/editor/callout-plugin.tsx
+++ b/src/components/editor/callout-plugin.tsx
@@ -69,7 +69,7 @@ export function CalloutPlugin(): null {
 
           const emoji = node.getEmoji();
 
-          // Check if emoji span already exists
+          // querySelector returns Element | null; safe to narrow because we create this span ourselves
           let emojiSpan = dom.querySelector(
             ".callout-emoji"
           ) as HTMLSpanElement | null;

--- a/src/components/editor/callout-plugin.tsx
+++ b/src/components/editor/callout-plugin.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $getNodeByKey,
+  $getSelection,
+  $insertNodes,
+  $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
+  createCommand,
+  type LexicalCommand,
+} from "lexical";
+import {
+  $createCalloutNode,
+  CalloutNode,
+  type CalloutVariant,
+} from "@/components/editor/callout-node";
+
+export interface InsertCalloutPayload {
+  emoji?: string;
+  variant?: CalloutVariant;
+}
+
+export const INSERT_CALLOUT_COMMAND: LexicalCommand<InsertCalloutPayload> =
+  createCommand("INSERT_CALLOUT_COMMAND");
+
+export function CalloutPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    // Register the CalloutNode if not already registered
+    if (!editor.hasNodes([CalloutNode])) {
+      throw new Error(
+        "CalloutPlugin: CalloutNode not registered on editor. Add it to initialConfig.nodes."
+      );
+    }
+
+    return editor.registerCommand(
+      INSERT_CALLOUT_COMMAND,
+      (payload: InsertCalloutPayload) => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          const calloutNode = $createCalloutNode(
+            payload.emoji,
+            payload.variant
+          );
+          $insertNodes([calloutNode]);
+          calloutNode.selectEnd();
+        }
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR
+    );
+  }, [editor]);
+
+  // Mutation listener to render emoji prefix in callout DOM
+  useEffect(() => {
+    return editor.registerMutationListener(CalloutNode, (mutations) => {
+      for (const [nodeKey, mutation] of mutations) {
+        if (mutation === "destroyed") continue;
+
+        const dom = editor.getElementByKey(nodeKey);
+        if (!dom) continue;
+
+        editor.read(() => {
+          const node = $getNodeByKey(nodeKey);
+          if (!(node instanceof CalloutNode)) return;
+
+          const emoji = node.getEmoji();
+
+          // Check if emoji span already exists
+          let emojiSpan = dom.querySelector(
+            ".callout-emoji"
+          ) as HTMLSpanElement | null;
+
+          if (!emojiSpan) {
+            emojiSpan = document.createElement("span");
+            emojiSpan.className = "callout-emoji select-none text-base shrink-0";
+            emojiSpan.contentEditable = "false";
+            dom.insertBefore(emojiSpan, dom.firstChild);
+          }
+
+          emojiSpan.textContent = emoji;
+        });
+      }
+    });
+  }, [editor]);
+
+  return null;
+}

--- a/src/components/editor/collapsible-node.tsx
+++ b/src/components/editor/collapsible-node.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import type {
+  DOMExportOutput,
+  LexicalNode,
+  NodeKey,
+  SerializedElementNode,
+  Spread,
+} from "lexical";
+import {
+  $applyNodeReplacement,
+  $createParagraphNode,
+  ElementNode,
+} from "lexical";
+
+// --- CollapsibleContainerNode ---
+
+export type SerializedCollapsibleContainerNode = Spread<
+  { open: boolean },
+  SerializedElementNode
+>;
+
+export class CollapsibleContainerNode extends ElementNode {
+  __open: boolean;
+
+  static getType(): string {
+    return "collapsible-container";
+  }
+
+  static clone(node: CollapsibleContainerNode): CollapsibleContainerNode {
+    return new CollapsibleContainerNode(node.__open, node.__key);
+  }
+
+  static importJSON(
+    serializedNode: SerializedCollapsibleContainerNode
+  ): CollapsibleContainerNode {
+    const node = $createCollapsibleContainerNode(serializedNode.open);
+    return node;
+  }
+
+  constructor(open?: boolean, key?: NodeKey) {
+    super(key);
+    this.__open = open ?? true;
+  }
+
+  exportJSON(): SerializedCollapsibleContainerNode {
+    return {
+      ...super.exportJSON(),
+      type: "collapsible-container",
+      version: 1,
+      open: this.__open,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    const details = document.createElement("details");
+    details.className = "mt-3 border border-white/[0.06] text-sm";
+    if (this.__open) {
+      details.open = true;
+    }
+    return details;
+  }
+
+  updateDOM(
+    prevNode: CollapsibleContainerNode,
+    dom: HTMLDetailsElement
+  ): boolean {
+    if (prevNode.__open !== this.__open) {
+      dom.open = this.__open;
+    }
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("details");
+    if (this.__open) element.open = true;
+    return { element };
+  }
+
+  getOpen(): boolean {
+    return this.getLatest().__open;
+  }
+
+  setOpen(open: boolean): void {
+    const writable = this.getWritable();
+    writable.__open = open;
+  }
+
+  toggleOpen(): void {
+    this.setOpen(!this.getOpen());
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+}
+
+// --- CollapsibleTitleNode ---
+
+export type SerializedCollapsibleTitleNode = SerializedElementNode;
+
+export class CollapsibleTitleNode extends ElementNode {
+  static getType(): string {
+    return "collapsible-title";
+  }
+
+  static clone(node: CollapsibleTitleNode): CollapsibleTitleNode {
+    return new CollapsibleTitleNode(node.__key);
+  }
+
+  static importJSON(): CollapsibleTitleNode {
+    return $createCollapsibleTitleNode();
+  }
+
+  exportJSON(): SerializedCollapsibleTitleNode {
+    return {
+      ...super.exportJSON(),
+      type: "collapsible-title",
+      version: 1,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    const summary = document.createElement("summary");
+    summary.className =
+      "cursor-pointer select-none p-3 text-sm font-medium text-foreground hover:bg-white/[0.04] list-none";
+    return summary;
+  }
+
+  updateDOM(): boolean {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("summary");
+    return { element };
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  collapseAtStart(): boolean {
+    // When backspacing at the start of the title, unwrap the collapsible
+    const container = this.getParent();
+    if (container instanceof CollapsibleContainerNode) {
+      const contentNode = this.getNextSibling();
+      const paragraph = $createParagraphNode();
+      const children = this.getChildren();
+      children.forEach((child) => paragraph.append(child));
+      container.insertBefore(paragraph);
+
+      // Move content children out of the container
+      if (contentNode instanceof CollapsibleContentNode) {
+        const contentChildren = contentNode.getChildren();
+        contentChildren.forEach((child) => {
+          container.insertBefore(child);
+        });
+      }
+
+      container.remove();
+      paragraph.selectStart();
+      return true;
+    }
+    return false;
+  }
+}
+
+// --- CollapsibleContentNode ---
+
+export type SerializedCollapsibleContentNode = SerializedElementNode;
+
+export class CollapsibleContentNode extends ElementNode {
+  static getType(): string {
+    return "collapsible-content";
+  }
+
+  static clone(node: CollapsibleContentNode): CollapsibleContentNode {
+    return new CollapsibleContentNode(node.__key);
+  }
+
+  static importJSON(): CollapsibleContentNode {
+    return $createCollapsibleContentNode();
+  }
+
+  exportJSON(): SerializedCollapsibleContentNode {
+    return {
+      ...super.exportJSON(),
+      type: "collapsible-content",
+      version: 1,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    const div = document.createElement("div");
+    div.className = "border-t border-white/[0.06] p-3 text-sm";
+    return div;
+  }
+
+  updateDOM(): boolean {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("div");
+    return { element };
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+}
+
+// --- Factory functions ---
+
+export function $createCollapsibleContainerNode(
+  open?: boolean
+): CollapsibleContainerNode {
+  return $applyNodeReplacement(new CollapsibleContainerNode(open));
+}
+
+export function $createCollapsibleTitleNode(): CollapsibleTitleNode {
+  return $applyNodeReplacement(new CollapsibleTitleNode());
+}
+
+export function $createCollapsibleContentNode(): CollapsibleContentNode {
+  return $applyNodeReplacement(new CollapsibleContentNode());
+}
+
+export function $isCollapsibleContainerNode(
+  node: LexicalNode | null | undefined
+): node is CollapsibleContainerNode {
+  return node instanceof CollapsibleContainerNode;
+}
+
+export function $isCollapsibleTitleNode(
+  node: LexicalNode | null | undefined
+): node is CollapsibleTitleNode {
+  return node instanceof CollapsibleTitleNode;
+}
+
+export function $isCollapsibleContentNode(
+  node: LexicalNode | null | undefined
+): node is CollapsibleContentNode {
+  return node instanceof CollapsibleContentNode;
+}

--- a/src/components/editor/collapsible-plugin.tsx
+++ b/src/components/editor/collapsible-plugin.tsx
@@ -79,16 +79,29 @@ export function CollapsiblePlugin(): null {
 
   // Handle toggle open/close via DOM events on <details>
   useEffect(() => {
-    return editor.registerMutationListener(
+    const cleanupMap = new Map<string, () => void>();
+
+    const unregister = editor.registerMutationListener(
       CollapsibleContainerNode,
       (mutations) => {
         for (const [nodeKey, mutation] of mutations) {
-          if (mutation === "destroyed") continue;
+          if (mutation === "destroyed") {
+            const cleanup = cleanupMap.get(nodeKey);
+            if (cleanup) {
+              cleanup();
+              cleanupMap.delete(nodeKey);
+            }
+            continue;
+          }
 
-          const dom = editor.getElementByKey(nodeKey) as HTMLDetailsElement | null;
+          // Skip if already listening
+          if (cleanupMap.has(nodeKey)) continue;
+
+          const dom = editor.getElementByKey(
+            nodeKey
+          ) as HTMLDetailsElement | null;
           if (!dom) continue;
 
-          // Listen for toggle events on the <details> element
           const handleToggle = () => {
             editor.update(() => {
               const node = $getNodeByKey(nodeKey);
@@ -99,9 +112,18 @@ export function CollapsiblePlugin(): null {
           };
 
           dom.addEventListener("toggle", handleToggle);
+          cleanupMap.set(nodeKey, () =>
+            dom.removeEventListener("toggle", handleToggle)
+          );
         }
       }
     );
+
+    return () => {
+      unregister();
+      cleanupMap.forEach((cleanup) => cleanup());
+      cleanupMap.clear();
+    };
   }, [editor]);
 
   return null;

--- a/src/components/editor/collapsible-plugin.tsx
+++ b/src/components/editor/collapsible-plugin.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKey,
+  $getSelection,
+  $insertNodes,
+  $isRangeSelection,
+  COMMAND_PRIORITY_EDITOR,
+  createCommand,
+  type LexicalCommand,
+} from "lexical";
+import {
+  $createCollapsibleContainerNode,
+  $createCollapsibleContentNode,
+  $createCollapsibleTitleNode,
+  CollapsibleContainerNode,
+  CollapsibleContentNode,
+  CollapsibleTitleNode,
+} from "@/components/editor/collapsible-node";
+
+export const INSERT_COLLAPSIBLE_COMMAND: LexicalCommand<void> = createCommand(
+  "INSERT_COLLAPSIBLE_COMMAND"
+);
+
+export function CollapsiblePlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (
+      !editor.hasNodes([
+        CollapsibleContainerNode,
+        CollapsibleTitleNode,
+        CollapsibleContentNode,
+      ])
+    ) {
+      throw new Error(
+        "CollapsiblePlugin: CollapsibleContainerNode, CollapsibleTitleNode, or CollapsibleContentNode not registered."
+      );
+    }
+
+    return editor.registerCommand(
+      INSERT_COLLAPSIBLE_COMMAND,
+      () => {
+        editor.update(() => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection)) return;
+
+          const title = $createCollapsibleTitleNode();
+          title.append($createTextNode("Toggle title"));
+
+          const contentParagraph = $createParagraphNode();
+          contentParagraph.append($createTextNode("Toggle content"));
+
+          const content = $createCollapsibleContentNode();
+          content.append(contentParagraph);
+
+          const container = $createCollapsibleContainerNode(true);
+          container.append(title);
+          container.append(content);
+
+          $insertNodes([container]);
+
+          // Add a paragraph after so the user can continue typing
+          const afterParagraph = $createParagraphNode();
+          container.insertAfter(afterParagraph);
+
+          // Select the title text for immediate editing
+          title.selectStart();
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR
+    );
+  }, [editor]);
+
+  // Handle toggle open/close via DOM events on <details>
+  useEffect(() => {
+    return editor.registerMutationListener(
+      CollapsibleContainerNode,
+      (mutations) => {
+        for (const [nodeKey, mutation] of mutations) {
+          if (mutation === "destroyed") continue;
+
+          const dom = editor.getElementByKey(nodeKey) as HTMLDetailsElement | null;
+          if (!dom) continue;
+
+          // Listen for toggle events on the <details> element
+          const handleToggle = () => {
+            editor.update(() => {
+              const node = $getNodeByKey(nodeKey);
+              if (node instanceof CollapsibleContainerNode) {
+                node.setOpen(dom.open);
+              }
+            });
+          };
+
+          dom.addEventListener("toggle", handleToggle);
+        }
+      }
+    );
+  }, [editor]);
+
+  return null;
+}

--- a/src/components/editor/draggable-block-plugin.tsx
+++ b/src/components/editor/draggable-block-plugin.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import type { JSX } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $getNearestNodeFromDOMNode,
+  $getNodeByKey,
+  COMMAND_PRIORITY_HIGH,
+  DRAGOVER_COMMAND,
+  DROP_COMMAND,
+  type LexicalEditor,
+} from "lexical";
+import { mergeRegister } from "@lexical/utils";
+import { GripVertical } from "lucide-react";
+
+const DRAG_DATA_FORMAT = "application/x-memo-drag-block";
+const DRAGGABLE_BLOCK_MENU_CLASSNAME = "memo-draggable-block-menu";
+const DROP_INDICATOR_CLASSNAME = "memo-drop-indicator";
+
+// Distance from left edge of editor to show drag handle
+const HANDLE_LEFT_OFFSET = -28;
+// Vertical dead zone — mouse must be within this distance of a block to show handle
+const HANDLE_DEAD_ZONE = 4;
+
+function getBlockElement(
+  anchorElem: HTMLElement,
+  editor: LexicalEditor,
+  event: MouseEvent
+): HTMLElement | null {
+  const editorBounds = anchorElem.getBoundingClientRect();
+  const y = event.clientY;
+
+  // Walk through top-level block elements in the editor
+  let blockElem: HTMLElement | null = null;
+  let minDistance = Infinity;
+
+  const children = anchorElem.querySelectorAll(
+    "[data-lexical-editor] > *"
+  );
+
+  // If no direct children found, try the contentEditable's children
+  const contentEditable = anchorElem.querySelector(
+    '[contenteditable="true"]'
+  );
+  const elements = children.length > 0 ? children : contentEditable?.children;
+
+  if (!elements) return null;
+
+  for (let i = 0; i < elements.length; i++) {
+    const elem = elements[i] as HTMLElement;
+    const rect = elem.getBoundingClientRect();
+    const centerY = rect.top + rect.height / 2;
+    const distance = Math.abs(y - centerY);
+
+    if (distance < minDistance && y >= rect.top - HANDLE_DEAD_ZONE && y <= rect.bottom + HANDLE_DEAD_ZONE) {
+      minDistance = distance;
+      blockElem = elem;
+    }
+  }
+
+  // Verify the mouse is within the editor bounds horizontally
+  if (
+    blockElem &&
+    (event.clientX < editorBounds.left - 50 ||
+      event.clientX > editorBounds.right + 50)
+  ) {
+    return null;
+  }
+
+  return blockElem;
+}
+
+function isOnMenu(element: HTMLElement): boolean {
+  return !!element.closest(`.${DRAGGABLE_BLOCK_MENU_CLASSNAME}`);
+}
+
+function setMenuPosition(
+  menuRef: HTMLElement,
+  targetElem: HTMLElement,
+  anchorElem: HTMLElement
+): void {
+  const targetRect = targetElem.getBoundingClientRect();
+  const anchorRect = anchorElem.getBoundingClientRect();
+
+  menuRef.style.top = `${targetRect.top - anchorRect.top + targetRect.height / 2 - 12}px`;
+  menuRef.style.left = `${HANDLE_LEFT_OFFSET}px`;
+  menuRef.style.opacity = "1";
+}
+
+function setDropIndicatorPosition(
+  indicator: HTMLElement,
+  targetElem: HTMLElement,
+  anchorElem: HTMLElement,
+  isBelow: boolean
+): void {
+  const targetRect = targetElem.getBoundingClientRect();
+  const anchorRect = anchorElem.getBoundingClientRect();
+
+  const top = isBelow
+    ? targetRect.bottom - anchorRect.top
+    : targetRect.top - anchorRect.top;
+
+  indicator.style.top = `${top}px`;
+  indicator.style.left = "0";
+  indicator.style.width = `${anchorRect.width}px`;
+  indicator.style.opacity = "1";
+}
+
+interface DraggableBlockPluginProps {
+  anchorElem: HTMLElement;
+}
+
+export function DraggableBlockPlugin({
+  anchorElem,
+}: DraggableBlockPluginProps): JSX.Element | null {
+  const [editor] = useLexicalComposerContext();
+  const menuRef = useRef<HTMLDivElement>(null);
+  const dropIndicatorRef = useRef<HTMLDivElement>(null);
+  const draggingBlockElemRef = useRef<HTMLElement | null>(null);
+  const targetBlockElemRef = useRef<HTMLElement | null>(null);
+  const isDraggingRef = useRef(false);
+
+  // Track the hovered block element for showing the drag handle
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (isOnMenu(target) || isDraggingRef.current) return;
+
+      const blockElem = getBlockElement(anchorElem, editor, event);
+      if (blockElem && menuRef.current) {
+        setMenuPosition(menuRef.current, blockElem, anchorElem);
+        targetBlockElemRef.current = blockElem;
+      } else if (menuRef.current) {
+        menuRef.current.style.opacity = "0";
+        targetBlockElemRef.current = null;
+      }
+    },
+    [anchorElem, editor]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    if (menuRef.current && !isDraggingRef.current) {
+      menuRef.current.style.opacity = "0";
+      targetBlockElemRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    anchorElem.addEventListener("mousemove", handleMouseMove);
+    anchorElem.addEventListener("mouseleave", handleMouseLeave);
+    return () => {
+      anchorElem.removeEventListener("mousemove", handleMouseMove);
+      anchorElem.removeEventListener("mouseleave", handleMouseLeave);
+    };
+  }, [anchorElem, handleMouseMove, handleMouseLeave]);
+
+  const handleDragStart = useCallback(
+    (event: React.DragEvent) => {
+      const target = targetBlockElemRef.current;
+      if (!target) return;
+
+      const dataTransfer = event.dataTransfer;
+      if (!dataTransfer) return;
+
+      isDraggingRef.current = true;
+
+      // Find the Lexical node key for this DOM element
+      let nodeKey: string | null = null;
+      editor.read(() => {
+        const node = $getNearestNodeFromDOMNode(target);
+        if (node) {
+          nodeKey = node.getKey();
+        }
+      });
+
+      if (!nodeKey) return;
+
+      dataTransfer.setData(DRAG_DATA_FORMAT, nodeKey);
+      dataTransfer.effectAllowed = "move";
+
+      // Set drag image
+      const dragImage = target.cloneNode(true) as HTMLElement;
+      dragImage.style.opacity = "0.5";
+      dragImage.style.position = "absolute";
+      dragImage.style.top = "-1000px";
+      document.body.appendChild(dragImage);
+      dataTransfer.setDragImage(dragImage, 0, 0);
+      setTimeout(() => document.body.removeChild(dragImage), 0);
+
+      draggingBlockElemRef.current = target;
+      target.style.opacity = "0.5";
+    },
+    [editor]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    isDraggingRef.current = false;
+    if (draggingBlockElemRef.current) {
+      draggingBlockElemRef.current.style.opacity = "1";
+      draggingBlockElemRef.current = null;
+    }
+    if (dropIndicatorRef.current) {
+      dropIndicatorRef.current.style.opacity = "0";
+    }
+  }, []);
+
+  // Register drag-over and drop commands on the Lexical editor
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        DRAGOVER_COMMAND,
+        (event: DragEvent) => {
+          if (!event.dataTransfer?.types.includes(DRAG_DATA_FORMAT)) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          const blockElem = getBlockElement(anchorElem, editor, event);
+          if (!blockElem || !dropIndicatorRef.current) return true;
+
+          const blockRect = blockElem.getBoundingClientRect();
+          const isBelow = event.clientY > blockRect.top + blockRect.height / 2;
+
+          setDropIndicatorPosition(
+            dropIndicatorRef.current,
+            blockElem,
+            anchorElem,
+            isBelow
+          );
+
+          event.dataTransfer.dropEffect = "move";
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH
+      ),
+      editor.registerCommand(
+        DROP_COMMAND,
+        (event: DragEvent) => {
+          if (!event.dataTransfer?.types.includes(DRAG_DATA_FORMAT)) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          const nodeKey = event.dataTransfer.getData(DRAG_DATA_FORMAT);
+          if (!nodeKey) return true;
+
+          const blockElem = getBlockElement(anchorElem, editor, event);
+          if (!blockElem) return true;
+
+          const blockRect = blockElem.getBoundingClientRect();
+          const isBelow = event.clientY > blockRect.top + blockRect.height / 2;
+
+          editor.update(() => {
+            const draggedNode = $getNodeByKey(nodeKey);
+            if (!draggedNode) return;
+
+            const targetNode = $getNearestNodeFromDOMNode(blockElem);
+            if (!targetNode) return;
+
+            // Don't drop on self
+            if (draggedNode.getKey() === targetNode.getKey()) return;
+
+            // Remove from current position
+            draggedNode.remove();
+
+            // Insert at new position
+            if (isBelow) {
+              targetNode.insertAfter(draggedNode);
+            } else {
+              targetNode.insertBefore(draggedNode);
+            }
+          });
+
+          if (dropIndicatorRef.current) {
+            dropIndicatorRef.current.style.opacity = "0";
+          }
+
+          isDraggingRef.current = false;
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH
+      )
+    );
+  }, [anchorElem, editor]);
+
+  return createPortal(
+    <>
+      {/* Drag handle */}
+      <div
+        ref={menuRef}
+        className={`${DRAGGABLE_BLOCK_MENU_CLASSNAME} absolute z-10 cursor-grab opacity-0 transition-opacity duration-100 active:cursor-grabbing`}
+        draggable
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        aria-label="Drag to reorder block"
+        role="button"
+        tabIndex={0}
+      >
+        <GripVertical className="h-5 w-5 text-muted-foreground hover:text-foreground" />
+      </div>
+      {/* Drop indicator line */}
+      <div
+        ref={dropIndicatorRef}
+        className={`${DROP_INDICATOR_CLASSNAME} pointer-events-none absolute z-10 h-0.5 bg-accent opacity-0 transition-opacity duration-100`}
+      />
+    </>,
+    anchorElem
+  );
+}

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -29,6 +29,17 @@ import { SlashCommandPlugin } from "@/components/editor/slash-command-plugin";
 import { FloatingToolbarPlugin } from "@/components/editor/floating-toolbar-plugin";
 import { FloatingLinkEditorPlugin } from "@/components/editor/floating-link-editor-plugin";
 import { CodeHighlightPlugin } from "@/components/editor/code-highlight-plugin";
+import { DraggableBlockPlugin } from "@/components/editor/draggable-block-plugin";
+import { ImageNode } from "@/components/editor/image-node";
+import { ImagePlugin } from "@/components/editor/image-plugin";
+import { CalloutNode } from "@/components/editor/callout-node";
+import { CalloutPlugin } from "@/components/editor/callout-plugin";
+import {
+  CollapsibleContainerNode,
+  CollapsibleTitleNode,
+  CollapsibleContentNode,
+} from "@/components/editor/collapsible-node";
+import { CollapsiblePlugin } from "@/components/editor/collapsible-plugin";
 import { createClient } from "@/lib/supabase/client";
 
 const SAVE_DEBOUNCE_MS = 500;
@@ -144,6 +155,11 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
       CodeHighlightNode,
       LinkNode,
       HorizontalRuleNode,
+      ImageNode,
+      CalloutNode,
+      CollapsibleContainerNode,
+      CollapsibleTitleNode,
+      CollapsibleContentNode,
     ],
     onError: (error: Error) => {
       Sentry.captureException(error);
@@ -179,6 +195,9 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
         <ClickableLinkPlugin />
         <HorizontalRulePlugin />
         <CodeHighlightPlugin />
+        <ImagePlugin />
+        <CalloutPlugin />
+        <CollapsiblePlugin />
         {editorRef && <EditorRefPlugin editorRef={editorRef} />}
         <OnChangePlugin
           onChange={handleChange}
@@ -189,6 +208,7 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
           <>
             <FloatingToolbarPlugin anchorElem={floatingAnchorElem} />
             <FloatingLinkEditorPlugin anchorElem={floatingAnchorElem} />
+            <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
           </>
         )}
       </LexicalComposer>

--- a/src/components/editor/image-node.tsx
+++ b/src/components/editor/image-node.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import type { JSX } from "react";
+import { useCallback, useRef, useState } from "react";
+import type {
+  DOMExportOutput,
+  LexicalEditor,
+  LexicalNode,
+  NodeKey,
+  SerializedLexicalNode,
+  Spread,
+} from "lexical";
+import { $applyNodeReplacement, $getNodeByKey, DecoratorNode } from "lexical";
+
+export interface ImagePayload {
+  src: string;
+  altText: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+  key?: NodeKey;
+}
+
+export type SerializedImageNode = Spread<
+  {
+    src: string;
+    altText: string;
+    caption: string;
+    width: number | undefined;
+    height: number | undefined;
+  },
+  SerializedLexicalNode
+>;
+
+function ImageComponent({
+  src,
+  altText,
+  caption,
+  width,
+  height,
+  nodeKey,
+  editor,
+}: {
+  src: string;
+  altText: string;
+  caption: string;
+  width: number | undefined;
+  height: number | undefined;
+  nodeKey: NodeKey;
+  editor: LexicalEditor;
+}): JSX.Element {
+  const [currentCaption, setCurrentCaption] = useState(caption);
+  const [isEditing, setIsEditing] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleCaptionSave = useCallback(() => {
+    setIsEditing(false);
+    editor.update(() => {
+      const node = $getImageNodeByKey(nodeKey);
+      if (node) {
+        node.setCaption(currentCaption);
+      }
+    });
+  }, [editor, nodeKey, currentCaption]);
+
+  return (
+    <figure className="mt-3 flex flex-col items-center">
+      {/* eslint-disable-next-line @next/next/no-img-element -- Lexical DecoratorNode with user-uploaded dynamic URLs */}
+      <img
+        src={src}
+        alt={altText}
+        width={width}
+        height={height}
+        className="max-w-full"
+        draggable={false}
+      />
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={currentCaption}
+          onChange={(e) => setCurrentCaption(e.target.value)}
+          onBlur={handleCaptionSave}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleCaptionSave();
+            }
+          }}
+          className="mt-2 w-full max-w-md bg-transparent text-center text-xs text-muted-foreground outline-none placeholder:text-muted-foreground"
+          placeholder="Add a caption..."
+          autoFocus
+        />
+      ) : (
+        <figcaption
+          className="mt-2 cursor-pointer text-center text-xs text-muted-foreground hover:text-foreground"
+          onClick={() => setIsEditing(true)}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") setIsEditing(true);
+          }}
+        >
+          {currentCaption || "Add a caption..."}
+        </figcaption>
+      )}
+    </figure>
+  );
+}
+
+function $getImageNodeByKey(key: NodeKey): ImageNode | null {
+  const node = $getNodeByKey(key);
+  if (node instanceof ImageNode) return node;
+  return null;
+}
+
+export class ImageNode extends DecoratorNode<JSX.Element> {
+  __src: string;
+  __altText: string;
+  __caption: string;
+  __width: number | undefined;
+  __height: number | undefined;
+
+  static getType(): string {
+    return "image";
+  }
+
+  static clone(node: ImageNode): ImageNode {
+    return new ImageNode(
+      node.__src,
+      node.__altText,
+      node.__caption,
+      node.__width,
+      node.__height,
+      node.__key
+    );
+  }
+
+  static importJSON(serializedNode: SerializedImageNode): ImageNode {
+    return $createImageNode({
+      src: serializedNode.src,
+      altText: serializedNode.altText,
+      caption: serializedNode.caption,
+      width: serializedNode.width,
+      height: serializedNode.height,
+    });
+  }
+
+  constructor(
+    src: string,
+    altText: string,
+    caption?: string,
+    width?: number,
+    height?: number,
+    key?: NodeKey
+  ) {
+    super(key);
+    this.__src = src;
+    this.__altText = altText;
+    this.__caption = caption ?? "";
+    this.__width = width;
+    this.__height = height;
+  }
+
+  exportJSON(): SerializedImageNode {
+    return {
+      type: "image",
+      version: 1,
+      src: this.__src,
+      altText: this.__altText,
+      caption: this.__caption,
+      width: this.__width,
+      height: this.__height,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    const div = document.createElement("div");
+    div.className = "editor-image";
+    return div;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("img");
+    element.setAttribute("src", this.__src);
+    element.setAttribute("alt", this.__altText);
+    if (this.__width) element.setAttribute("width", String(this.__width));
+    if (this.__height) element.setAttribute("height", String(this.__height));
+    return { element };
+  }
+
+  setCaption(caption: string): void {
+    const writable = this.getWritable();
+    writable.__caption = caption;
+  }
+
+  decorate(editor: LexicalEditor): JSX.Element {
+    return (
+      <ImageComponent
+        src={this.__src}
+        altText={this.__altText}
+        caption={this.__caption}
+        width={this.__width}
+        height={this.__height}
+        nodeKey={this.getKey()}
+        editor={editor}
+      />
+    );
+  }
+}
+
+export function $createImageNode(payload: ImagePayload): ImageNode {
+  return $applyNodeReplacement(
+    new ImageNode(
+      payload.src,
+      payload.altText,
+      payload.caption,
+      payload.width,
+      payload.height,
+      payload.key
+    )
+  );
+}
+
+export function $isImageNode(
+  node: LexicalNode | null | undefined
+): node is ImageNode {
+  return node instanceof ImageNode;
+}

--- a/src/components/editor/image-plugin.tsx
+++ b/src/components/editor/image-plugin.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createParagraphNode,
+  $insertNodes,
+  COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_HIGH,
+  createCommand,
+  DRAGOVER_COMMAND,
+  DROP_COMMAND,
+  type LexicalCommand,
+} from "lexical";
+import { $createImageNode, type ImagePayload } from "@/components/editor/image-node";
+import { createClient } from "@/lib/supabase/client";
+
+export const INSERT_IMAGE_COMMAND: LexicalCommand<ImagePayload> =
+  createCommand("INSERT_IMAGE_COMMAND");
+
+const ACCEPTED_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+]);
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+async function uploadImage(file: File): Promise<string | null> {
+  if (!ACCEPTED_IMAGE_TYPES.has(file.type)) return null;
+  if (file.size > MAX_FILE_SIZE) return null;
+
+  const supabase = createClient();
+  const ext = file.name.split(".").pop() ?? "png";
+  const fileName = `${crypto.randomUUID()}.${ext}`;
+  const filePath = `uploads/${fileName}`;
+
+  const { error } = await supabase.storage
+    .from("page-images")
+    .upload(filePath, file, {
+      cacheControl: "3600",
+      upsert: false,
+    });
+
+  if (error) {
+    console.error("Image upload failed:", error.message);
+    return null;
+  }
+
+  const { data: urlData } = supabase.storage
+    .from("page-images")
+    .getPublicUrl(filePath);
+
+  return urlData.publicUrl;
+}
+
+export function ImagePlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  // Register INSERT_IMAGE_COMMAND
+  useEffect(() => {
+    return editor.registerCommand(
+      INSERT_IMAGE_COMMAND,
+      (payload: ImagePayload) => {
+        editor.update(() => {
+          const imageNode = $createImageNode(payload);
+          $insertNodes([imageNode]);
+
+          // Add a paragraph after the image so the user can continue typing
+          const paragraphNode = $createParagraphNode();
+          imageNode.insertAfter(paragraphNode);
+          paragraphNode.selectEnd();
+        });
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR
+    );
+  }, [editor]);
+
+  // Handle file drop onto the editor (image files only)
+  useEffect(() => {
+    return editor.registerCommand(
+      DROP_COMMAND,
+      (event: DragEvent) => {
+        const files = event.dataTransfer?.files;
+        if (!files || files.length === 0) return false;
+
+        const imageFiles = Array.from(files).filter((f) =>
+          ACCEPTED_IMAGE_TYPES.has(f.type)
+        );
+        if (imageFiles.length === 0) return false;
+
+        event.preventDefault();
+
+        for (const file of imageFiles) {
+          void uploadImage(file).then((url) => {
+            if (url) {
+              editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+                src: url,
+                altText: file.name,
+              });
+            }
+          });
+        }
+
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+  }, [editor]);
+
+  // Handle dragover for image files to show drop cursor
+  useEffect(() => {
+    return editor.registerCommand(
+      DRAGOVER_COMMAND,
+      (event: DragEvent) => {
+        const hasFiles = event.dataTransfer?.types.includes("Files");
+        if (hasFiles) {
+          event.preventDefault();
+          return true;
+        }
+        return false;
+      },
+      COMMAND_PRIORITY_HIGH
+    );
+  }, [editor]);
+
+  return null;
+}
+
+/** Opens a file picker and dispatches INSERT_IMAGE_COMMAND for the selected file. */
+export function openImagePicker(editor: ReturnType<typeof useLexicalComposerContext>[0]): void {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = "image/*";
+  input.onchange = async () => {
+    const file = input.files?.[0];
+    if (!file) return;
+
+    const url = await uploadImage(file);
+    if (url) {
+      editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+        src: url,
+        altText: file.name,
+      });
+    }
+  };
+  input.click();
+}

--- a/src/components/editor/slash-command-plugin.tsx
+++ b/src/components/editor/slash-command-plugin.tsx
@@ -34,8 +34,14 @@ import {
   Quote,
   Minus,
   Type,
+  ImageIcon,
+  MessageSquare,
+  ChevronRight,
 } from "lucide-react";
 import type { JSX, ReactElement } from "react";
+import { openImagePicker } from "@/components/editor/image-plugin";
+import { INSERT_CALLOUT_COMMAND } from "@/components/editor/callout-plugin";
+import { INSERT_COLLAPSIBLE_COMMAND } from "@/components/editor/collapsible-plugin";
 
 class SlashCommandOption extends MenuOption {
   title: string;
@@ -173,6 +179,27 @@ export function SlashCommandPlugin(): JSX.Element | null {
         icon: <Minus className="h-5 w-5" />,
         onSelect: () => {
           editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined);
+        },
+      }),
+      new SlashCommandOption("Image", {
+        description: "Upload an image",
+        icon: <ImageIcon className="h-5 w-5" />,
+        onSelect: () => {
+          openImagePicker(editor);
+        },
+      }),
+      new SlashCommandOption("Callout", {
+        description: "Highlighted info block",
+        icon: <MessageSquare className="h-5 w-5" />,
+        onSelect: () => {
+          editor.dispatchCommand(INSERT_CALLOUT_COMMAND, {});
+        },
+      }),
+      new SlashCommandOption("Toggle", {
+        description: "Collapsible section",
+        icon: <ChevronRight className="h-5 w-5" />,
+        onSelect: () => {
+          editor.dispatchCommand(INSERT_COLLAPSIBLE_COMMAND, undefined);
         },
       }),
     ];


### PR DESCRIPTION
Closes #29

## What

Adds advanced block types to the Lexical editor: drag-and-drop reordering, image upload, callout blocks, and collapsible/toggle blocks.

## How

**Drag-and-drop reordering** (`draggable-block-plugin.tsx`)
- Grip handle appears on hover to the left of each top-level block
- Drag handle initiates HTML5 drag with the Lexical node key as payload
- Drop indicator (2px `bg-accent` line) shows insertion position
- Registers `DRAGOVER_COMMAND` and `DROP_COMMAND` at high priority

**Image blocks** (`image-node.tsx`, `image-plugin.tsx`)
- `ImageNode` (DecoratorNode) renders a React component with `<figure>`, `<img>`, and editable `<figcaption>`
- Upload via file picker (slash command → `openImagePicker`) or drag-and-drop files onto editor
- Files uploaded to Supabase Storage `page-images` bucket; public URL stored in node state
- 5MB max file size, accepts PNG/JPEG/GIF/WebP/SVG

**Callout blocks** (`callout-node.tsx`, `callout-plugin.tsx`)
- `CalloutNode` (ElementNode) with emoji prefix + `bg-muted` container
- Emoji rendered via `registerMutationListener` as a non-editable `<span>`
- Supports variants (info/warning/success/error) for future styling
- Backspace at start collapses to paragraph

**Collapsible/toggle blocks** (`collapsible-node.tsx`, `collapsible-plugin.tsx`)
- Three-node structure: `CollapsibleContainerNode` (`<details>`), `CollapsibleTitleNode` (`<summary>`), `CollapsibleContentNode` (`<div>`)
- Native HTML5 `<details>` toggle behavior synced to Lexical state via `toggle` event listener
- Backspace at start of title unwraps the entire collapsible structure
- Inserted with default "Toggle title" / "Toggle content" placeholder text

**Slash command menu** — three new entries: Image, Callout, Toggle

All nodes implement `exportJSON()`/`importJSON()` for persistence in `pages.content` jsonb column.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 25/25 tests pass ✅
- All acceptance criteria verified locally

## Notes

- Image upload requires the `page-images` Supabase Storage bucket to exist. This is a runtime/admin configuration, not a database migration.
- The `@next/next/no-img-element` lint rule is suppressed for `ImageNode` because `next/image` cannot be used inside a Lexical DecoratorNode with dynamic user-uploaded URLs.