### PR TITLE
chore: normalize issue titles during Feature Planner triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
+title: "fix: "
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Suggest a new feature or enhancement
+title: "feat: "
 labels: []
 body:
   - type: markdown

--- a/.ona/automations/feature-planner.yaml
+++ b/.ona/automations/feature-planner.yaml
@@ -58,6 +58,11 @@ action:
                 - A testable definition of "done"
 
                 **If sufficient:**
+                - Normalize the title to conventional format if it doesn't already match:
+                  `<type>: <short imperative description>` where type is feat|fix|chore|perf.
+                  Examples: "feat: add drag-and-drop column reordering", "fix: sidebar flickers on page switch".
+                  Use `gh issue edit <N> --title "<normalized title>"` to update.
+                  Only rename user-created issues — never rename issues created by other automations.
                 - Enrich the issue body if needed (add Acceptance Criteria, Technical Notes
                   sections if missing, referencing .agents/conventions.md and .agents/architecture.md)
                 - Add exactly 3 labels: `status:backlog` + appropriate `priority:*` + type label


### PR DESCRIPTION
Feature Planner now renames user-created issues to conventional format (`feat:`/`fix:`/`chore:`/`perf:`) during triage. Issue templates pre-fill the title prefix as a non-enforcing hint.

## Changes

- **Feature Planner prompt** — added title normalization step in the "If sufficient" triage path. Only renames user-created issues, skips automation-created ones.
- **`feature.yml` template** — pre-fills title with `feat: `.
- **`bug.yml` template** — pre-fills title with `fix: `.

## Why

Aligns issue titles with the conventional commit format used in PR titles and commit messages, keeping the chain consistent: issue → branch → commit → PR.