### PR TITLE
fix(db): qualify cross-function calls in search migration

### DIFF
--- a/supabase/migrations/20260415111351_add_page_search_vector.sql
+++ b/supabase/migrations/20260415111351_add_page_search_vector.sql
@@ -60,7 +60,7 @@ as $$
 begin
   return (
     setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
-    setweight(to_tsvector('english', coalesce(extract_text_from_lexical(content), '')), 'B')
+    setweight(to_tsvector('english', coalesce(public.extract_text_from_lexical(content), '')), 'B')
   );
 end;
 $$;
@@ -132,7 +132,7 @@ begin
       p.icon,
       ts_headline(
         'english',
-        coalesce(p.title, '') || ' ' || coalesce(extract_text_from_lexical(p.content), ''),
+        coalesce(p.title, '') || ' ' || coalesce(public.extract_text_from_lexical(p.content), ''),
         tsquery_val,
         'StartSel=<<, StopSel=>>, MaxWords=35, MinWords=15, MaxFragments=1'
       ) as snippet,


### PR DESCRIPTION
## Problem

The **Deploy Migrations** workflow has failed on every push to `main` since PR #53 was merged — 4 consecutive failures, all with:

```
ERROR: function extract_text_from_lexical(jsonb) does not exist (SQLSTATE 42883)
```

The search migration (`20260415111351_add_page_search_vector.sql`) has never been applied to production.

## Root Cause

Both `page_search_vector` and `search_pages` functions use `set search_path = ''` (a Supabase security best practice), but call `extract_text_from_lexical(content)` without schema qualification. With an empty search path, PostgreSQL cannot resolve the unqualified function name.

The PR dry-run passed because `supabase db push --dry-run` only checks which migrations are pending — it doesn't execute the SQL.

## Fix

Prefix cross-function calls with `public.` so they resolve correctly under an empty search path. Self-recursive calls within `extract_text_from_lexical` are unaffected (a function's own name is always resolvable during execution).

Closes #53's deployment gap — no new issue created since this is a direct fix for the broken migration.