### PR TITLE
chore: Onafy repository with devcontainer, automations, and README updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,13 @@
   "name": "memo",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli": {}
   },
-  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y --no-install-recommends curl && pnpm install && npx playwright install --with-deps chromium",
-  "forwardPorts": [3000]
+  "forwardPorts": [3000],
+  "portsAttributes": {
+    "3000": {
+      "label": "Memo App",
+      "onAutoForward": "notify"
+    }
+  }
 }

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,16 @@
+tasks:
+  installDeps:
+    name: Install dependencies
+    description: Install npm packages and Playwright browsers.
+    command: |
+      pnpm install && npx playwright install --with-deps chromium
+    triggeredBy:
+      - postDevcontainerStart
+
+services:
+  dev-server:
+    name: Dev Server
+    description: Next.js development server on port 3000.
+    commands:
+      start: pnpm dev
+      ready: curl -sf http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -37,14 +37,32 @@ Past streams are available on the [YouTube channel](https://www.youtube.com/@ona
 - [Vitest](https://vitest.dev/) + [Playwright](https://playwright.dev/) (testing)
 - Deployed on [Vercel](https://vercel.com/)
 
-## Quick start
+## Getting started
 
-```bash
-pnpm install
-pnpm dev
-```
+[![Run in Ona](https://ona.com/run-in-ona.svg)](https://app.ona.com/#https://github.com/gitpod-io/memo)
 
-Open [http://localhost:3000](http://localhost:3000).
+The fastest way to run Memo is in an [Ona](https://ona.com). Click the badge above, or:
+
+1. [Add this repository to an Ona project](https://ona.com/docs/ona/create-first-project)
+2. Configure the required [**project secrets**](https://ona.com/docs/ona/projects/project-secrets#project-secrets) (see below)
+3. Open the environment — dependencies install automatically and the dev server starts on port 3000
+
+### Required project secrets
+
+Set these in your Ona project settings under **Secrets**:
+
+| Secret | Description |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Supabase anon/public key |
+| `SUPABASE_SECRET_KEY` | Supabase service role key |
+| `NEXT_PUBLIC_SENTRY_DSN` | Sentry DSN (optional — leave empty to disable) |
+| `SENTRY_DSN` | Sentry server-side DSN (optional) |
+| `SENTRY_AUTH_TOKEN` | Sentry auth token for source maps (optional) |
+| `SENTRY_ORG` | Sentry organization slug (optional) |
+| `SENTRY_PROJECT` | Sentry project slug (optional) |
+
+Without Supabase secrets, the app starts but auth and data features won't work.
 
 ## Project links
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  allowedDevOrigins: ["*.preview.devx.network", "*.preview.env.ona.dev"],
+};
 
 export default withSentryConfig(nextConfig, {
   org: process.env.SENTRY_ORG,


### PR DESCRIPTION
## What

Onafies the repository so new contributors can open it in Ona with one click and have a working dev environment automatically.

## Changes

- **`next.config.ts`**: Add `allowedDevOrigins` for `*.preview.devx.network` and `*.preview.env.ona.dev` — fixes cross-origin HMR block in Ona preview environments
- **`.devcontainer/devcontainer.json`**: Remove `postCreateCommand` lifecycle hook (moved to automations), add `portsAttributes` for port 3000 labeling
- **`.ona/automations.yaml`** (new): `installDeps` task (runs on `postDevcontainerStart`) and `dev-server` service that auto-starts `pnpm dev`
- **`README.md`**: Replace "Quick start" with "Getting started" section containing the Run in Ona badge, project setup steps, and required secrets table