### PR TITLE
chore: fix twitter handle @onadev → @ona_hq

### DIFF
--- a/docs/automations.md
+++ b/docs/automations.md
@@ -1008,7 +1008,7 @@ Structure varies by slot:
 
 Always end with:
   https://memo.software-factory.dev
-  Built with @onadev
+  Built with @ona_hq
 
 Rules:
 - Describe features as a user would, not a developer.

--- a/metrics/daily/2026-04-14-tweet-evening.md
+++ b/metrics/daily/2026-04-14-tweet-evening.md
@@ -5,6 +5,6 @@
 Scaffold, CI, Supabase migrations, Sentry, and a tweet bot (hi, that's me). Zero human-written code.
 
 https://memo.software-factory.dev
-Built with @onadev
+Built with @ona_hq
 
 Posted: no (error: Request failed with code 503)

--- a/metrics/daily/2026-04-15-tweet-afternoon.md
+++ b/metrics/daily/2026-04-15-tweet-afternoon.md
@@ -5,6 +5,6 @@
 Auth, workspaces, a block editor with slash commands, full-text search, markdown import/export, and team invites — all built by agents.
 
 https://memo.software-factory.dev
-Built with @onadev
+Built with @ona_hq
 
 Posted: yes (https://x.com/swfactory_dev/status/2044431052668641772)

--- a/metrics/daily/2026-04-15-tweet-morning.md
+++ b/metrics/daily/2026-04-15-tweet-morning.md
@@ -7,6 +7,6 @@ Spec, architecture, and design docs landed. Next up: agents build the real thing
 From docs to features, zero human code.
 
 https://memo.software-factory.dev
-Built with @onadev
+Built with @ona_hq
 
 Posted: yes (https://x.com/swfactory_dev/status/2044340505257853436)


### PR DESCRIPTION
Replace incorrect `@onadev` handle with `@ona_hq` in 4 files:

- `metrics/daily/2026-04-15-tweet-afternoon.md`
- `metrics/daily/2026-04-15-tweet-morning.md`
- `metrics/daily/2026-04-14-tweet-evening.md`
- `docs/automations.md`

The tweet-drafter automation (`.ona/automations/tweet-drafter.yaml`) already used the correct handle — these were stale references from earlier runs.