### PR TITLE
test: add E2E tests for workspace member management (#110)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -141,6 +141,28 @@ The helper accepts `PostgrestError` (from query results) and generic `Error` (fr
 catch blocks). It tags the Sentry event with the operation name, error code, and
 message so errors are filterable in the Sentry dashboard.
 
+### Disambiguating Supabase joins
+
+When a table has multiple foreign keys to the same target table, PostgREST cannot
+infer which relationship to use. The query silently returns `null` data (no error
+thrown). Disambiguate by specifying the FK constraint name:
+
+```typescript
+// BAD — ambiguous: members has both user_id and invited_by referencing profiles
+const { data } = await supabase
+  .from("members")
+  .select("*, profiles(email, display_name)");
+// data will be null with a PGRST201 error
+
+// GOOD — specify the FK constraint
+const { data } = await supabase
+  .from("members")
+  .select("*, profiles!members_user_id_fkey(email, display_name)");
+```
+
+Check `supabase/migrations/` for constraint names. The naming convention is
+`{table}_{column}_fkey`.
+
 ### API route catch blocks
 
 All catch blocks in API routes must call `Sentry.captureException`:

--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -21,7 +21,7 @@ Updated weekly by the Automation Auditor. Tracks code quality per domain.
 | Editor | A | Full Lexical editor: slash commands, floating toolbar, floating link editor, drag-and-drop blocks, code highlighting, image upload, callouts, collapsible/toggle blocks. Markdown import/export. 4 unit test files (24 tests): theme mapping, markdown utils, design spec compliance, Node.contains safety. 4 E2E specs (editor-drag, editor-link, editor-slash-commands, editor-toolbar). Auto-save with debounce. Sentry error capture on save failures and image uploads. |
 | Search | B | Full-text search via PostgreSQL tsvector + tsquery. API route with integration tests (8 tests). Sidebar search component with debounced input (300ms) and results dropdown. Sentry error capture. No E2E test for search interaction. |
 | Import/Export | B | Markdown export (download .md) and import (parse .md, create page) via page menu. Markdown utils with unit tests (8 tests). No E2E test for import/export flow. |
-| Members | B | Member list with role badges, role change, remove. Invite form (email + role). Pending invite list with revoke. Invite accept page. Role select dropdown. Settings members page with server-side data fetching. No unit or E2E tests for member management. |
+| Members | A | Member list with role badges, role change, remove. Invite form (email + role). Pending invite list with revoke. Invite accept page. Role select dropdown. Settings members page with server-side data fetching. Full E2E coverage: invite, pending list, revoke, accept, role change, remove, member role restrictions. |
 | App Shell | B | Collapsible sidebar (desktop: aside, mobile: Sheet), sidebar context with ⌘+\ shortcut, workspace switcher, page tree, user menu with sign-out. Clean component decomposition. No unit tests for sidebar context or app shell layout. |
 | API Routes | A | Health endpoint (DB connectivity check, 6 tests) and search endpoint (full-text search, 8 tests). Both routes have Sentry error capture. Both have integration tests with mocked Supabase. |
 | UI Components | A | 13 shadcn/ui components (base-nova style): alert-dialog, badge, button, card, dialog, dropdown-menu, input, label, select, separator, sheet, table, tooltip. Overlay opacity regression test (2 tests). Toast error duration regression test (1 test). Design tokens use oklch color space, --radius: 0 for sharp corners. |
@@ -48,7 +48,7 @@ Updated weekly by the Automation Auditor. Tracks code quality per domain.
 
 ## Known Gaps
 
-- **Members**: No unit or E2E tests for member list, invite form, invite accept, or role changes.
+- **Members**: Full E2E coverage added (7 tests). Disambiguated Supabase join bug fixed in members page and invite form.
 - **Search UI**: No E2E test for the sidebar search interaction (typing, results display, navigation).
 - **Import/Export**: No E2E test for markdown export/import flow via page menu.
 - **Page tree**: No unit tests for the tree manipulation logic (nest, unnest, reorder). The component is 836 lines — extracting tree logic into a utility would improve testability.

--- a/e2e/fixtures/supabase-admin.ts
+++ b/e2e/fixtures/supabase-admin.ts
@@ -1,0 +1,152 @@
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Creates a Supabase admin client using the secret (service role) key.
+ * Used in E2E tests to create/delete temporary test users and query data
+ * that bypasses RLS.
+ */
+function getAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const secretKey = process.env.SUPABASE_SECRET_KEY;
+
+  if (!url || !secretKey) {
+    throw new Error(
+      "NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SECRET_KEY must be set for admin E2E helpers"
+    );
+  }
+
+  return createClient(url, secretKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+interface TestUser {
+  id: string;
+  email: string;
+  password: string;
+}
+
+/**
+ * Creates a temporary test user via the Supabase Admin API.
+ * The user is auto-confirmed so they can sign in immediately.
+ */
+export async function createTestUser(
+  email: string,
+  password: string,
+  displayName: string
+): Promise<TestUser> {
+  const admin = getAdminClient();
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+    user_metadata: { display_name: displayName },
+  });
+
+  if (error) {
+    throw new Error(`Failed to create test user ${email}: ${error.message}`);
+  }
+
+  return { id: data.user.id, email, password };
+}
+
+/**
+ * Deletes a test user and all their data via the Supabase Admin API.
+ */
+export async function deleteTestUser(userId: string): Promise<void> {
+  const admin = getAdminClient();
+
+  // Delete memberships first (the user's personal workspace will cascade)
+  await admin.from("members").delete().eq("user_id", userId);
+
+  // Delete workspaces created by this user
+  await admin.from("workspaces").delete().eq("created_by", userId);
+
+  // Delete profile
+  await admin.from("profiles").delete().eq("id", userId);
+
+  // Delete the auth user
+  const { error } = await admin.auth.admin.deleteUser(userId);
+  if (error) {
+    console.warn(`Failed to delete test user ${userId}: ${error.message}`);
+  }
+}
+
+/**
+ * Fetches the invite token for a given email and workspace from the database.
+ * Bypasses RLS via the admin client.
+ */
+export async function getInviteToken(
+  workspaceId: string,
+  email: string
+): Promise<string> {
+  const admin = getAdminClient();
+
+  const { data, error } = await admin
+    .from("workspace_invites")
+    .select("token")
+    .eq("workspace_id", workspaceId)
+    .ilike("email", email)
+    .is("accepted_at", null)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(
+      `No pending invite found for ${email}: ${error?.message ?? "not found"}`
+    );
+  }
+
+  return data.token;
+}
+
+/**
+ * Fetches the workspace ID and slug for a user's first non-personal workspace,
+ * or their personal workspace if no team workspaces exist.
+ */
+export async function getWorkspaceForUser(
+  userId: string
+): Promise<{ id: string; slug: string }> {
+  const admin = getAdminClient();
+
+  const { data, error } = await admin
+    .from("members")
+    .select("workspace_id, workspaces(id, slug, is_personal)")
+    .eq("user_id", userId)
+    .limit(10);
+
+  if (error || !data || data.length === 0) {
+    throw new Error(
+      `No workspace found for user ${userId}: ${error?.message ?? "no memberships"}`
+    );
+  }
+
+  // Prefer non-personal workspace, fall back to personal
+  for (const row of data) {
+    const ws = row.workspaces as unknown as {
+      id: string;
+      slug: string;
+      is_personal: boolean;
+    };
+    if (!ws.is_personal) {
+      return { id: ws.id, slug: ws.slug };
+    }
+  }
+
+  const ws = data[0].workspaces as unknown as { id: string; slug: string };
+  return { id: ws.id, slug: ws.slug };
+}
+
+/**
+ * Cleans up any pending invites for a given email across all workspaces.
+ */
+export async function cleanupInvitesForEmail(email: string): Promise<void> {
+  const admin = getAdminClient();
+  await admin
+    .from("workspace_invites")
+    .delete()
+    .ilike("email", email)
+    .is("accepted_at", null);
+}

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -1,0 +1,307 @@
+import { test, expect } from "./fixtures/auth";
+import {
+  createTestUser,
+  deleteTestUser,
+  getInviteToken,
+  cleanupInvitesForEmail,
+} from "./fixtures/supabase-admin";
+import { createClient } from "@supabase/supabase-js";
+import { type Browser, type Page } from "@playwright/test";
+
+const INVITE_EMAIL = `e2e-member-${Date.now()}@test.local`;
+const INVITE_DISPLAY_NAME = "E2E Member";
+const INVITE_PASSWORD = "TestPassword123!";
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } }
+  );
+}
+
+/**
+ * Extract the workspace slug from the current URL after login redirect.
+ */
+function extractWorkspaceSlug(page: Page): string {
+  const url = new URL(page.url());
+  const segments = url.pathname.split("/").filter(Boolean);
+  const slug = segments[0];
+  if (!slug) {
+    throw new Error(`Could not extract workspace slug from URL: ${page.url()}`);
+  }
+  return slug;
+}
+
+/**
+ * Navigate to the members settings page for a given workspace slug.
+ */
+async function goToMembersPage(page: Page, slug: string): Promise<void> {
+  await page.goto(`/${slug}/settings/members`);
+  await expect(page.getByRole("heading", { name: "Members" })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+/**
+ * Sign in as a specific user in a new browser context.
+ */
+async function signInAs(
+  browser: Browser,
+  email: string,
+  password: string
+): Promise<Page> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto("/sign-in");
+  await page.fill('input[type="email"]', email);
+  await page.fill('input[type="password"]', password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL((url) => !url.pathname.includes("/sign-in"), {
+    timeout: 15_000,
+  });
+
+  return page;
+}
+
+test.describe("Workspace member management", () => {
+  test.describe.configure({ mode: "serial" });
+
+  // Shared state across serial tests
+  let invitedUserId: string | undefined;
+  let workspaceSlug: string;
+
+  test.afterAll(async () => {
+    await cleanupInvitesForEmail(INVITE_EMAIL).catch(() => {});
+    if (invitedUserId) {
+      await deleteTestUser(invitedUserId).catch(() => {});
+    }
+  });
+
+  test("owner can invite a user by email", async ({
+    authenticatedPage: page,
+  }) => {
+    workspaceSlug = extractWorkspaceSlug(page);
+    await goToMembersPage(page, workspaceSlug);
+
+    // The invite form should be visible (owner has admin privileges)
+    const inviteSection = page.locator("text=Invite").first();
+    await expect(inviteSection).toBeVisible();
+
+    // Fill in the invite form
+    await page.fill("#invite-email", INVITE_EMAIL);
+
+    // Submit the invite
+    await page.getByRole("button", { name: /invite/i }).click();
+
+    // Wait for success message
+    await expect(page.locator("text=Invite sent.")).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("invited user appears in the pending invites list", async ({
+    authenticatedPage: page,
+  }) => {
+    await goToMembersPage(page, workspaceSlug);
+
+    // The pending invites section should show the invited email
+    const pendingSection = page.locator("text=Pending invites").first();
+    await expect(pendingSection).toBeVisible({ timeout: 5_000 });
+
+    // The invited email should appear in the pending invites table
+    await expect(page.locator(`text=${INVITE_EMAIL}`)).toBeVisible();
+  });
+
+  test("owner can revoke a pending invite", async ({
+    authenticatedPage: page,
+  }) => {
+    await goToMembersPage(page, workspaceSlug);
+
+    // Find the revoke button for the invited email's row
+    const inviteRow = page
+      .getByRole("row")
+      .filter({ hasText: INVITE_EMAIL });
+    await expect(inviteRow).toBeVisible({ timeout: 5_000 });
+
+    const revokeButton = inviteRow.getByRole("button", {
+      name: new RegExp(`Revoke invite for ${INVITE_EMAIL}`, "i"),
+    });
+    await revokeButton.click();
+
+    // The invite should disappear from the list
+    await expect(page.locator(`text=${INVITE_EMAIL}`)).not.toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("owner can re-invite and invited user can accept", async ({
+    authenticatedPage: page,
+    browser,
+  }) => {
+    await goToMembersPage(page, workspaceSlug);
+
+    // Re-invite the same email
+    await page.fill("#invite-email", INVITE_EMAIL);
+    await page.getByRole("button", { name: /invite/i }).click();
+    await expect(page.locator("text=Invite sent.")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Create the test user via admin API so they can accept the invite
+    const testUser = await createTestUser(
+      INVITE_EMAIL,
+      INVITE_PASSWORD,
+      INVITE_DISPLAY_NAME
+    );
+    invitedUserId = testUser.id;
+
+    // Look up the invite token via admin API
+    const admin = getAdminClient();
+    const { data: ws } = await admin
+      .from("workspaces")
+      .select("id")
+      .eq("slug", workspaceSlug)
+      .maybeSingle();
+    if (!ws) throw new Error(`Workspace ${workspaceSlug} not found`);
+
+    const inviteToken = await getInviteToken(ws.id, INVITE_EMAIL);
+
+    // Sign in as the invited user and accept the invite
+    const invitedPage = await signInAs(browser, INVITE_EMAIL, INVITE_PASSWORD);
+
+    await invitedPage.goto(`/invite/${inviteToken}`);
+
+    await expect(
+      invitedPage.getByRole("button", { name: /accept invite/i })
+    ).toBeVisible({ timeout: 10_000 });
+
+    await invitedPage.getByRole("button", { name: /accept invite/i }).click();
+
+    // Should redirect to the workspace
+    await invitedPage.waitForURL(
+      (url) => url.pathname.includes(workspaceSlug),
+      { timeout: 15_000 }
+    );
+
+    await invitedPage.context().close();
+
+    // Back on the owner's page — navigate explicitly to the members page
+    await goToMembersPage(page, workspaceSlug);
+
+    // The new member should appear in the member list
+    await expect(page.locator(`text=${INVITE_DISPLAY_NAME}`)).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("owner can change a member's role", async ({
+    authenticatedPage: page,
+  }) => {
+    await goToMembersPage(page, workspaceSlug);
+
+    // Find the row for the invited member
+    const memberRow = page
+      .getByRole("row")
+      .filter({ hasText: INVITE_DISPLAY_NAME });
+    await expect(memberRow).toBeVisible({ timeout: 5_000 });
+
+    // The member should have a role select (since the owner can change roles)
+    const roleSelect = memberRow.getByRole("combobox");
+    await expect(roleSelect).toBeVisible();
+
+    // Change role from member to admin
+    await roleSelect.click();
+    await page.getByRole("option", { name: "admin" }).click();
+
+    // Wait for the page to refresh and verify the role changed
+    await page.waitForTimeout(1_000);
+    await goToMembersPage(page, workspaceSlug);
+
+    // Verify the member now has admin role — the select should show "admin"
+    const updatedRow = page
+      .getByRole("row")
+      .filter({ hasText: INVITE_DISPLAY_NAME });
+    await expect(updatedRow).toBeVisible();
+    await expect(updatedRow.getByRole("combobox")).toHaveText(/admin/i);
+  });
+
+  test("member role cannot access invite or remove controls", async ({
+    browser,
+  }) => {
+    if (!invitedUserId) {
+      test.skip(true, "No invited user created in previous test");
+      return;
+    }
+
+    // Change the invited user's role back to "member" via admin API
+    const admin = getAdminClient();
+    await admin
+      .from("members")
+      .update({ role: "member" })
+      .eq("user_id", invitedUserId);
+
+    // Sign in as the invited user (member role)
+    const memberPage = await signInAs(browser, INVITE_EMAIL, INVITE_PASSWORD);
+
+    await memberPage.goto(`/${workspaceSlug}/settings/members`);
+    await expect(
+      memberPage.getByRole("heading", { name: "Members" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Member should NOT see the invite form
+    await expect(memberPage.locator("#invite-email")).not.toBeVisible();
+
+    // Member should NOT see remove buttons (trash icons)
+    const removeButtons = memberPage.getByRole("button", {
+      name: /remove/i,
+    });
+    await expect(removeButtons).toHaveCount(0);
+
+    // Member should NOT see role select dropdowns in the members table
+    // (roles are shown as badges, not selects, for non-admin users)
+    const membersTable = memberPage.getByRole("table").first();
+    const roleSelects = membersTable.getByRole("combobox");
+    await expect(roleSelects).toHaveCount(0);
+
+    await memberPage.context().close();
+  });
+
+  test("owner can remove a member", async ({ authenticatedPage: page }) => {
+    if (!invitedUserId) {
+      test.skip(true, "No invited user created in previous test");
+      return;
+    }
+
+    await goToMembersPage(page, workspaceSlug);
+
+    // Find the row for the invited member
+    const memberRow = page
+      .getByRole("row")
+      .filter({ hasText: INVITE_DISPLAY_NAME });
+    await expect(memberRow).toBeVisible({ timeout: 5_000 });
+
+    // Click the remove button
+    const removeButton = memberRow.getByRole("button", {
+      name: new RegExp(`Remove ${INVITE_DISPLAY_NAME}`, "i"),
+    });
+    await removeButton.click();
+
+    // Confirm in the alert dialog
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible({ timeout: 3_000 });
+    await expect(dialog.locator("text=Remove member")).toBeVisible();
+
+    await dialog.getByRole("button", { name: /^remove$/i }).click();
+
+    // Wait for the dialog to close
+    await expect(dialog).not.toBeVisible({ timeout: 5_000 });
+
+    // The member row should disappear from the table
+    const removedRow = page
+      .getByRole("row")
+      .filter({ hasText: INVITE_DISPLAY_NAME });
+    await expect(removedRow).not.toBeVisible({ timeout: 5_000 });
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
@@ -41,10 +41,12 @@ export default async function WorkspaceMembersPage({
     notFound();
   }
 
-  // Fetch all members with profile info
+  // Fetch all members with profile info.
+  // Disambiguate the profiles join: members has two FKs to profiles
+  // (user_id and invited_by). We want the user's profile.
   const { data: membersRaw } = await supabase
     .from("members")
-    .select("*, profiles(email, display_name, avatar_url)")
+    .select("*, profiles!members_user_id_fkey(email, display_name, avatar_url)")
     .eq("workspace_id", workspace.id)
     .order("created_at", { ascending: true });
 

--- a/src/components/members/invite-form.tsx
+++ b/src/components/members/invite-form.tsx
@@ -47,10 +47,11 @@ export function InviteForm({
 
     const supabase = createClient();
 
-    // Check if user is already a member
+    // Check if user is already a member.
+    // Disambiguate: members has two FKs to profiles (user_id, invited_by).
     const { data: existingMember } = await supabase
       .from("members")
-      .select("id, profiles(email)")
+      .select("id, profiles!members_user_id_fkey(email)")
       .eq("workspace_id", workspaceId);
 
     const alreadyMember = existingMember?.some((m) => {


### PR DESCRIPTION
Closes #110

## What

Adds 7 E2E tests covering the full workspace member management lifecycle, and fixes a pre-existing bug where the members list was always empty due to an ambiguous Supabase join.

## How

**E2E tests** (`e2e/members.spec.ts`):
- Owner can invite a user by email
- Invited user appears in the pending invites list
- Owner can revoke a pending invite
- Owner can re-invite and invited user can accept (via invite token)
- Owner can change a member's role
- Member role cannot access invite or remove controls
- Owner can remove a member

Tests use a temporary test user created/deleted via the Supabase Admin API (`e2e/fixtures/supabase-admin.ts`). The test suite runs serially since later tests depend on state from earlier ones.

**Bug fix**: The `members` table has two foreign keys to `profiles` (`user_id` and `invited_by`). PostgREST cannot disambiguate the join, causing `select("*, profiles(...)")` to silently return `null`. Fixed by specifying the constraint name: `profiles!members_user_id_fkey(...)`. Affected files:
- `src/app/(app)/[workspaceSlug]/settings/members/page.tsx`
- `src/components/members/invite-form.tsx`

**Knowledge base updates**:
- `.agents/conventions.md` — added "Disambiguating Supabase joins" pattern
- `.agents/quality.md` — updated Members domain quality rating

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 58 tests passed ✅
- `pnpm test:e2e` — 35 tests passed (7 new) ✅