### PR TITLE
fix: create workspace button in workspace switcher has no effect (#105)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -550,6 +550,31 @@ base-ui's `TooltipTrigger` does NOT support `asChild`. Use the `render` prop ins
 </TooltipTrigger>
 ```
 
+### Dialogs triggered from dropdown menus
+
+Never nest a `DialogTrigger` inside a `DropdownMenuItem`. Base UI's `DialogTrigger`
+with `render={<>{children}</>}` wraps children in a fragment, which has no DOM node
+for the click handler. Instead, use controlled dialog state:
+
+```typescript
+// ✅ Correct — controlled dialog opened by menu item click
+const [dialogOpen, setDialogOpen] = useState(false);
+
+<DropdownMenu>
+  <DropdownMenuContent>
+    <DropdownMenuItem onClick={() => setDialogOpen(true)}>
+      Open dialog
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+  <MyDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+</DropdownMenu>
+
+// ❌ Wrong — DialogTrigger inside DropdownMenuItem never fires
+<DropdownMenuItem onSelect={(e) => e.preventDefault()}>
+  <DialogTrigger render={<>{children}</>} />
+</DropdownMenuItem>
+```
+
 ### Button primitives
 
 Buttons use `@base-ui/react/button` internally. The `Button` component accepts

--- a/e2e/workspace.spec.ts
+++ b/e2e/workspace.spec.ts
@@ -38,4 +38,31 @@ test.describe("Workspace switcher", () => {
       await expect(workspaceItems.first()).toBeVisible();
     }
   });
+
+  test("create workspace menu item opens the dialog", async ({
+    authenticatedPage: page,
+  }) => {
+    const sidebar = page.locator("aside, nav, [data-sidebar]").first();
+    await expect(sidebar).toBeVisible({ timeout: 5_000 });
+
+    // Open the workspace switcher dropdown
+    const workspaceTrigger = sidebar.locator(
+      'button[aria-label="Switch workspace"]'
+    );
+    await workspaceTrigger.click();
+
+    // Click "Create workspace" menu item
+    const createItem = page.getByRole("menuitem", {
+      name: /create workspace/i,
+    });
+    await expect(createItem).toBeVisible({ timeout: 3_000 });
+    await createItem.click();
+
+    // The create workspace dialog should appear
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 3_000 });
+    await expect(
+      dialog.getByRole("heading", { name: /create workspace/i })
+    ).toBeVisible();
+  });
 });

--- a/src/components/sidebar/create-workspace-dialog.tsx
+++ b/src/components/sidebar/create-workspace-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { generateSlug, WORKSPACE_LIMIT } from "@/lib/workspace";
@@ -14,22 +14,22 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 
 interface CreateWorkspaceDialogProps {
-  children: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   workspaceCount: number;
   userId: string;
 }
 
 export function CreateWorkspaceDialog({
-  children,
+  open,
+  onOpenChange,
   workspaceCount,
   userId,
 }: CreateWorkspaceDialogProps) {
   const router = useRouter();
-  const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -81,7 +81,7 @@ export function CreateWorkspaceDialog({
       return;
     }
 
-    setOpen(false);
+    onOpenChange(false);
     setName("");
     setLoading(false);
     router.push(`/${workspace.slug}`);
@@ -89,8 +89,7 @@ export function CreateWorkspaceDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={<>{children}</>} />
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create workspace</DialogTitle>

--- a/src/components/sidebar/workspace-switcher.tsx
+++ b/src/components/sidebar/workspace-switcher.tsx
@@ -25,6 +25,7 @@ export function WorkspaceSwitcher({ userId }: WorkspaceSwitcherProps) {
   const params = useParams<{ workspaceSlug?: string }>();
   const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
   const [loading, setLoading] = useState(true);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   useEffect(() => {
     const supabase = createClient();
@@ -98,18 +99,22 @@ export function WorkspaceSwitcher({ userId }: WorkspaceSwitcherProps) {
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />
-        <CreateWorkspaceDialog workspaceCount={createdCount} userId={userId}>
-          <DropdownMenuItem onSelect={(e) => e.preventDefault()}>
-            <Plus className="h-4 w-4" />
-            Create workspace
-            {createdCount >= WORKSPACE_LIMIT && (
-              <span className="ml-auto text-xs text-muted-foreground">
-                Limit reached
-              </span>
-            )}
-          </DropdownMenuItem>
-        </CreateWorkspaceDialog>
+        <DropdownMenuItem onClick={() => setCreateDialogOpen(true)}>
+          <Plus className="h-4 w-4" />
+          Create workspace
+          {createdCount >= WORKSPACE_LIMIT && (
+            <span className="ml-auto text-xs text-muted-foreground">
+              Limit reached
+            </span>
+          )}
+        </DropdownMenuItem>
       </DropdownMenuContent>
+      <CreateWorkspaceDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        workspaceCount={createdCount}
+        userId={userId}
+      />
     </DropdownMenu>
   );
 }


### PR DESCRIPTION
Closes #105

## What

Clicking "Create workspace" in the workspace switcher dropdown had no effect. The `CreateWorkspaceDialog` used a `DialogTrigger` with `render={<>{children}</>}` inside a `DropdownMenuItem`. Base UI's `DialogTrigger` cannot attach its click handler to a React fragment (no DOM node), so the dialog's open state was never toggled.

## How

Switched to a controlled dialog pattern. The `DropdownMenuItem` `onClick` sets `createDialogOpen = true`, and `CreateWorkspaceDialog` now accepts `open`/`onOpenChange` props instead of wrapping children with `DialogTrigger`. The dialog is rendered as a sibling inside `DropdownMenu` (it portals to the body, so placement doesn't matter). Also added a convention to `.agents/conventions.md` to prevent this class of bug.

## Testing

- Added E2E test `create workspace menu item opens the dialog` in `e2e/workspace.spec.ts` that opens the workspace switcher, clicks "Create workspace", and asserts the dialog appears with the correct heading.
- All 28 E2E tests pass. Lint, typecheck, and 58 unit tests pass.