### PR TITLE
feat: add Sentry error capture to API routes and sidebar components (#81)

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { createClient } from "@/lib/supabase/server";
+import { captureSupabaseError } from "@/lib/sentry";
 
 export async function GET(request: NextRequest) {
   if (
@@ -45,6 +47,7 @@ export async function GET(request: NextRequest) {
     });
 
     if (error) {
+      captureSupabaseError(error, "search_pages");
       return NextResponse.json(
         { error: "Search failed" },
         { status: 500 }
@@ -52,7 +55,8 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json({ results: data ?? [] });
-  } catch {
+  } catch (error) {
+    Sentry.captureException(error);
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/src/components/editor/image-plugin.tsx
+++ b/src/components/editor/image-plugin.tsx
@@ -14,6 +14,7 @@ import {
 } from "lexical";
 import { $createImageNode, type ImagePayload } from "@/components/editor/image-node";
 import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
 
 export const INSERT_IMAGE_COMMAND: LexicalCommand<ImagePayload> =
   createCommand("INSERT_IMAGE_COMMAND");
@@ -45,7 +46,7 @@ async function uploadImage(file: File): Promise<string | null> {
     });
 
   if (error) {
-    console.error("Image upload failed:", error.message);
+    captureSupabaseError(error, "image-plugin:upload");
     return null;
   }
 

--- a/src/components/page-menu.tsx
+++ b/src/components/page-menu.tsx
@@ -18,7 +18,9 @@ import {
   readFileAsText,
   parseMarkdownToEditorState,
 } from "@/components/editor/markdown-utils";
+import * as Sentry from "@sentry/nextjs";
 import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
 
 interface PageMenuProps {
   pageId: string;
@@ -51,10 +53,10 @@ export function PageMenu({
       const filename = (pageTitle.trim() || "Untitled") + ".md";
       downloadMarkdown(markdown, filename);
     } catch (error) {
+      Sentry.captureException(error);
       toast.error("Export failed", {
         duration: 8000,
       });
-      console.error("Markdown export error:", error);
     }
   }, [editorRef, pageTitle]);
 
@@ -107,21 +109,27 @@ export function PageMenu({
           .select("id")
           .single();
 
-        if (error || !newPage) {
+        if (error) {
+          captureSupabaseError(error, "page-menu:import-create-page");
           toast.error("Failed to create page from import", {
             duration: 8000,
           });
-          console.error("Import error:", error);
+          return;
+        }
+        if (!newPage) {
+          toast.error("Failed to create page from import", {
+            duration: 8000,
+          });
           return;
         }
 
         router.push(`/${workspaceSlug}/${newPage.id}`);
         router.refresh();
       } catch (error) {
+        Sentry.captureException(error);
         toast.error("Failed to read or parse the markdown file", {
           duration: 8000,
         });
-        console.error("Import error:", error);
       }
     },
     [workspaceId, workspaceSlug, userId, router]

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -3,8 +3,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { FileText, Search, X } from "lucide-react";
+import * as Sentry from "@sentry/nextjs";
 import { Input } from "@/components/ui/input";
 import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
 
 interface SearchResult {
   id: string;
@@ -42,7 +44,11 @@ export function PageSearch() {
       .select("id")
       .eq("slug", params.workspaceSlug)
       .maybeSingle()
-      .then(({ data }) => {
+      .then(({ data, error }) => {
+        if (error) {
+          captureSupabaseError(error, "page-search:workspace-lookup");
+          return;
+        }
         setWorkspaceId(data?.id ?? null);
       });
   }, [params.workspaceSlug]);
@@ -67,7 +73,8 @@ export function PageSearch() {
         } else {
           setResults([]);
         }
-      } catch {
+      } catch (error) {
+        Sentry.captureException(error);
         setResults([]);
       } finally {
         setLoading(false);

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -10,7 +10,9 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
+import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -113,7 +115,11 @@ export function PageTree({ userId }: PageTreeProps) {
       .select("id")
       .eq("slug", workspaceSlug)
       .maybeSingle()
-      .then(({ data }) => {
+      .then(({ data, error }) => {
+        if (error) {
+          captureSupabaseError(error, "page-tree:workspace-lookup");
+          return;
+        }
         if (data) setWorkspaceId(data.id);
       });
   }, [workspaceSlug]);
@@ -122,11 +128,16 @@ export function PageTree({ userId }: PageTreeProps) {
     if (!workspaceId) return;
 
     const supabase = createClient();
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from("pages")
       .select("*")
       .eq("workspace_id", workspaceId)
       .order("position", { ascending: true });
+
+    if (error) {
+      captureSupabaseError(error, "page-tree:fetch-pages");
+      toast.error("Failed to load pages");
+    }
 
     if (data) {
       setPages(data);
@@ -176,7 +187,12 @@ export function PageTree({ userId }: PageTreeProps) {
       .select()
       .single();
 
-    if (error || !newPage) return;
+    if (error) {
+      captureSupabaseError(error, "page-tree:create-page");
+      toast.error("Failed to create page");
+      return;
+    }
+    if (!newPage) return;
 
     setPages((prev) => [...prev, newPage]);
 
@@ -197,7 +213,10 @@ export function PageTree({ userId }: PageTreeProps) {
       .delete()
       .eq("id", deleteTarget.page.id);
 
-    if (!error) {
+    if (error) {
+      captureSupabaseError(error, "page-tree:delete-page");
+      toast.error("Failed to delete page");
+    } else {
       const removedIds = new Set([
         deleteTarget.page.id,
         ...getDescendantIds(deleteTarget),
@@ -248,10 +267,18 @@ export function PageTree({ userId }: PageTreeProps) {
       })
     );
 
-    await Promise.all([
+    const results = await Promise.all([
       supabase.from("pages").update({ position: b.position }).eq("id", a.id),
       supabase.from("pages").update({ position: a.position }).eq("id", b.id),
     ]);
+
+    for (const result of results) {
+      if (result.error) {
+        captureSupabaseError(result.error, "page-tree:swap-positions");
+        toast.error("Failed to reorder page");
+        break;
+      }
+    }
   }
 
   async function handleNest(page: Page) {
@@ -281,10 +308,15 @@ export function PageTree({ userId }: PageTreeProps) {
 
     setExpanded((prev) => new Set(prev).add(newParent.id));
 
-    await supabase
+    const { error } = await supabase
       .from("pages")
       .update({ parent_id: newParent.id, position: nextPosition })
       .eq("id", page.id);
+
+    if (error) {
+      captureSupabaseError(error, "page-tree:nest-page");
+      toast.error("Failed to nest page");
+    }
   }
 
   async function handleUnnest(page: Page) {
@@ -330,7 +362,15 @@ export function PageTree({ userId }: PageTreeProps) {
       ),
     ];
 
-    await Promise.all(updates);
+    const results = await Promise.all(updates);
+
+    for (const result of results) {
+      if (result.error) {
+        captureSupabaseError(result.error, "page-tree:unnest-page");
+        toast.error("Failed to unnest page");
+        break;
+      }
+    }
   }
 
   function handleDragStart(e: React.DragEvent, pageId: string) {
@@ -408,10 +448,15 @@ export function PageTree({ userId }: PageTreeProps) {
       );
       setExpanded((prev) => new Set(prev).add(targetPage.id));
 
-      await supabase
+      const { error } = await supabase
         .from("pages")
         .update({ parent_id: targetPage.id, position: nextPos })
         .eq("id", draggedId);
+
+      if (error) {
+        captureSupabaseError(error, "page-tree:drop-inside");
+        toast.error("Failed to move page");
+      }
     } else {
       const newParentId = targetPage.parent_id;
       const siblings = pages
@@ -441,10 +486,16 @@ export function PageTree({ userId }: PageTreeProps) {
       });
 
       for (let i = 0; i < reordered.length; i++) {
-        await supabase
+        const { error } = await supabase
           .from("pages")
           .update({ parent_id: newParentId, position: i })
           .eq("id", reordered[i].id);
+
+        if (error) {
+          captureSupabaseError(error, "page-tree:drop-reorder");
+          toast.error("Failed to move page");
+          break;
+        }
       }
     }
 

--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -2,7 +2,9 @@
 
 import { useRouter } from "next/navigation";
 import { FileText, Plus } from "lucide-react";
+import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 
 interface WorkspaceHomeProps {
@@ -37,7 +39,12 @@ export function WorkspaceHome({
       .select()
       .single();
 
-    if (error || !newPage) return;
+    if (error) {
+      captureSupabaseError(error, "workspace-home:create-page");
+      toast.error("Failed to create page");
+      return;
+    }
+    if (!newPage) return;
 
     router.push(`/${workspace.slug}/${newPage.id}`);
     router.refresh();

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -23,9 +23,7 @@ const BARE_CATCH_PERMANENT_ALLOWLIST = new Set([
  * Files with bare `catch {}` that will be fixed in subsequent PRs.
  * Each entry should reference the issue that will fix it.
  */
-const BARE_CATCH_PENDING_ALLOWLIST = new Set([
-  "src/components/sidebar/page-search.tsx", // #81 or follow-up
-  "src/app/api/search/route.ts", // #81 or follow-up
+const BARE_CATCH_PENDING_ALLOWLIST = new Set<string>([
 ]);
 
 const BARE_CATCH_ALLOWLIST = new Set([
@@ -37,9 +35,7 @@ const BARE_CATCH_ALLOWLIST = new Set([
  * Files with `console.error` without Sentry capture that will be fixed
  * in subsequent PRs.
  */
-const CONSOLE_ERROR_PENDING_ALLOWLIST = new Set([
-  "src/components/editor/image-plugin.tsx", // #81 or follow-up
-  "src/components/page-menu.tsx", // #81 or follow-up
+const CONSOLE_ERROR_PENDING_ALLOWLIST = new Set<string>([
 ]);
 
 function collectTsFiles(dir: string): string[] {


### PR DESCRIPTION
Closes #81

## What

Adds `captureSupabaseError` / `Sentry.captureException` calls to all silent error paths in API routes, sidebar components, and related client components. Adds `toast.error()` notifications for user-facing failures.

## Changes

**API route** (`src/app/api/search/route.ts`):
- `supabase.rpc` error path now calls `captureSupabaseError`
- Outer catch block captures the error variable and calls `Sentry.captureException`

**Sidebar** (`page-tree.tsx`):
- Workspace lookup `.then()` checks for error
- All operations (create, delete, swap, nest, unnest, drop) capture errors via `captureSupabaseError` and show `toast.error()` on failure
- `Promise.all` results checked individually for `.error`

**Sidebar** (`page-search.tsx`):
- Workspace lookup `.then()` checks for error
- Search fetch catch block captures the exception via `Sentry.captureException`

**Workspace home** (`workspace-home.tsx`):
- Page create failure captured + toast

**Editor** (`image-plugin.tsx`):
- Replaced `console.error` with `captureSupabaseError` for upload failures

**Page menu** (`page-menu.tsx`):
- Replaced `console.error` with `Sentry.captureException` / `captureSupabaseError` for export and import errors

**Static analysis** (`sentry.test.ts`):
- Removed all files from `BARE_CATCH_PENDING_ALLOWLIST` and `CONSOLE_ERROR_PENDING_ALLOWLIST`

## Testing

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 50/50 tests pass (including static analysis regression tests)