### PR TITLE
fix(db): explicitly create search functions in public schema

### DIFF
--- a/supabase/migrations/20260415111351_add_page_search_vector.sql
+++ b/supabase/migrations/20260415111351_add_page_search_vector.sql
@@ -1,4 +1,8 @@
 -- Full-text search on pages: extract text from Lexical JSON, build tsvector, index with GIN.
+--
+-- All functions are explicitly created in the public schema so that
+-- cross-function calls resolve correctly regardless of the session's
+-- search_path (Supabase migration runners may use a non-public default).
 
 -- =============================================================================
 -- 1. Function to extract plain text from Lexical editor JSON
@@ -7,7 +11,7 @@
 -- type = "text" under a "text" key. This function recursively walks the
 -- JSON tree and concatenates all text values separated by spaces.
 
-create or replace function extract_text_from_lexical(content jsonb)
+create or replace function public.extract_text_from_lexical(content jsonb)
 returns text
 language plpgsql
 immutable
@@ -32,14 +36,14 @@ begin
   if children is not null and jsonb_typeof(children) = 'array' then
     for child in select jsonb_array_elements(children)
     loop
-      result := result || extract_text_from_lexical(child);
+      result := result || public.extract_text_from_lexical(child);
     end loop;
   end if;
 
   -- Lexical wraps content in { root: { children: [...] } }
   -- Handle the root wrapper
   if content ? 'root' then
-    result := result || extract_text_from_lexical(content -> 'root');
+    result := result || public.extract_text_from_lexical(content -> 'root');
   end if;
 
   return result;
@@ -51,7 +55,7 @@ $$;
 -- =============================================================================
 -- Title gets weight A (highest), content text gets weight B.
 
-create or replace function page_search_vector(title text, content jsonb)
+create or replace function public.page_search_vector(title text, content jsonb)
 returns tsvector
 language plpgsql
 immutable
@@ -69,15 +73,15 @@ $$;
 -- 3. Generated column on pages table
 -- =============================================================================
 
-alter table pages
+alter table public.pages
   add column search_vector tsvector
-  generated always as (page_search_vector(title, content)) stored;
+  generated always as (public.page_search_vector(title, content)) stored;
 
 -- =============================================================================
 -- 4. GIN index for fast full-text search
 -- =============================================================================
 
-create index pages_search_idx on pages using gin (search_vector);
+create index pages_search_idx on public.pages using gin (search_vector);
 
 -- =============================================================================
 -- 5. Search function — called via supabase.rpc('search_pages', ...)
@@ -85,7 +89,7 @@ create index pages_search_idx on pages using gin (search_vector);
 -- Returns matching pages within a workspace, ranked by relevance.
 -- Includes a text snippet from the content for display in search results.
 
-create or replace function search_pages(
+create or replace function public.search_pages(
   query text,
   ws_id uuid,
   result_limit integer default 20


### PR DESCRIPTION
## Problem

PR #66 added `public.` to cross-function *calls* but the `CREATE FUNCTION` statements themselves had no schema prefix. On Supabase hosted projects the migration runner's `search_path` may not default to `public`, so the functions were created in the wrong schema while the qualified calls pointed at `public.extract_text_from_lexical` — which didn't exist there.

The Deploy Migrations workflow has now failed on **5 consecutive pushes** to `main`, including the PR #66 merge itself.

## Changes

### 1. Schema-qualify all DDL in the search migration

Prefix **all** statements with `public.`:
- `CREATE OR REPLACE FUNCTION public.extract_text_from_lexical`
- `CREATE OR REPLACE FUNCTION public.page_search_vector`
- `CREATE OR REPLACE FUNCTION public.search_pages`
- `ALTER TABLE public.pages`
- `CREATE INDEX ... ON public.pages`
- Generated column expression: `public.page_search_vector(title, content)`
- Recursive self-calls: `public.extract_text_from_lexical(child)` / `(content -> 'root')`

The migration is now fully schema-explicit and independent of the session's `search_path`.

### 2. Replace dry-run with staging DB validation

`supabase db push --dry-run` only lists pending migrations — it doesn't execute SQL. This is why the original bug passed PR checks but failed on deploy.

The PR job now:
1. Links to a **staging** Supabase project (`SUPABASE_STAGING_PROJECT_ID`)
2. Runs `supabase db reset --linked` to wipe staging to a clean state
3. Runs `supabase db push` to apply all migrations for real

This catches runtime SQL errors (missing functions, schema resolution, syntax in PL/pgSQL bodies) before merge.

**Requires two new repository secrets:**
- `SUPABASE_STAGING_PROJECT_ID` — project ref for the staging Supabase instance
- `SUPABASE_STAGING_DB_PASSWORD` — database password for the staging instance

A `concurrency` group serializes staging access so parallel PRs don't collide.