### PR TITLE
fix(editor): drag handle hover zone + Playwright E2E infrastructure

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -319,11 +319,59 @@ Rules:
 
 ## Testing
 
+### Vitest (unit / integration / static analysis)
+
 - Unit tests go next to the file they test: `foo.test.ts` alongside `foo.ts`
 - Use Vitest: `import { describe, it, expect } from 'vitest'`
 - API route tests: test the route handler directly
 - Skip tests for components that are just layout/styling with no logic
-- Run before pushing: `pnpm lint && pnpm typecheck && pnpm test`
+
+### Playwright (E2E)
+
+E2E tests live in `e2e/` at the project root. Config: `playwright.config.ts`.
+
+```typescript
+// Unauthenticated test — uses base Playwright test
+import { test, expect } from "@playwright/test";
+
+test("sign-in page renders", async ({ page }) => {
+  await page.goto("/sign-in");
+  await expect(page.locator('input[type="email"]')).toBeVisible();
+});
+```
+
+```typescript
+// Authenticated test — uses the auth fixture
+import { test, expect } from "./fixtures/auth";
+
+test("editor loads on page", async ({ authenticatedPage: page }) => {
+  // authenticatedPage is already logged in
+  const editor = page.locator('[contenteditable="true"]');
+  await expect(editor).toBeVisible({ timeout: 10_000 });
+});
+```
+
+#### Selector conventions
+
+- Prefer `getByRole`, `getByLabel`, `getByText` over CSS selectors
+- For editor elements: `[contenteditable="true"]`, `[data-lexical-editor]`
+- For drag handles: `.memo-draggable-block-menu`
+- For floating UI: `[role="toolbar"]`, `[role="option"]`
+- Use `.filter({ hasText: ... })` to narrow generic selectors
+
+#### Test structure
+
+- One `describe` block per feature area
+- Use `test.beforeEach` for common navigation (e.g., opening a page)
+- Use `test.skip(true, "reason")` when preconditions aren't met (no pages, no button)
+- Timeouts: 10s for page loads, 3s for UI elements, 2s for state changes
+
+#### Running
+
+- All tests: `pnpm test:e2e`
+- Single file: `pnpm test:e2e -- e2e/editor-drag.spec.ts`
+- Authenticated tests require `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` env vars
+- Run before pushing: `pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e`
 
 ## Imports
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run unauthenticated E2E tests
         run: pnpm test:e2e -- e2e/auth.spec.ts
         env:
-          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.placeholder
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,17 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm test -- --run
+  e2e:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: npx playwright install --with-deps chromium
+      - name: Run unauthenticated E2E tests
+        run: pnpm test:e2e -- e2e/auth.spec.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - name: Run unauthenticated E2E tests
         run: pnpm test:e2e -- e2e/auth.spec.ts
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.placeholder

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/blob-report/
 
 # next.js
 /.next/

--- a/.ona/automations/bug-fixer.yaml
+++ b/.ona/automations/bug-fixer.yaml
@@ -102,9 +102,15 @@ action:
                 9. Fix the root cause. Do NOT fix symptoms.
                    - Follow every convention in AGENTS.md without exception.
                    - Add a regression test that would have caught this bug.
+                     For interaction bugs (drag-and-drop, floating UI, hover states, multi-step
+                     flows), add a Playwright E2E test in `e2e/`. Use the auth fixture from
+                     `e2e/fixtures/auth.ts` for authenticated tests. See `.agents/conventions.md`
+                     → Testing → Playwright for patterns.
+                     For logic/data bugs, add a Vitest unit or integration test.
                    - For database changes: `npx supabase migration new <name>`
                 10. Run the full CI check locally: `pnpm lint && pnpm typecheck && pnpm test`
-                11. Fix any errors before proceeding.
+                11. Run E2E tests: `pnpm test:e2e`
+                12. Fix any errors before proceeding.
 
                 ## Update Knowledge Base
 

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -139,8 +139,13 @@ action:
                 2. For each criterion, confirm your implementation satisfies it.
                    If a criterion cannot be verified locally (e.g., "works on mobile"), note it in the PR.
                 3. Run the full CI check: `pnpm lint && pnpm typecheck && pnpm test`
-                4. Fix any errors before proceeding.
-                5. If any acceptance criterion is NOT met, either fix it or explain in the PR body
+                4. If the feature involves interactive UI (drag-and-drop, floating toolbars/menus,
+                   multi-step flows), write E2E tests in `e2e/` using Playwright. Use the auth
+                   fixture from `e2e/fixtures/auth.ts` for authenticated tests. See
+                   `.agents/conventions.md` → Testing → Playwright for patterns.
+                5. Run E2E tests: `pnpm test:e2e`
+                6. Fix any errors before proceeding.
+                7. If any acceptance criterion is NOT met, either fix it or explain in the PR body
                    why it was descoped (and create a follow-up issue if needed).
 
                 ## Update Knowledge Base

--- a/.ona/automations/post-merge-verifier.yaml
+++ b/.ona/automations/post-merge-verifier.yaml
@@ -34,7 +34,16 @@ action:
 
                 Wait 90 seconds for Vercel to deploy the merge to production.
 
-                ## Step 3 — Run smoke tests
+                ## Step 3 — Run E2E test suite
+
+                First, run the project's E2E test suite against the live site:
+                  BASE_URL=https://memo.software-factory.dev pnpm test:e2e
+
+                If E2E tests fail, include the failures in the report (Step 4).
+                If E2E tests pass, still run the ad-hoc smoke tests below for routes
+                not yet covered by the E2E suite.
+
+                ## Step 3b — Run ad-hoc smoke tests
 
                 Write a Playwright script to /tmp/smoke-test.mjs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,11 +40,36 @@ metrics/           → Daily/weekly metrics snapshots
 
 ## Testing
 
-- Unit tests: utility functions, non-trivial logic
-- Integration tests: API routes
-- E2E (Playwright): critical user flows, new pages
+- Unit tests (Vitest): utility functions, non-trivial logic, API route handlers
+- Integration tests (Vitest): API routes with mocked Supabase
+- E2E tests (Playwright): interactive features, critical user flows, new pages
+- Static analysis tests (Vitest): design spec compliance checks on source code
 - Skip tests for trivial layout-only components
-- Run before pushing: `pnpm lint && pnpm typecheck && pnpm test`
+
+### When to write E2E tests
+
+- Drag-and-drop (editor blocks, sidebar pages)
+- Floating UI (toolbars, menus, popovers that appear/disappear based on user action)
+- Multi-step flows (auth, page creation, workspace switching)
+- Any feature where the bug would only manifest in a real browser (not jsdom)
+
+### When unit tests are sufficient
+
+- Pure functions and utilities
+- API route handlers (mock Supabase)
+- Data transformations (markdown conversion, tree building)
+- Component rendering without complex interaction
+
+### E2E test location
+
+- Config: `playwright.config.ts`
+- Tests: `e2e/` directory
+- Auth fixture: `e2e/fixtures/auth.ts` — provides `authenticatedPage` for tests needing login
+- Authenticated tests require `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` env vars
+
+### Running tests
+
+- Run before pushing: `pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e`
 
 ## Backlog
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Authentication", () => {
+  test("sign-in page renders with email and password inputs", async ({
+    page,
+  }) => {
+    await page.goto("/sign-in");
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign in/i })).toBeVisible();
+  });
+
+  test("sign-up page renders with display name, email, and password inputs", async ({
+    page,
+  }) => {
+    await page.goto("/sign-up");
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+    await expect(page.getByRole("button", { name: /sign up/i })).toBeVisible();
+  });
+
+  test("unauthenticated user is redirected to sign-in", async ({ page }) => {
+    // Try to access an authenticated route
+    await page.goto("/test-workspace");
+    await page.waitForURL(/sign-in/, { timeout: 10_000 });
+    expect(page.url()).toContain("/sign-in");
+  });
+
+  test("user can sign in and lands in a workspace", async ({ page }) => {
+    const email = process.env.TEST_USER_EMAIL;
+    const password = process.env.TEST_USER_PASSWORD;
+    if (!email || !password) {
+      test.skip(true, "TEST_USER_EMAIL / TEST_USER_PASSWORD not set");
+      return;
+    }
+
+    await page.goto("/sign-in");
+    await page.fill('input[type="email"]', email);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+
+    // Should redirect to a workspace (not stay on sign-in)
+    await page.waitForURL((url) => !url.pathname.includes("/sign-in"), {
+      timeout: 15_000,
+    });
+    expect(page.url()).not.toContain("/sign-in");
+  });
+
+  test("user can sign out", async ({ page }) => {
+    const email = process.env.TEST_USER_EMAIL;
+    const password = process.env.TEST_USER_PASSWORD;
+    if (!email || !password) {
+      test.skip(true, "TEST_USER_EMAIL / TEST_USER_PASSWORD not set");
+      return;
+    }
+
+    // Sign in first
+    await page.goto("/sign-in");
+    await page.fill('input[type="email"]', email);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((url) => !url.pathname.includes("/sign-in"), {
+      timeout: 15_000,
+    });
+
+    // Find and click sign out (in user menu)
+    // Try the user menu dropdown first
+    const userMenuTrigger = page.locator("button").filter({ hasText: /@|sign out/i });
+    if ((await userMenuTrigger.count()) > 0) {
+      await userMenuTrigger.first().click();
+      await page.waitForTimeout(300);
+    }
+
+    const signOutBtn = page.getByRole("menuitem", { name: /sign out/i }).or(
+      page.locator("button").filter({ hasText: /sign out/i })
+    );
+
+    if ((await signOutBtn.count()) > 0) {
+      await signOutBtn.first().click();
+      await page.waitForURL(/sign-in/, { timeout: 10_000 });
+      expect(page.url()).toContain("/sign-in");
+    }
+  });
+});

--- a/e2e/editor-drag.spec.ts
+++ b/e2e/editor-drag.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Editor drag-and-drop", () => {
+  test("drag handle appears when hovering a block", async ({
+    authenticatedPage: page,
+  }) => {
+    // Navigate to workspace, create or open a page
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    const hasPages = (await pageButton.count()) > 0;
+
+    if (!hasPages) {
+      // Create a new page via sidebar
+      const newPageBtn = page.getByRole("button", { name: /new page/i });
+      if ((await newPageBtn.count()) > 0) {
+        await newPageBtn.click();
+        await page.waitForURL((url) => url.pathname.split("/").filter(Boolean).length >= 2);
+      } else {
+        test.skip(true, "No pages and no create button found");
+        return;
+      }
+    } else {
+      await pageButton.first().click();
+      await page.waitForURL((url) => url.pathname.split("/").filter(Boolean).length >= 2);
+    }
+
+    // Wait for the editor to load
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Type some content to create blocks
+    await editor.click();
+    await editor.pressSequentially("First block");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("Second block");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("Third block");
+
+    // Wait for content to render
+    await page.waitForTimeout(500);
+
+    // Find the first block element and hover near it
+    const firstBlock = editor.locator("p").filter({ hasText: "First block" });
+    await expect(firstBlock).toBeVisible();
+
+    // Hover over the first block
+    await firstBlock.hover();
+
+    // The drag handle should become visible
+    const dragHandle = page.locator(".memo-draggable-block-menu");
+    await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
+  });
+
+  test("drag handle stays visible when moving cursor toward it", async ({
+    authenticatedPage: page,
+  }) => {
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageButton.count()) > 0) {
+      await pageButton.first().click();
+      await page.waitForURL((url) => url.pathname.split("/").filter(Boolean).length >= 2);
+    } else {
+      test.skip(true, "No pages available");
+      return;
+    }
+
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Ensure there's content
+    await editor.click();
+    await editor.pressSequentially("Drag test block");
+    await page.waitForTimeout(300);
+
+    const block = editor.locator("p").first();
+    await expect(block).toBeVisible();
+
+    // Hover the block to show the drag handle
+    const blockBox = await block.boundingBox();
+    if (!blockBox) {
+      test.skip(true, "Could not get block bounding box");
+      return;
+    }
+
+    await page.mouse.move(blockBox.x + blockBox.width / 2, blockBox.y + blockBox.height / 2);
+    await page.waitForTimeout(100);
+
+    const dragHandle = page.locator(".memo-draggable-block-menu");
+    await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
+
+    // Move cursor left toward the drag handle
+    const handleBox = await dragHandle.boundingBox();
+    if (!handleBox) {
+      test.skip(true, "Could not get drag handle bounding box");
+      return;
+    }
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.waitForTimeout(100);
+
+    // Handle should still be visible
+    await expect(dragHandle).toHaveCSS("opacity", "1");
+  });
+
+  test("blocks can be reordered via drag-and-drop", async ({
+    authenticatedPage: page,
+  }) => {
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageButton.count()) > 0) {
+      await pageButton.first().click();
+      await page.waitForURL((url) => url.pathname.split("/").filter(Boolean).length >= 2);
+    } else {
+      test.skip(true, "No pages available");
+      return;
+    }
+
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Clear and type fresh content
+    await editor.click();
+    await page.keyboard.press("Meta+a");
+    await page.keyboard.press("Backspace");
+    await editor.pressSequentially("AAA");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("BBB");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("CCC");
+    await page.waitForTimeout(300);
+
+    // Verify initial order
+    const paragraphs = editor.locator("p");
+    await expect(paragraphs.nth(0)).toContainText("AAA");
+    await expect(paragraphs.nth(1)).toContainText("BBB");
+    await expect(paragraphs.nth(2)).toContainText("CCC");
+
+    // Hover the first block to show drag handle
+    const firstBlock = paragraphs.nth(0);
+    await firstBlock.hover();
+    await page.waitForTimeout(200);
+
+    const dragHandle = page.locator(".memo-draggable-block-menu");
+    await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
+
+    // Drag the first block below the third block
+    const handleBox = await dragHandle.boundingBox();
+    const thirdBlock = paragraphs.nth(2);
+    const thirdBox = await thirdBlock.boundingBox();
+
+    if (!handleBox || !thirdBox) {
+      test.skip(true, "Could not get element bounding boxes");
+      return;
+    }
+
+    await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+    await page.mouse.down();
+    // Move to below the third block
+    await page.mouse.move(thirdBox.x + thirdBox.width / 2, thirdBox.y + thirdBox.height + 5, {
+      steps: 10,
+    });
+    await page.mouse.up();
+    await page.waitForTimeout(300);
+
+    // Verify new order: BBB, CCC, AAA
+    const updatedParagraphs = editor.locator("p");
+    await expect(updatedParagraphs.nth(0)).toContainText("BBB");
+    await expect(updatedParagraphs.nth(1)).toContainText("CCC");
+    await expect(updatedParagraphs.nth(2)).toContainText("AAA");
+  });
+});

--- a/e2e/editor-link.spec.ts
+++ b/e2e/editor-link.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Editor floating link editor", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageButton.count()) > 0) {
+      await pageButton.first().click();
+      await page.waitForURL((url) => url.pathname.split("/").filter(Boolean).length >= 2);
+    }
+  });
+
+  test("link button in toolbar creates a link", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("link text here");
+    await page.waitForTimeout(200);
+
+    // Select text
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Home");
+    await page.keyboard.up("Shift");
+
+    // Click link button in toolbar
+    const toolbar = page.locator('[role="toolbar"][aria-label="Text formatting"]');
+    await expect(toolbar).toBeVisible({ timeout: 3_000 });
+
+    const linkBtn = toolbar.getByRole("button", { name: /link/i });
+    await linkBtn.click();
+    await page.waitForTimeout(300);
+
+    // A link element should be created (with default https://)
+    const link = editor.locator("a");
+    await expect(link).toBeVisible({ timeout: 2_000 });
+  });
+
+  test("link editor appears when cursor is in a link", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Create a link first
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("click me");
+    await page.waitForTimeout(200);
+
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Home");
+    await page.keyboard.up("Shift");
+
+    // Use Cmd+K to create link
+    await page.keyboard.press("Meta+k");
+    await page.waitForTimeout(500);
+
+    // The link editor popover should appear with a URL input
+    const linkEditor = page.locator('input[type="url"]');
+    await expect(linkEditor).toBeVisible({ timeout: 3_000 });
+
+    // Type a URL and save
+    await linkEditor.fill("https://example.com");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(300);
+
+    // The link should now have the URL
+    const link = editor.locator('a[href="https://example.com"]');
+    await expect(link).toBeVisible({ timeout: 2_000 });
+  });
+
+  test("link can be removed via link editor", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Create a link
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("remove me");
+    await page.waitForTimeout(200);
+
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Home");
+    await page.keyboard.up("Shift");
+
+    await page.keyboard.press("Meta+k");
+    await page.waitForTimeout(500);
+
+    const linkInput = page.locator('input[type="url"]');
+    await expect(linkInput).toBeVisible({ timeout: 3_000 });
+    await linkInput.fill("https://example.com");
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(300);
+
+    // Click on the link to show the link editor
+    const link = editor.locator("a").first();
+    await expect(link).toBeVisible();
+    await link.click();
+    await page.waitForTimeout(300);
+
+    // Click remove button
+    const removeBtn = page.getByRole("button", { name: /remove link/i });
+    await expect(removeBtn).toBeVisible({ timeout: 3_000 });
+    await removeBtn.click();
+    await page.waitForTimeout(300);
+
+    // Link should be gone
+    const links = editor.locator("a");
+    await expect(links).toHaveCount(0, { timeout: 2_000 });
+  });
+});

--- a/e2e/editor-slash-commands.spec.ts
+++ b/e2e/editor-slash-commands.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Editor slash commands", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    // Navigate to a page with the editor
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageButton.count()) > 0) {
+      await pageButton.first().click();
+      await page.waitForURL((url) => url.pathname.split("/").filter(Boolean).length >= 2);
+    }
+  });
+
+  test("slash menu appears when typing /", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/");
+
+    // The slash command menu should appear
+    const menu = page.locator('[role="option"]').first();
+    await expect(menu).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("slash menu filters options on typing", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/head");
+
+    // Should show heading options, filtered
+    const options = page.locator('[role="option"]');
+    await expect(options.first()).toBeVisible({ timeout: 3_000 });
+
+    const count = await options.count();
+    // "head" should match Heading 1, Heading 2, Heading 3
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(count).toBeLessThanOrEqual(3);
+  });
+
+  test("selecting a heading option inserts a heading block", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/");
+
+    // Wait for menu
+    const heading1Option = page.locator('[role="option"]').filter({ hasText: "Heading 1" });
+    await expect(heading1Option).toBeVisible({ timeout: 3_000 });
+    await heading1Option.click();
+
+    // A heading element should now exist in the editor
+    const heading = editor.locator("h1");
+    await expect(heading).toBeVisible({ timeout: 2_000 });
+  });
+
+  test("slash menu is keyboard navigable", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/");
+
+    const options = page.locator('[role="option"]');
+    await expect(options.first()).toBeVisible({ timeout: 3_000 });
+
+    // First option should be selected by default
+    await expect(options.first()).toHaveClass(/bg-white/);
+
+    // Arrow down should move selection
+    await page.keyboard.press("ArrowDown");
+    await expect(options.nth(1)).toHaveClass(/bg-white/);
+
+    // Escape should close the menu
+    await page.keyboard.press("Escape");
+    await expect(options.first()).not.toBeVisible({ timeout: 2_000 });
+  });
+});

--- a/e2e/editor-toolbar.spec.ts
+++ b/e2e/editor-toolbar.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Editor floating toolbar", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageButton.count()) > 0) {
+      await pageButton.first().click();
+      await page.waitForURL((url) => url.pathname.split("/").filter(Boolean).length >= 2);
+    }
+  });
+
+  test("toolbar appears on text selection", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Type some text
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("Select this text for toolbar");
+    await page.waitForTimeout(200);
+
+    // Select the text
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Home");
+    await page.keyboard.up("Shift");
+
+    // Toolbar should appear
+    const toolbar = page.locator('[role="toolbar"][aria-label="Text formatting"]');
+    await expect(toolbar).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("bold button toggles bold formatting", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("bold me");
+    await page.waitForTimeout(200);
+
+    // Select "bold me"
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Home");
+    await page.keyboard.up("Shift");
+
+    const toolbar = page.locator('[role="toolbar"][aria-label="Text formatting"]');
+    await expect(toolbar).toBeVisible({ timeout: 3_000 });
+
+    // Click bold button
+    const boldBtn = toolbar.getByRole("button", { name: /bold/i });
+    await boldBtn.click();
+
+    // The bold button should now be active (pressed)
+    await expect(boldBtn).toHaveAttribute("aria-pressed", "true");
+
+    // The text should be wrapped in a bold element
+    const boldText = editor.locator("strong");
+    await expect(boldText).toContainText("bold me");
+  });
+
+  test("toolbar disappears when selection is collapsed", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("deselect test");
+    await page.waitForTimeout(200);
+
+    // Select text
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Home");
+    await page.keyboard.up("Shift");
+
+    const toolbar = page.locator('[role="toolbar"][aria-label="Text formatting"]');
+    await expect(toolbar).toBeVisible({ timeout: 3_000 });
+
+    // Click somewhere to collapse selection
+    await editor.click();
+    await page.waitForTimeout(300);
+
+    // Toolbar should disappear
+    await expect(toolbar).not.toBeVisible({ timeout: 2_000 });
+  });
+
+  test("keyboard shortcut Cmd+B applies bold", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await editor.pressSequentially("shortcut bold");
+    await page.waitForTimeout(200);
+
+    // Select text
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("Home");
+    await page.keyboard.up("Shift");
+
+    // Apply bold via keyboard shortcut
+    await page.keyboard.press("Meta+b");
+    await page.waitForTimeout(200);
+
+    const boldText = editor.locator("strong");
+    await expect(boldText).toContainText("shortcut bold");
+  });
+});

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,35 @@
+import { test as base, type Page } from "@playwright/test";
+
+/**
+ * Extends the base Playwright test with an `authenticatedPage` fixture.
+ * Logs in once per test using TEST_USER_EMAIL / TEST_USER_PASSWORD env vars,
+ * then provides an authenticated Page instance.
+ */
+export const test = base.extend<{ authenticatedPage: Page }>({
+  authenticatedPage: async ({ browser }, use) => {
+    const email = process.env.TEST_USER_EMAIL;
+    const password = process.env.TEST_USER_PASSWORD;
+
+    if (!email || !password) {
+      throw new Error(
+        "TEST_USER_EMAIL and TEST_USER_PASSWORD must be set for authenticated E2E tests"
+      );
+    }
+
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto("/sign-in");
+    await page.fill('input[type="email"]', email);
+    await page.fill('input[type="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((url) => !url.pathname.includes("/sign-in"), {
+      timeout: 15_000,
+    });
+
+    await use(page);
+    await context.close();
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/page-crud.spec.ts
+++ b/e2e/page-crud.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Page CRUD", () => {
+  test("user can create a new page from sidebar", async ({
+    authenticatedPage: page,
+  }) => {
+    const newPageBtn = page.getByRole("button", { name: /new page/i });
+    if ((await newPageBtn.count()) === 0) {
+      test.skip(true, "New page button not found");
+      return;
+    }
+
+    const initialUrl = page.url();
+    await newPageBtn.click();
+
+    // Should navigate to the new page
+    await page.waitForURL((url) => url.href !== initialUrl, { timeout: 10_000 });
+    const newUrl = page.url();
+    expect(new URL(newUrl).pathname.split("/").filter(Boolean).length).toBeGreaterThanOrEqual(2);
+
+    // Editor should be visible
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("user can navigate to a page via sidebar", async ({
+    authenticatedPage: page,
+  }) => {
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageButton.count()) === 0) {
+      test.skip(true, "No pages in sidebar");
+      return;
+    }
+
+    await pageButton.first().click();
+    await page.waitForURL(
+      (url) => url.pathname.split("/").filter(Boolean).length >= 2,
+      { timeout: 10_000 }
+    );
+
+    // Editor should be visible on the page
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("user can rename a page via inline title", async ({
+    authenticatedPage: page,
+  }) => {
+    // Navigate to a page
+    const pageButton = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageButton.count()) === 0) {
+      test.skip(true, "No pages available");
+      return;
+    }
+
+    await pageButton.first().click();
+    await page.waitForURL(
+      (url) => url.pathname.split("/").filter(Boolean).length >= 2,
+      { timeout: 10_000 }
+    );
+
+    // Find the page title input
+    const titleInput = page.locator('input[aria-label*="title" i], input[placeholder*="untitled" i]').or(
+      page.locator("h1").first()
+    );
+
+    if ((await titleInput.count()) === 0) {
+      test.skip(true, "Title input not found");
+      return;
+    }
+
+    // Click and edit the title
+    await titleInput.first().click();
+    await page.keyboard.press("Meta+a");
+    const testTitle = `E2E Test ${Date.now()}`;
+    await page.keyboard.type(testTitle);
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1_000);
+
+    // Title should be updated (could be an input or a contenteditable heading)
+    const titleText = await titleInput.first().inputValue().catch(() => null)
+      ?? await titleInput.first().textContent();
+    expect(titleText).toContain(testTitle);
+  });
+
+  test("user can delete a page with confirmation", async ({
+    authenticatedPage: page,
+  }) => {
+    // Create a page first so we have something to delete
+    const newPageBtn = page.getByRole("button", { name: /new page/i });
+    if ((await newPageBtn.count()) === 0) {
+      test.skip(true, "New page button not found");
+      return;
+    }
+
+    await newPageBtn.click();
+    await page.waitForURL(
+      (url) => url.pathname.split("/").filter(Boolean).length >= 2,
+      { timeout: 10_000 }
+    );
+    await page.waitForTimeout(1_000);
+
+    // Look for a delete option in the page tree context menu
+    // Hover the page item in the sidebar to reveal the more menu
+    const sidebarItems = page.locator("button").filter({ hasText: /ago/ });
+    if ((await sidebarItems.count()) === 0) {
+      test.skip(true, "No sidebar items to test delete");
+      return;
+    }
+
+    await sidebarItems.first().hover();
+    await page.waitForTimeout(300);
+
+    // Look for a "..." or more options button
+    const moreBtn = page.locator('[aria-label*="more" i], [aria-label*="options" i]').or(
+      page.locator("button").filter({ hasText: "..." })
+    );
+
+    if ((await moreBtn.count()) === 0) {
+      test.skip(true, "More options button not found");
+      return;
+    }
+
+    await moreBtn.first().click();
+    await page.waitForTimeout(300);
+
+    // Click delete
+    const deleteBtn = page.getByRole("menuitem", { name: /delete/i });
+    if ((await deleteBtn.count()) === 0) {
+      test.skip(true, "Delete menu item not found");
+      return;
+    }
+
+    await deleteBtn.click();
+
+    // Confirmation dialog should appear
+    const confirmBtn = page.getByRole("button", { name: /delete|confirm/i }).last();
+    await expect(confirmBtn).toBeVisible({ timeout: 3_000 });
+    await confirmBtn.click();
+
+    await page.waitForTimeout(1_000);
+  });
+});

--- a/e2e/sidebar-drag.spec.ts
+++ b/e2e/sidebar-drag.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Sidebar page tree drag-and-drop", () => {
+  test("drag handle appears on sidebar page item hover", async ({
+    authenticatedPage: page,
+  }) => {
+    const pageItems = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageItems.count()) < 1) {
+      test.skip(true, "Need at least 1 page in sidebar");
+      return;
+    }
+
+    await pageItems.first().hover();
+    await page.waitForTimeout(300);
+
+    // The sidebar drag handle should be visible (GripVertical icon)
+    const gripIcon = page.locator("svg.lucide-grip-vertical").first();
+    await expect(gripIcon).toBeVisible({ timeout: 2_000 });
+  });
+
+  test("pages can be reordered in sidebar via drag-and-drop", async ({
+    authenticatedPage: page,
+  }) => {
+    const pageItems = page.locator("button").filter({ hasText: /ago/ });
+    if ((await pageItems.count()) < 2) {
+      test.skip(true, "Need at least 2 pages in sidebar to test reorder");
+      return;
+    }
+
+    // Get initial order
+    const secondText = await pageItems.nth(1).textContent();
+
+    // Hover first item to reveal drag handle
+    await pageItems.first().hover();
+    await page.waitForTimeout(300);
+
+    const gripIcon = page.locator("svg.lucide-grip-vertical").first();
+    if ((await gripIcon.count()) === 0) {
+      test.skip(true, "Drag handle not found");
+      return;
+    }
+
+    const gripBox = await gripIcon.boundingBox();
+    const secondBox = await pageItems.nth(1).boundingBox();
+
+    if (!gripBox || !secondBox) {
+      test.skip(true, "Could not get element positions");
+      return;
+    }
+
+    // Drag first item below second
+    await page.mouse.move(gripBox.x + gripBox.width / 2, gripBox.y + gripBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(
+      secondBox.x + secondBox.width / 2,
+      secondBox.y + secondBox.height + 5,
+      { steps: 10 }
+    );
+    await page.mouse.up();
+    await page.waitForTimeout(500);
+
+    // Verify order changed
+    const updatedItems = page.locator("button").filter({ hasText: /ago/ });
+    const newFirstText = await updatedItems.nth(0).textContent();
+
+    // The first item should now be what was previously second
+    expect(newFirstText).toBe(secondText);
+  });
+});

--- a/e2e/workspace.spec.ts
+++ b/e2e/workspace.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("Workspace switcher", () => {
+  test("workspace switcher is visible in sidebar", async ({
+    authenticatedPage: page,
+  }) => {
+    // The workspace switcher should be in the sidebar
+    // It's typically a dropdown or button showing the current workspace name
+    const sidebar = page.locator("aside, nav, [data-sidebar]").first();
+    await expect(sidebar).toBeVisible({ timeout: 5_000 });
+
+    // Look for a workspace-related dropdown trigger
+    const workspaceTrigger = page.locator(
+      'button[aria-label*="workspace" i], [data-workspace-switcher]'
+    ).or(
+      // The workspace switcher might just be a button with the workspace name
+      sidebar.locator("button").first()
+    );
+
+    await expect(workspaceTrigger).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("workspace switcher opens and shows workspaces", async ({
+    authenticatedPage: page,
+  }) => {
+    // Find and click the workspace switcher
+    const sidebar = page.locator("aside, nav, [data-sidebar]").first();
+    await expect(sidebar).toBeVisible({ timeout: 5_000 });
+
+    // The workspace switcher is typically the first interactive element in the sidebar
+    const workspaceTrigger = sidebar.locator("button").first();
+    await workspaceTrigger.click();
+    await page.waitForTimeout(500);
+
+    // At minimum, the personal workspace should be listed
+    const workspaceItems = page.locator('[role="menuitem"], [role="option"]');
+    if ((await workspaceItems.count()) > 0) {
+      await expect(workspaceItems.first()).toBeVisible();
+    }
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,13 @@ const eslintConfig = defineConfig([
     "build/**",
     "next-env.d.ts",
   ]),
+  // Playwright E2E tests are not React — disable React-specific rules
+  {
+    files: ["e2e/**/*.ts"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "html" : "list",
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: "pnpm dev",
+        url: "http://localhost:3000",
+        reuseExistingServer: true,
+        timeout: 30_000,
+      },
+});

--- a/src/components/editor/design-spec-compliance.test.ts
+++ b/src/components/editor/design-spec-compliance.test.ts
@@ -34,6 +34,18 @@ describe("callout-plugin design spec compliance", () => {
   });
 });
 
+describe("editor anchor element", () => {
+  const source = readSource("./editor.tsx");
+
+  it("anchor div has left padding for drag handle area", () => {
+    // The anchor element must extend left so the drag handle (portaled inside)
+    // stays within its bounds and receives mouse events.
+    expect(source).toMatch(/ref={onFloatingAnchorRef}[^>]*>/);
+    expect(source).toContain("pl-8");
+    expect(source).toContain("-ml-8");
+  });
+});
+
 describe("draggable-block-plugin design spec compliance", () => {
   const source = readSource("./draggable-block-plugin.tsx");
 

--- a/src/components/editor/draggable-block-plugin.tsx
+++ b/src/components/editor/draggable-block-plugin.tsx
@@ -19,8 +19,8 @@ const DRAG_DATA_FORMAT = "application/x-memo-drag-block";
 const DRAGGABLE_BLOCK_MENU_CLASSNAME = "memo-draggable-block-menu";
 const DROP_INDICATOR_CLASSNAME = "memo-drop-indicator";
 
-// Distance from left edge of editor to show drag handle
-const HANDLE_LEFT_OFFSET = -28;
+// Position drag handle within the anchor's left padding (anchor has pl-8 = 32px)
+const HANDLE_LEFT_OFFSET = 0;
 // Vertical dead zone — mouse must be within this distance of a block to show handle
 const HANDLE_DEAD_ZONE = 4;
 
@@ -140,8 +140,12 @@ export function DraggableBlockPlugin({
     [anchorElem, editor]
   );
 
-  const handleMouseLeave = useCallback(() => {
+  const handleMouseLeave = useCallback((event: MouseEvent) => {
     if (menuRef.current && !isDraggingRef.current) {
+      // Don't hide if the mouse moved to the drag handle itself
+      const relatedTarget = event.relatedTarget as HTMLElement | null;
+      if (relatedTarget && isOnMenu(relatedTarget)) return;
+
       menuRef.current.style.opacity = "0";
       targetBlockElemRef.current = null;
     }
@@ -155,6 +159,21 @@ export function DraggableBlockPlugin({
       anchorElem.removeEventListener("mouseleave", handleMouseLeave);
     };
   }, [anchorElem, handleMouseMove, handleMouseLeave]);
+
+  const handleMenuMouseLeave = useCallback(
+    (event: React.MouseEvent) => {
+      if (isDraggingRef.current) return;
+      // Don't hide if the mouse moved back into the anchor element
+      const relatedTarget = event.relatedTarget as HTMLElement | null;
+      if (relatedTarget && anchorElem.contains(relatedTarget)) return;
+
+      if (menuRef.current) {
+        menuRef.current.style.opacity = "0";
+        targetBlockElemRef.current = null;
+      }
+    },
+    [anchorElem]
+  );
 
   const handleDragStart = useCallback(
     (event: React.DragEvent) => {
@@ -304,6 +323,7 @@ export function DraggableBlockPlugin({
         draggable
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
+        onMouseLeave={handleMenuMouseLeave}
         aria-label="Drag to reorder block"
         role="button"
         tabIndex={0}

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -172,7 +172,7 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
   return (
     <div className="relative">
       <LexicalComposer initialConfig={initialConfig}>
-        <div className="relative" ref={onFloatingAnchorRef}>
+        <div className="relative -ml-8 pl-8" ref={onFloatingAnchorRef}>
           <RichTextPlugin
             contentEditable={
               <ContentEditable

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     passWithNoTests: true,
+    exclude: ["node_modules", "e2e"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #74

## What

Two changes in this PR:

### 1. Fix editor drag handle hover zone

The drag handle was positioned at `left: -28px` outside the anchor element's bounds. Moving the cursor toward the handle triggered `mouseleave` on the anchor, hiding it before the user could grab it.

**Fix:** Extend the anchor `div` with `-ml-8 pl-8` so the handle sits within its bounds. Add `relatedTarget` checks to both the anchor's `mouseleave` and the handle's `onMouseLeave` to prevent hiding when the mouse moves between the two.

Audited the floating toolbar, slash commands, and link editor — they all use `position: fixed` via `@floating-ui/react` and are unaffected by the anchor bounds issue.

### 2. Playwright E2E testing infrastructure

The project had Playwright installed but no config, no tests, and no CI integration. Interactive features like drag-and-drop could ship broken without detection.

**Added:**
- `playwright.config.ts` — Chromium, auto-starts dev server, configurable `BASE_URL`
- `e2e/fixtures/auth.ts` — reusable authenticated page fixture
- 27 E2E tests across 8 files: editor drag (3), slash commands (4), floating toolbar (4), link editor (3), auth (5), page CRUD (4), sidebar drag (2), workspace switcher (2)
- CI `e2e` job running unauthenticated tests on PRs
- Updated `AGENTS.md` and `.agents/conventions.md` with E2E test rules and Playwright patterns
- Updated Feature Builder, Post-Merge Verifier, and Bug Fixer automation prompts to require E2E tests for interactive features

## Verification

- ✅ `pnpm lint` — clean
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm test` — 48 tests pass
- ✅ `pnpm test:e2e` (unauthenticated) — 3 tests pass
- ✅ Drag handle manually verified in dev server