### PR TITLE
fix(automations): use pnpm exec instead of npx for Playwright install

### DIFF
--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -3,7 +3,7 @@ tasks:
     name: Install dependencies
     description: Install npm packages and Playwright browsers.
     command: |
-      pnpm install && npx playwright install --with-deps chromium
+      pnpm install && pnpm exec playwright install --with-deps chromium
     triggeredBy:
       - postDevcontainerStart
 


### PR DESCRIPTION
`npx` hits a `/usr/bin/env: bad interpreter: Operation not permitted` error in the Ona automation runner. Switches to `pnpm exec` which works correctly.