### PR TITLE
chore: remove title prefixes from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug or unexpected behavior
-title: "fix: "
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest a new feature or enhancement
-title: "feat: "
 labels: []
 body:
   - type: markdown


### PR DESCRIPTION
Removes `feat: ` and `fix: ` title prefixes from issue templates. Users report bugs and request features — they shouldn't need to know conventional commit types. The Feature Planner already adds the correct prefix during triage based on the template's label.