### PR TITLE
ci: replace dry-run with staging DB for PR migration checks

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -54,11 +54,11 @@ jobs:
 
       - name: Reset staging DB to clean state
         if: steps.check-secrets.outputs.skip == 'false'
-        run: supabase db reset --linked
+        run: supabase db reset --linked --yes
 
       - name: Push migrations to staging
         if: steps.check-secrets.outputs.skip == 'false'
-        run: supabase db push
+        run: supabase db push --yes
 
   # ---------------------------------------------------------------------------
   # Production deploy: runs on push to main
@@ -84,7 +84,7 @@ jobs:
         run: supabase link --project-ref $SUPABASE_PROJECT_ID
 
       - name: Deploy migrations
-        run: supabase db push
+        run: supabase db push --yes
 
       - name: Verify critical tables exist
         env:

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -15,7 +15,7 @@ jobs:
   # PR check: reset staging DB then push migrations for real execution
   # ---------------------------------------------------------------------------
   staging:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && secrets.SUPABASE_STAGING_PROJECT_ID != ''
     runs-on: ubuntu-latest
     # Only one staging validation at a time — later PRs queue behind earlier ones
     concurrency:

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -15,7 +15,7 @@ jobs:
   # PR check: reset staging DB then push migrations for real execution
   # ---------------------------------------------------------------------------
   staging:
-    if: github.event_name == 'pull_request' && secrets.SUPABASE_STAGING_PROJECT_ID != ''
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     # Only one staging validation at a time — later PRs queue behind earlier ones
     concurrency:
@@ -28,20 +28,36 @@ jobs:
       SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_STAGING_PROJECT_ID }}
 
     steps:
+      - name: Check staging secrets are configured
+        id: check-secrets
+        run: |
+          if [ -z "$SUPABASE_PROJECT_ID" ] || [ -z "$SUPABASE_DB_PASSWORD" ]; then
+            echo "⚠️ Staging secrets not configured — skipping migration validation."
+            echo "Add SUPABASE_STAGING_PROJECT_ID and SUPABASE_STAGING_DB_PASSWORD repository secrets to enable."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.check-secrets.outputs.skip == 'false'
 
       # supabase/setup-cli@v1 still targets node20; keep FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 until they ship a node24 version
       - uses: supabase/setup-cli@v1
+        if: steps.check-secrets.outputs.skip == 'false'
         with:
           version: latest
 
       - name: Link staging project
+        if: steps.check-secrets.outputs.skip == 'false'
         run: supabase link --project-ref $SUPABASE_PROJECT_ID
 
       - name: Reset staging DB to clean state
+        if: steps.check-secrets.outputs.skip == 'false'
         run: supabase db reset --linked
 
       - name: Push migrations to staging
+        if: steps.check-secrets.outputs.skip == 'false'
         run: supabase db push
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -11,14 +11,21 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  dry-run:
+  # ---------------------------------------------------------------------------
+  # PR check: reset staging DB then push migrations for real execution
+  # ---------------------------------------------------------------------------
+  staging:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # Only one staging validation at a time — later PRs queue behind earlier ones
+    concurrency:
+      group: staging-migrations
+      cancel-in-progress: false
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_STAGING_PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@v6
@@ -28,12 +35,18 @@ jobs:
         with:
           version: latest
 
-      - name: Link Supabase project
+      - name: Link staging project
         run: supabase link --project-ref $SUPABASE_PROJECT_ID
 
-      - name: Dry-run migrations
-        run: supabase db push --dry-run
+      - name: Reset staging DB to clean state
+        run: supabase db reset --linked
 
+      - name: Push migrations to staging
+        run: supabase db push
+
+  # ---------------------------------------------------------------------------
+  # Production deploy: runs on push to main
+  # ---------------------------------------------------------------------------
   deploy:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`supabase db push --dry-run` only lists pending migrations — it doesn't execute SQL. This is why the search migration bug (fixed in #66 and #67) passed PR checks but failed on every deploy. Runtime errors like missing functions, schema resolution failures, and PL/pgSQL body issues are invisible to the dry-run.

## Change

Replace the `dry-run` PR job with a `staging` job that validates migrations against a real Supabase database:

1. Links to a **staging** Supabase project
2. Runs `supabase db reset --linked` to wipe staging to a clean state
3. Runs `supabase db push` to apply all migrations for real

A `concurrency` group (`staging-migrations`, non-cancelling) serializes access so parallel PRs don't collide on the shared staging DB.

## Required setup

Two new repository secrets:
- **`SUPABASE_STAGING_PROJECT_ID`** — project ref for the staging Supabase instance
- **`SUPABASE_STAGING_DB_PASSWORD`** — database password for the staging instance

Create a free Supabase project for staging (no data needed — it's reset on every PR run).