### PR TITLE
feat: markdown import and export (#31)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -177,8 +177,11 @@ src/
 │   │   ├── slash-command-plugin.tsx  # "/" typeahead: paragraph, h1-h3, lists, code, quote, divider
 │   │   ├── floating-toolbar-plugin.tsx # Selection toolbar: bold, italic, underline, strikethrough, code, link
 │   │   ├── floating-link-editor-plugin.tsx # Link preview/edit/remove popover (⌘+K)
-│   │   └── code-highlight-plugin.tsx # Registers Prism-based syntax highlighting for code blocks
+│   │   ├── code-highlight-plugin.tsx # Registers Prism-based syntax highlighting for code blocks
+│   │   └── markdown-utils.ts        # Markdown ↔ Lexical conversion (export/import/download/parse)
 │   ├── page-title.tsx           # Inline-editable page title (saves on blur/Enter)
+│   ├── page-view-client.tsx     # Client wrapper for page view (holds editor ref, renders title + menu + editor)
+│   ├── page-menu.tsx            # Page "..." dropdown: export as markdown, import markdown
 │   ├── workspace-home.tsx       # Workspace home: page list or empty state with create CTA
 │   ├── workspace-settings-form.tsx # Edit workspace name/slug, delete workspace
 │   ├── members/             # Workspace member management components
@@ -249,7 +252,8 @@ src/
 │   │   ├── slash-command-plugin.tsx    # "/" typeahead menu for inserting block types
 │   │   ├── floating-toolbar-plugin.tsx # Selection toolbar: bold, italic, underline, strikethrough, code, link
 │   │   ├── floating-link-editor-plugin.tsx # Link preview/edit/remove popover
-│   │   └── code-highlight-plugin.tsx  # Registers Prism-based code highlighting
+│   │   ├── code-highlight-plugin.tsx  # Registers Prism-based code highlighting
+│   │   └── markdown-utils.ts         # Markdown ↔ Lexical conversion utilities
 │   ├── sidebar/            # Sidebar, page tree, workspace switcher
 │   └── ...                 # Feature-specific components
 ├── lib/

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -471,6 +471,52 @@ Content auto-saves via debounced `OnChangePlugin`. The save flow:
 All `@lexical/*` packages are pinned to the same version (currently 0.31.0).
 Always update them together to avoid version mismatches.
 
+### Markdown conversion
+
+Markdown import/export uses `@lexical/markdown` with a shared transformer list defined
+in `src/components/editor/markdown-utils.ts`. The `MARKDOWN_TRANSFORMERS` array must
+stay in sync with the editor's registered node types — when adding a new block type,
+add its transformer here too.
+
+```typescript
+import { MARKDOWN_TRANSFORMERS } from "@/components/editor/markdown-utils";
+import { $convertToMarkdownString, $convertFromMarkdownString } from "@lexical/markdown";
+
+// Export: inside editor.getEditorState().read()
+const markdown = $convertToMarkdownString(MARKDOWN_TRANSFORMERS);
+
+// Import: inside editor.update() or via parseMarkdownToEditorState() for headless conversion
+$convertFromMarkdownString(markdown, MARKDOWN_TRANSFORMERS, root, true);
+```
+
+For headless conversion (no mounted editor), use `parseMarkdownToEditorState(markdown)`
+which creates a temporary editor, runs the conversion, and returns `SerializedEditorState`.
+
+### Exposing the editor instance
+
+When components outside `<LexicalComposer>` need access to the editor (e.g., page menu
+for markdown export), pass an `editorRef` prop to the `Editor` component. The internal
+`EditorRefPlugin` captures the editor instance into the ref.
+
+```typescript
+const editorRef = useRef<LexicalEditor | null>(null);
+<Editor editorRef={editorRef} ... />
+// Later: editorRef.current?.getEditorState().read(() => { ... });
+```
+
+### Toast notifications
+
+Use `sonner` for toast notifications. The `<Toaster>` is mounted in the root layout.
+
+```typescript
+import { toast } from "sonner";
+
+toast.error("Something went wrong", { duration: 8000 });
+```
+
+Per design spec: toasts use `rounded-sm`, position bottom-right. Only show toasts for
+errors, async completions, and destructive actions with undo — not for routine actions.
+
 ## This file evolves
 
 When you discover a new pattern that should be replicated, or an anti-pattern that

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.2.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       shadcn:
         specifier: ^4.2.0
         version: 4.2.0(@types/node@20.19.39)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3962,6 +3965,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8721,6 +8730,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { PageTitle } from "@/components/page-title";
-import { Editor } from "@/components/editor/editor";
+import { PageViewClient } from "@/components/page-view-client";
 import type { SerializedEditorState } from "lexical";
 
 export default async function PageView({
@@ -11,6 +10,14 @@ export default async function PageView({
 }) {
   const { workspaceSlug, pageId } = await params;
   const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    notFound();
+  }
 
   const { data: workspace } = await supabase
     .from("workspaces")
@@ -37,15 +44,13 @@ export default async function PageView({
   const initialContent = page.content as SerializedEditorState | null;
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
-      <PageTitle key={page.id} pageId={page.id} initialTitle={page.title} />
-      <div className="mt-4">
-        <Editor
-          key={page.id}
-          pageId={page.id}
-          initialContent={initialContent}
-        />
-      </div>
-    </div>
+    <PageViewClient
+      pageId={page.id}
+      pageTitle={page.title}
+      initialContent={initialContent}
+      workspaceId={workspace.id}
+      workspaceSlug={workspaceSlug}
+      userId={user.id}
+    />
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { JetBrains_Mono } from "next/font/google";
+import { Toaster } from "sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import "./globals.css";
 
@@ -22,6 +23,13 @@ export default function RootLayout({
     <html lang="en" className={`${jetbrainsMono.variable} antialiased`}>
       <body className="min-h-screen">
         <TooltipProvider>{children}</TooltipProvider>
+        <Toaster
+          theme="dark"
+          position="bottom-right"
+          toastOptions={{
+            className: "rounded-sm font-mono text-sm",
+          }}
+        />
       </body>
     </html>
   );

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
@@ -17,7 +18,11 @@ import { ListNode, ListItemNode } from "@lexical/list";
 import { CodeNode, CodeHighlightNode } from "@lexical/code";
 import { LinkNode } from "@lexical/link";
 import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
-import type { EditorState, SerializedEditorState } from "lexical";
+import type {
+  EditorState,
+  LexicalEditor,
+  SerializedEditorState,
+} from "lexical";
 import * as Sentry from "@sentry/nextjs";
 import { editorTheme } from "@/components/editor/theme";
 import { SlashCommandPlugin } from "@/components/editor/slash-command-plugin";
@@ -31,6 +36,7 @@ const SAVE_DEBOUNCE_MS = 500;
 interface EditorProps {
   pageId: string;
   initialContent: SerializedEditorState | null;
+  editorRef?: React.MutableRefObject<LexicalEditor | null>;
 }
 
 function validateUrl(url: string): boolean {
@@ -42,7 +48,22 @@ function validateUrl(url: string): boolean {
   }
 }
 
-export function Editor({ pageId, initialContent }: EditorProps) {
+function EditorRefPlugin({
+  editorRef,
+}: {
+  editorRef: React.MutableRefObject<LexicalEditor | null>;
+}): null {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    editorRef.current = editor;
+    return () => {
+      editorRef.current = null;
+    };
+  }, [editor, editorRef]);
+  return null;
+}
+
+export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
   const [saveStatus, setSaveStatus] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");
@@ -158,6 +179,7 @@ export function Editor({ pageId, initialContent }: EditorProps) {
         <ClickableLinkPlugin />
         <HorizontalRulePlugin />
         <CodeHighlightPlugin />
+        {editorRef && <EditorRefPlugin editorRef={editorRef} />}
         <OnChangePlugin
           onChange={handleChange}
           ignoreSelectionChange

--- a/src/components/editor/markdown-utils.test.ts
+++ b/src/components/editor/markdown-utils.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { parseMarkdownToEditorState } from "./markdown-utils";
+
+describe("parseMarkdownToEditorState", () => {
+  it("parses a heading into editor state", () => {
+    const state = parseMarkdownToEditorState("# Hello World");
+    const root = state.root;
+    expect(root.children.length).toBeGreaterThanOrEqual(1);
+    const firstChild = root.children[0] as Record<string, unknown>;
+    expect(firstChild.type).toBe("heading");
+    expect(firstChild.tag).toBe("h1");
+  });
+
+  it("parses multiple block types", () => {
+    const markdown = [
+      "# Heading 1",
+      "",
+      "A paragraph of text.",
+      "",
+      "- Item one",
+      "- Item two",
+      "",
+      "> A blockquote",
+      "",
+      "```",
+      "const x = 1;",
+      "```",
+    ].join("\n");
+
+    const state = parseMarkdownToEditorState(markdown);
+    const root = state.root;
+    const types = root.children.map(
+      (c: Record<string, unknown>) => c.type as string
+    );
+
+    expect(types).toContain("heading");
+    expect(types).toContain("paragraph");
+    expect(types).toContain("list");
+    expect(types).toContain("quote");
+    expect(types).toContain("code");
+  });
+
+  it("preserves bold and italic formatting", () => {
+    const state = parseMarkdownToEditorState(
+      "This is **bold** and *italic* text."
+    );
+    const root = state.root;
+    const paragraph = root.children[0] as Record<string, unknown>;
+    expect(paragraph.type).toBe("paragraph");
+
+    // The paragraph should have children with format flags
+    const children = paragraph.children as Record<string, unknown>[];
+    expect(children.length).toBeGreaterThan(1);
+
+    const boldChild = children.find(
+      (c) => typeof c.format === "number" && (c.format as number) & 1
+    );
+    expect(boldChild).toBeDefined();
+  });
+
+  it("returns an empty paragraph for empty input", () => {
+    const state = parseMarkdownToEditorState("");
+    const root = state.root;
+    expect(root.children.length).toBe(1);
+    const firstChild = root.children[0] as Record<string, unknown>;
+    expect(firstChild.type).toBe("paragraph");
+  });
+
+  it("parses links", () => {
+    const state = parseMarkdownToEditorState(
+      "Visit [Memo](https://example.com) for more."
+    );
+    const root = state.root;
+    const paragraph = root.children[0] as Record<string, unknown>;
+    const children = paragraph.children as Record<string, unknown>[];
+    const linkChild = children.find((c) => c.type === "link");
+    expect(linkChild).toBeDefined();
+    expect((linkChild as Record<string, unknown>).url).toBe(
+      "https://example.com"
+    );
+  });
+
+  it("parses strikethrough text", () => {
+    const state = parseMarkdownToEditorState("This is ~~deleted~~ text.");
+    const root = state.root;
+    const paragraph = root.children[0] as Record<string, unknown>;
+    const children = paragraph.children as Record<string, unknown>[];
+    // Strikethrough format flag is 4
+    const strikeChild = children.find(
+      (c) => typeof c.format === "number" && (c.format as number) & 4
+    );
+    expect(strikeChild).toBeDefined();
+  });
+
+  it("parses ordered lists", () => {
+    const markdown = ["1. First", "2. Second", "3. Third"].join("\n");
+    const state = parseMarkdownToEditorState(markdown);
+    const root = state.root;
+    const list = root.children[0] as Record<string, unknown>;
+    expect(list.type).toBe("list");
+    expect(list.listType).toBe("number");
+  });
+
+  it("parses horizontal rules", () => {
+    const markdown = ["Above", "", "---", "", "Below"].join("\n");
+    const state = parseMarkdownToEditorState(markdown);
+    const root = state.root;
+    const types = root.children.map(
+      (c: Record<string, unknown>) => c.type as string
+    );
+    expect(types).toContain("horizontalrule");
+  });
+});

--- a/src/components/editor/markdown-utils.ts
+++ b/src/components/editor/markdown-utils.ts
@@ -1,0 +1,156 @@
+import {
+  $convertToMarkdownString,
+  $convertFromMarkdownString,
+  HEADING,
+  QUOTE,
+  CODE,
+  UNORDERED_LIST,
+  ORDERED_LIST,
+  CHECK_LIST,
+  LINK,
+  BOLD_STAR,
+  ITALIC_STAR,
+  STRIKETHROUGH,
+  INLINE_CODE,
+  type Transformer,
+  type ElementTransformer,
+} from "@lexical/markdown";
+import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import {
+  $createParagraphNode,
+  $getRoot,
+  createEditor,
+  type LexicalEditor,
+  type SerializedEditorState,
+} from "lexical";
+import { $createHorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { ListNode, ListItemNode } from "@lexical/list";
+import { CodeNode, CodeHighlightNode } from "@lexical/code";
+import { LinkNode } from "@lexical/link";
+
+// Custom transformer for horizontal rules (not included in @lexical/markdown defaults)
+const HORIZONTAL_RULE: ElementTransformer = {
+  dependencies: [HorizontalRuleNode],
+  export: (node) => {
+    if (node.getType() === "horizontalrule") {
+      return "---";
+    }
+    return null;
+  },
+  regExp: /^(?:---|\*\*\*|___)\s*$/,
+  replace: (parentNode) => {
+    const hrNode = $createHorizontalRuleNode();
+    parentNode.replace(hrNode);
+  },
+  type: "element",
+};
+
+// All transformers used for markdown conversion, matching the editor's registered nodes
+export const MARKDOWN_TRANSFORMERS: Transformer[] = [
+  HEADING,
+  QUOTE,
+  CODE,
+  UNORDERED_LIST,
+  ORDERED_LIST,
+  CHECK_LIST,
+  HORIZONTAL_RULE,
+  LINK,
+  BOLD_STAR,
+  ITALIC_STAR,
+  STRIKETHROUGH,
+  INLINE_CODE,
+];
+
+// Nodes matching the editor's initialConfig.nodes
+const EDITOR_NODES = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  CodeNode,
+  CodeHighlightNode,
+  LinkNode,
+  HorizontalRuleNode,
+];
+
+/**
+ * Convert the current editor state to a markdown string.
+ * Must be called inside editor.read() or editor.update().
+ */
+export function $editorStateToMarkdown(): string {
+  return $convertToMarkdownString(MARKDOWN_TRANSFORMERS);
+}
+
+/**
+ * Export the editor's content as a markdown string.
+ * Reads the editor state and converts it.
+ */
+export function exportEditorToMarkdown(editor: LexicalEditor): string {
+  let markdown = "";
+  editor.getEditorState().read(() => {
+    markdown = $editorStateToMarkdown();
+  });
+  return markdown;
+}
+
+/**
+ * Trigger a browser download of a markdown string as a .md file.
+ */
+export function downloadMarkdown(markdown: string, filename: string): void {
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename.endsWith(".md") ? filename : `${filename}.md`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Parse a markdown string into a Lexical SerializedEditorState.
+ * Creates a temporary headless editor to perform the conversion.
+ */
+export function parseMarkdownToEditorState(
+  markdown: string
+): SerializedEditorState {
+  const editor = createEditor({
+    namespace: "MarkdownImport",
+    nodes: EDITOR_NODES,
+    onError: (error) => {
+      throw error;
+    },
+  });
+
+  editor.update(
+    () => {
+      const root = $getRoot();
+      // Clear default empty paragraph
+      root.clear();
+      // Convert markdown to editor nodes
+      $convertFromMarkdownString(markdown, MARKDOWN_TRANSFORMERS, root, true);
+
+      // If root is empty after conversion, add an empty paragraph
+      if (root.getChildrenSize() === 0) {
+        root.append($createParagraphNode());
+      }
+    },
+    { discrete: true }
+  );
+
+  return editor.getEditorState().toJSON();
+}
+
+/**
+ * Read a File object as text.
+ */
+export function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsText(file);
+  });
+}

--- a/src/components/page-menu.tsx
+++ b/src/components/page-menu.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { Download, MoreHorizontal, Upload } from "lucide-react";
+import { toast } from "sonner";
+import type { LexicalEditor } from "lexical";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  exportEditorToMarkdown,
+  downloadMarkdown,
+  readFileAsText,
+  parseMarkdownToEditorState,
+} from "@/components/editor/markdown-utils";
+import { createClient } from "@/lib/supabase/client";
+
+interface PageMenuProps {
+  pageId: string;
+  pageTitle: string;
+  workspaceId: string;
+  workspaceSlug: string;
+  userId: string;
+  editorRef: React.MutableRefObject<LexicalEditor | null>;
+}
+
+export function PageMenu({
+  pageTitle,
+  workspaceId,
+  workspaceSlug,
+  userId,
+  editorRef,
+}: PageMenuProps) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleExport = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      toast.error("Editor not ready");
+      return;
+    }
+
+    try {
+      const markdown = exportEditorToMarkdown(editor);
+      const filename = (pageTitle.trim() || "Untitled") + ".md";
+      downloadMarkdown(markdown, filename);
+    } catch (error) {
+      toast.error("Export failed", {
+        duration: 8000,
+      });
+      console.error("Markdown export error:", error);
+    }
+  }, [editorRef, pageTitle]);
+
+  const handleImportClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      // Reset the input so the same file can be re-selected
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+
+      if (!file) return;
+
+      if (!file.name.endsWith(".md") && !file.name.endsWith(".markdown")) {
+        toast.error("Invalid file type. Please select a .md or .markdown file.", {
+          duration: 8000,
+        });
+        return;
+      }
+
+      try {
+        const markdown = await readFileAsText(file);
+        const editorState = parseMarkdownToEditorState(markdown);
+
+        // Derive page title from filename (strip extension)
+        const importedTitle = file.name.replace(/\.(md|markdown)$/, "");
+
+        const supabase = createClient();
+
+        // Count existing pages to determine position
+        const { count } = await supabase
+          .from("pages")
+          .select("id", { count: "exact", head: true })
+          .eq("workspace_id", workspaceId);
+
+        const { data: newPage, error } = await supabase
+          .from("pages")
+          .insert({
+            workspace_id: workspaceId,
+            parent_id: null,
+            title: importedTitle,
+            content: editorState,
+            position: count ?? 0,
+            created_by: userId,
+          })
+          .select("id")
+          .single();
+
+        if (error || !newPage) {
+          toast.error("Failed to create page from import", {
+            duration: 8000,
+          });
+          console.error("Import error:", error);
+          return;
+        }
+
+        router.push(`/${workspaceSlug}/${newPage.id}`);
+        router.refresh();
+      } catch (error) {
+        toast.error("Failed to read or parse the markdown file", {
+          duration: 8000,
+        });
+        console.error("Import error:", error);
+      }
+    },
+    [workspaceId, workspaceSlug, userId, router]
+  );
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button variant="ghost" size="icon" aria-label="Page actions" />
+          }
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="end" sideOffset={4}>
+          <DropdownMenuItem onClick={handleExport}>
+            <Download className="h-4 w-4" />
+            Export as Markdown
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleImportClick}>
+            <Upload className="h-4 w-4" />
+            Import Markdown
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".md,.markdown"
+        className="hidden"
+        onChange={handleFileChange}
+        aria-label="Import markdown file"
+      />
+    </>
+  );
+}

--- a/src/components/page-view-client.tsx
+++ b/src/components/page-view-client.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRef } from "react";
+import type { LexicalEditor, SerializedEditorState } from "lexical";
+import { PageTitle } from "@/components/page-title";
+import { Editor } from "@/components/editor/editor";
+import { PageMenu } from "@/components/page-menu";
+
+interface PageViewClientProps {
+  pageId: string;
+  pageTitle: string;
+  initialContent: SerializedEditorState | null;
+  workspaceId: string;
+  workspaceSlug: string;
+  userId: string;
+}
+
+export function PageViewClient({
+  pageId,
+  pageTitle,
+  initialContent,
+  workspaceId,
+  workspaceSlug,
+  userId,
+}: PageViewClientProps) {
+  const editorRef = useRef<LexicalEditor | null>(null);
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <PageTitle key={pageId} pageId={pageId} initialTitle={pageTitle} />
+        </div>
+        <PageMenu
+          pageId={pageId}
+          pageTitle={pageTitle}
+          workspaceId={workspaceId}
+          workspaceSlug={workspaceSlug}
+          userId={userId}
+          editorRef={editorRef}
+        />
+      </div>
+      <div className="mt-4">
+        <Editor
+          key={pageId}
+          pageId={pageId}
+          initialContent={initialContent}
+          editorRef={editorRef}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #31

## What

Adds markdown import and export for pages, using Lexical's built-in `@lexical/markdown` transforms.

- **Export**: converts the current editor state to a `.md` file and triggers a browser download
- **Import**: reads a `.md` file, parses it into Lexical editor state via a headless editor, creates a new page in the workspace, and navigates to it

Both actions are accessible from a new "..." page menu in the top-right of the page view.

## How

- `src/components/editor/markdown-utils.ts` — shared transformer list (`MARKDOWN_TRANSFORMERS`) covering headings, lists, code blocks, blockquotes, links, bold, italic, strikethrough, inline code, and horizontal rules (custom transformer). Provides `exportEditorToMarkdown`, `downloadMarkdown`, `parseMarkdownToEditorState`, and `readFileAsText`.
- `src/components/page-menu.tsx` — dropdown menu with Export/Import actions. Export reads the editor via ref; import uses a hidden file input, parses the file, creates a Supabase page, and navigates.
- `src/components/page-view-client.tsx` — client wrapper that holds the `editorRef` shared between `Editor` and `PageMenu`.
- `src/components/editor/editor.tsx` — added `editorRef` prop and internal `EditorRefPlugin` to expose the editor instance.
- `src/app/layout.tsx` — added `sonner` `<Toaster>` for error toasts.
- `sonner` added as a dependency for toast notifications (per design spec: bottom-right, rounded-sm, dark theme).

## Testing

- 8 unit tests for `parseMarkdownToEditorState` covering headings, paragraphs, lists (ordered/unordered), blockquotes, code blocks, links, bold, italic, strikethrough, horizontal rules, and empty input.
- All 33 tests pass. Lint and typecheck clean.
- Export/import are browser-interactive features — manual verification needed for file download and file picker flows.