### PR TITLE
feat: add Sentry error capture to page title and image plugin (#82)

### DIFF
--- a/src/components/editor/image-plugin.tsx
+++ b/src/components/editor/image-plugin.tsx
@@ -12,6 +12,7 @@ import {
   DROP_COMMAND,
   type LexicalCommand,
 } from "lexical";
+import * as Sentry from "@sentry/nextjs";
 import { $createImageNode, type ImagePayload } from "@/components/editor/image-node";
 import { createClient } from "@/lib/supabase/client";
 import { captureSupabaseError } from "@/lib/sentry";
@@ -96,14 +97,18 @@ export function ImagePlugin(): null {
         event.preventDefault();
 
         for (const file of imageFiles) {
-          void uploadImage(file).then((url) => {
-            if (url) {
-              editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
-                src: url,
-                altText: file.name,
-              });
-            }
-          });
+          void uploadImage(file)
+            .then((url) => {
+              if (url) {
+                editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+                  src: url,
+                  altText: file.name,
+                });
+              }
+            })
+            .catch((error) => {
+              Sentry.captureException(error);
+            });
         }
 
         return true;
@@ -140,12 +145,16 @@ export function openImagePicker(editor: ReturnType<typeof useLexicalComposerCont
     const file = input.files?.[0];
     if (!file) return;
 
-    const url = await uploadImage(file);
-    if (url) {
-      editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
-        src: url,
-        altText: file.name,
-      });
+    try {
+      const url = await uploadImage(file);
+      if (url) {
+        editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+          src: url,
+          altText: file.name,
+        });
+      }
+    } catch (error) {
+      Sentry.captureException(error);
     }
   };
   input.click();

--- a/src/components/page-title.tsx
+++ b/src/components/page-title.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
 
 interface PageTitleProps {
   pageId: string;
@@ -37,6 +38,8 @@ export function PageTitle({ pageId, initialTitle }: PageTitleProps) {
 
       if (!error) {
         lastSavedRef.current = trimmed;
+      } else {
+        captureSupabaseError(error, "page.title.save");
       }
     },
     [pageId]


### PR DESCRIPTION
Closes #82

## What

Adds Sentry error capture to the remaining editor-adjacent components that were silently dropping errors.

## Changes

### `src/components/page-title.tsx`
- Added `captureSupabaseError(error, "page.title.save")` in the `else` branch when the Supabase title update fails. Previously, save failures were silently ignored.

### `src/components/editor/image-plugin.tsx`
- Added `Sentry.captureException` in a `.catch()` handler on the drop-to-upload promise chain, which previously had no error handling for unhandled rejections.
- Wrapped `openImagePicker`'s upload call in a `try/catch` with `Sentry.captureException` for the same reason.

### Already handled (no changes needed)
- `page-menu.tsx`: Already has `Sentry.captureException` and `captureSupabaseError` from PR #86 (issue #81).
- Static analysis allowlists in `sentry.test.ts`: Already empty — no entries to remove.

## Acceptance Criteria Verification

- ✅ `page-title.tsx`: title save failure captured via `captureSupabaseError`
- ✅ `page-menu.tsx`: export and import catch blocks already use `Sentry.captureException` (from #86)
- ✅ `image-plugin.tsx`: upload failure captured via `Sentry.captureException` + `captureSupabaseError`
- ✅ No files to remove from static analysis allowlist (already empty)
- ✅ No `console.error` without an accompanying Sentry call in changed files
- ✅ `pnpm lint && pnpm typecheck && pnpm test` pass (51/51 tests)