### PR TITLE
chore: add cron trigger to Feature Planner (every 30 min)

### DIFF
--- a/.ona/automations/feature-planner.yaml
+++ b/.ona/automations/feature-planner.yaml
@@ -5,6 +5,12 @@ triggers:
         projects:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: "*/30 * * * *"
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       manual: {}
 action:
     limits:


### PR DESCRIPTION
User-filed issues only get the `bug`/`feature` label from templates — they need the Feature Planner to triage and add `status:backlog` before the Bug Fixer or Feature Builder can pick them up. Without a cron trigger, issues sat in limbo until someone manually ran the planner.

Adds a `*/30 * * * *` cron trigger alongside the existing manual trigger.