### PR TITLE
fix(editor): render checklist checkboxes via CSS pseudo-elements (#95)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,3 +145,62 @@
     @apply font-sans;
   }
 }
+
+/*
+ * Lexical checklist checkbox rendering.
+ * Lexical's CheckListPlugin expects ::before pseudo-elements to render checkboxes.
+ * Tailwind cannot generate these, so raw CSS is required here.
+ */
+.editor-checklist-checked,
+.editor-checklist-unchecked {
+  outline: none;
+  display: block;
+  min-height: 1.5em;
+}
+
+.editor-checklist-unchecked::before,
+.editor-checklist-checked::before {
+  content: "\200B";
+  width: 0.9em;
+  height: 0.9em;
+  top: 50%;
+  left: 0;
+  cursor: pointer;
+  display: block;
+  background-size: cover;
+  position: absolute;
+  transform: translateY(-50%);
+  border-radius: 2px;
+}
+
+.editor-checklist-unchecked::before {
+  border: 1px solid var(--muted-foreground);
+}
+
+.editor-checklist-checked::before {
+  border: 1px solid var(--accent);
+  background-color: var(--accent);
+  background-repeat: no-repeat;
+}
+
+/* Checkmark on checked items */
+.editor-checklist-checked::after {
+  content: "";
+  cursor: pointer;
+  border-color: var(--primary-foreground);
+  border-style: solid;
+  position: absolute;
+  display: block;
+  top: 45%;
+  width: 0.2em;
+  left: 0.35em;
+  height: 0.4em;
+  transform: translateY(-50%) rotate(45deg);
+  border-width: 0 0.1em 0.1em 0;
+}
+
+/* Focus ring on checkbox */
+.editor-checklist-unchecked:focus::before,
+.editor-checklist-checked:focus::before {
+  box-shadow: 0 0 0 2px var(--ring);
+}

--- a/src/components/editor/theme.test.ts
+++ b/src/components/editor/theme.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import { editorTheme } from "./theme";
 
 /**
@@ -59,5 +61,45 @@ describe("editorTheme", () => {
     const quote = editorTheme.quote as string;
     expect(quote).toContain("border-white/[0.06]");
     expect(quote).not.toContain("border-white/[0.12]");
+  });
+});
+
+/**
+ * Regression test for issue #95: checklist checkboxes not visible.
+ * Lexical's CheckListPlugin renders checkboxes via CSS ::before pseudo-elements
+ * on the theme class names. The theme must include marker classes that the
+ * globals.css rules can target.
+ */
+describe("editorTheme checklist checkbox rendering", () => {
+  const listTheme = editorTheme.list as Record<string, string>;
+
+  it("listitemChecked includes the CSS marker class", () => {
+    expect(listTheme.listitemChecked).toContain("editor-checklist-checked");
+  });
+
+  it("listitemUnchecked includes the CSS marker class", () => {
+    expect(listTheme.listitemUnchecked).toContain("editor-checklist-unchecked");
+  });
+
+  it("listitemChecked has relative positioning for pseudo-element placement", () => {
+    expect(listTheme.listitemChecked).toContain("relative");
+  });
+
+  it("listitemUnchecked has relative positioning for pseudo-element placement", () => {
+    expect(listTheme.listitemUnchecked).toContain("relative");
+  });
+
+  it("listitemChecked applies strikethrough styling", () => {
+    expect(listTheme.listitemChecked).toContain("line-through");
+  });
+
+  it("globals.css defines ::before rules for checklist marker classes", () => {
+    const css = readFileSync(
+      resolve(__dirname, "../../app/globals.css"),
+      "utf-8"
+    );
+    expect(css).toContain(".editor-checklist-unchecked::before");
+    expect(css).toContain(".editor-checklist-checked::before");
+    expect(css).toContain(".editor-checklist-checked::after");
   });
 });

--- a/src/components/editor/theme.ts
+++ b/src/components/editor/theme.ts
@@ -17,8 +17,9 @@ export const editorTheme: EditorThemeClasses = {
       listitem: "list-none",
     },
     listitemChecked:
-      "relative mt-0.5 list-none pl-6 line-through text-muted-foreground",
-    listitemUnchecked: "relative mt-0.5 list-none pl-6",
+      "editor-checklist-checked relative mt-0.5 list-none pl-6 line-through text-muted-foreground",
+    listitemUnchecked:
+      "editor-checklist-unchecked relative mt-0.5 list-none pl-6",
     olDepth: ["list-decimal", "list-[lower-alpha]", "list-[lower-roman]"],
   },
   code: "mt-3 block bg-muted rounded-sm p-4 font-mono text-sm overflow-x-auto",


### PR DESCRIPTION
Closes #95

## What

Checklist/todo items in the editor had no visible checkboxes. Lexical's `CheckListPlugin` applies theme classes to `<li>` elements and expects CSS `::before` pseudo-elements on those classes to render the checkbox UI. The theme only had Tailwind utility classes for padding and strikethrough — no actual checkbox was rendered, so items appeared as plain text.

## How

Added marker CSS class names (`editor-checklist-checked`, `editor-checklist-unchecked`) to the editor theme's `listitemChecked` and `listitemUnchecked` entries. Added corresponding `::before` and `::after` pseudo-element rules in `globals.css` that render a checkbox square (unchecked) or a filled checkbox with checkmark (checked). This is raw CSS because Tailwind cannot generate `::before` content for Lexical's injected DOM — an acceptable exception noted in the issue. Colors use design tokens (`--muted-foreground`, `--accent`, `--primary-foreground`, `--ring`).

## Testing

- Added 6 regression tests in `theme.test.ts` verifying:
  - Theme classes include the marker CSS class names
  - Theme classes have `relative` positioning for pseudo-element placement
  - Checked items have `line-through` styling
  - `globals.css` contains the required `::before`/`::after` rules
- `pnpm lint && pnpm typecheck && pnpm test` — all 57 tests pass
- `pnpm test:e2e` — all 27 tests pass