### PR TITLE
feat: extract page tree logic into testable utility (#113)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -176,7 +176,7 @@ src/
 │   │   ├── workspace-switcher.tsx # Dropdown listing all workspaces, create workspace trigger
 │   │   ├── create-workspace-dialog.tsx # Dialog for creating a new workspace
 │   │   ├── page-search.tsx      # Full-text search input + results dropdown (debounced, 300ms)
-│   │   ├── page-tree.tsx        # Hierarchical page tree with CRUD, drag-and-drop, nest/unnest
+│   │   ├── page-tree.tsx        # Hierarchical page tree with CRUD, drag-and-drop, nest/unnest (uses lib/page-tree.ts)
 │   │   └── user-menu.tsx        # User dropdown with settings link + sign-out
 │   ├── editor/                  # Lexical block editor
 │   │   ├── editor.tsx               # Main editor: LexicalComposer, plugins, auto-save to Supabase
@@ -220,6 +220,7 @@ src/
 │       ├── table.tsx
 │       └── tooltip.tsx
 ├── lib/
+│   ├── page-tree.ts        # Pure functions: tree building, reorder, nest/unnest, drop computation
 │   ├── sentry.ts           # captureSupabaseError helper (structured Sentry reporting)
 │   ├── utils.ts            # cn() utility (clsx + tailwind-merge)
 │   ├── types.ts            # Database entity types

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -32,60 +32,20 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import type { Page } from "@/lib/types";
+import {
+  buildTree,
+  computeDrop,
+  computeNest,
+  computeSwapPositions,
+  computeUnnest,
+  getDescendantIds,
+  getNextSiblingPosition,
+  getSortedSiblings,
+  type TreeNode,
+} from "@/lib/page-tree";
 
 interface PageTreeProps {
   userId: string;
-}
-
-interface TreeNode {
-  page: Page;
-  children: TreeNode[];
-}
-
-function buildTree(pages: Page[]): TreeNode[] {
-  const map = new Map<string, TreeNode>();
-  const roots: TreeNode[] = [];
-
-  for (const page of pages) {
-    map.set(page.id, { page, children: [] });
-  }
-
-  for (const page of pages) {
-    const node = map.get(page.id)!;
-    if (page.parent_id && map.has(page.parent_id)) {
-      map.get(page.parent_id)!.children.push(node);
-    } else {
-      roots.push(node);
-    }
-  }
-
-  function sortChildren(nodes: TreeNode[]) {
-    nodes.sort((a, b) => a.page.position - b.page.position);
-    for (const node of nodes) {
-      sortChildren(node.children);
-    }
-  }
-  sortChildren(roots);
-
-  return roots;
-}
-
-function getDescendantIds(node: TreeNode): string[] {
-  const ids: string[] = [];
-  for (const child of node.children) {
-    ids.push(child.page.id);
-    ids.push(...getDescendantIds(child));
-  }
-  return ids;
-}
-
-function findNode(nodes: TreeNode[], id: string): TreeNode | null {
-  for (const node of nodes) {
-    if (node.page.id === id) return node;
-    const found = findNode(node.children, id);
-    if (found) return found;
-  }
-  return null;
 }
 
 export function PageTree({ userId }: PageTreeProps) {
@@ -124,32 +84,38 @@ export function PageTree({ userId }: PageTreeProps) {
       });
   }, [workspaceSlug]);
 
-  const fetchPages = useCallback(async () => {
+  useEffect(() => {
     if (!workspaceId) return;
 
-    const supabase = createClient();
-    const { data, error } = await supabase
-      .from("pages")
-      .select("*")
-      .eq("workspace_id", workspaceId)
-      .order("position", { ascending: true });
+    let cancelled = false;
 
-    if (error) {
-      captureSupabaseError(error, "page-tree:fetch-pages");
-      toast.error("Failed to load pages", { duration: 8000 });
+    async function fetchPages() {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from("pages")
+        .select("*")
+        .eq("workspace_id", workspaceId)
+        .order("position", { ascending: true });
+
+      if (cancelled) return;
+
+      if (error) {
+        captureSupabaseError(error, "page-tree:fetch-pages");
+        toast.error("Failed to load pages", { duration: 8000 });
+      }
+
+      if (data) {
+        setPages(data);
+      }
+      setLoading(false);
     }
 
-    if (data) {
-      setPages(data);
-    }
-    setLoading(false);
+    fetchPages();
+
+    return () => {
+      cancelled = true;
+    };
   }, [workspaceId]);
-
-  useEffect(() => {
-    if (workspaceId) {
-      fetchPages();
-    }
-  }, [workspaceId, fetchPages]);
 
   const tree = useMemo(() => buildTree(pages), [pages]);
 
@@ -168,11 +134,7 @@ export function PageTree({ userId }: PageTreeProps) {
   async function handleCreate(parentId: string | null) {
     if (!workspaceId || !workspaceSlug) return;
 
-    const siblings = pages.filter((p) => p.parent_id === parentId);
-    const nextPosition =
-      siblings.length > 0
-        ? Math.max(...siblings.map((p) => p.position)) + 1
-        : 0;
+    const nextPosition = getNextSiblingPosition(pages, parentId);
 
     const supabase = createClient();
     const { data: newPage, error } = await supabase
@@ -233,44 +195,34 @@ export function PageTree({ userId }: PageTreeProps) {
   }
 
   async function handleMoveUp(page: Page) {
-    const siblings = pages
-      .filter((p) => p.parent_id === page.parent_id)
-      .sort((a, b) => a.position - b.position);
-
-    const idx = siblings.findIndex((p) => p.id === page.id);
-    if (idx <= 0) return;
-
-    const prev = siblings[idx - 1];
-    await swapPositions(page, prev);
+    const result = computeSwapPositions(pages, page.id, "up");
+    if (!result) return;
+    await applySwap(result.updates);
   }
 
   async function handleMoveDown(page: Page) {
-    const siblings = pages
-      .filter((p) => p.parent_id === page.parent_id)
-      .sort((a, b) => a.position - b.position);
-
-    const idx = siblings.findIndex((p) => p.id === page.id);
-    if (idx < 0 || idx >= siblings.length - 1) return;
-
-    const next = siblings[idx + 1];
-    await swapPositions(page, next);
+    const result = computeSwapPositions(pages, page.id, "down");
+    if (!result) return;
+    await applySwap(result.updates);
   }
 
-  async function swapPositions(a: Page, b: Page) {
+  async function applySwap(
+    updates: Array<{ id: string; position: number }>,
+  ) {
     const supabase = createClient();
 
     setPages((prev) =>
       prev.map((p) => {
-        if (p.id === a.id) return { ...p, position: b.position };
-        if (p.id === b.id) return { ...p, position: a.position };
-        return p;
+        const update = updates.find((u) => u.id === p.id);
+        return update ? { ...p, position: update.position } : p;
       })
     );
 
-    const results = await Promise.all([
-      supabase.from("pages").update({ position: b.position }).eq("id", a.id),
-      supabase.from("pages").update({ position: a.position }).eq("id", b.id),
-    ]);
+    const results = await Promise.all(
+      updates.map((u) =>
+        supabase.from("pages").update({ position: u.position }).eq("id", u.id)
+      )
+    );
 
     for (const result of results) {
       if (result.error) {
@@ -282,35 +234,25 @@ export function PageTree({ userId }: PageTreeProps) {
   }
 
   async function handleNest(page: Page) {
-    const siblings = pages
-      .filter((p) => p.parent_id === page.parent_id)
-      .sort((a, b) => a.position - b.position);
+    const result = computeNest(pages, page.id);
+    if (!result) return;
 
-    const idx = siblings.findIndex((p) => p.id === page.id);
-    if (idx <= 0) return;
-
-    const newParent = siblings[idx - 1];
-    const newSiblings = pages.filter((p) => p.parent_id === newParent.id);
-    const nextPosition =
-      newSiblings.length > 0
-        ? Math.max(...newSiblings.map((p) => p.position)) + 1
-        : 0;
-
+    const { parentId, position } = result;
     const supabase = createClient();
 
     setPages((prev) =>
       prev.map((p) =>
         p.id === page.id
-          ? { ...p, parent_id: newParent.id, position: nextPosition }
+          ? { ...p, parent_id: parentId, position }
           : p
       )
     );
 
-    setExpanded((prev) => new Set(prev).add(newParent.id));
+    setExpanded((prev) => new Set(prev).add(parentId));
 
     const { error } = await supabase
       .from("pages")
-      .update({ parent_id: newParent.id, position: nextPosition })
+      .update({ parent_id: parentId, position })
       .eq("id", page.id);
 
     if (error) {
@@ -320,53 +262,43 @@ export function PageTree({ userId }: PageTreeProps) {
   }
 
   async function handleUnnest(page: Page) {
-    if (!page.parent_id) return;
+    const result = computeUnnest(pages, page.id);
+    if (!result) return;
 
-    const parent = pages.find((p) => p.id === page.parent_id);
-    if (!parent) return;
-
-    const parentSiblings = pages
-      .filter((p) => p.parent_id === parent.parent_id)
-      .sort((a, b) => a.position - b.position);
-
-    const nextPosition = parent.position + 1;
-
-    const toShift = parentSiblings.filter(
-      (p) => p.position >= nextPosition && p.id !== page.id
-    );
-
+    const { pageUpdate, shiftUpdates } = result;
     const supabase = createClient();
 
     setPages((prev) =>
       prev.map((p) => {
         if (p.id === page.id) {
-          return { ...p, parent_id: parent.parent_id, position: nextPosition };
+          return { ...p, parent_id: pageUpdate.parentId, position: pageUpdate.position };
         }
-        if (toShift.some((s) => s.id === p.id)) {
-          return { ...p, position: p.position + 1 };
+        const shift = shiftUpdates.find((s) => s.id === p.id);
+        if (shift) {
+          return { ...p, position: shift.position };
         }
         return p;
       })
     );
 
-    const updates = [
+    const dbUpdates = [
       supabase
         .from("pages")
-        .update({ parent_id: parent.parent_id, position: nextPosition })
+        .update({ parent_id: pageUpdate.parentId, position: pageUpdate.position })
         .eq("id", page.id),
-      ...toShift.map((s) =>
+      ...shiftUpdates.map((s) =>
         supabase
           .from("pages")
-          .update({ position: s.position + 1 })
+          .update({ position: s.position })
           .eq("id", s.id)
       ),
     ];
 
-    const results = await Promise.all(updates);
+    const results = await Promise.all(dbUpdates);
 
-    for (const result of results) {
-      if (result.error) {
-        captureSupabaseError(result.error, "page-tree:unnest-page");
+    for (const r of results) {
+      if (r.error) {
+        captureSupabaseError(r.error, "page-tree:unnest-page");
         toast.error("Failed to unnest page", { duration: 8000 });
         break;
       }
@@ -411,91 +343,54 @@ export function PageTree({ userId }: PageTreeProps) {
       return;
     }
 
-    const draggedPage = pages.find((p) => p.id === draggedId);
-    const targetPage = pages.find((p) => p.id === dropTarget.id);
-    if (!draggedPage || !targetPage) {
+    const result = computeDrop(
+      pages,
+      tree,
+      draggedId,
+      dropTarget.id,
+      dropTarget.position,
+    );
+
+    if (!result) {
       setDraggedId(null);
       setDropTarget(null);
       return;
     }
 
-    // Prevent dropping a parent onto its own descendant
-    const draggedNode = findNode(tree, draggedId);
-    if (draggedNode) {
-      const descendantIds = getDescendantIds(draggedNode);
-      if (descendantIds.includes(dropTarget.id)) {
-        setDraggedId(null);
-        setDropTarget(null);
-        return;
-      }
-    }
-
     const supabase = createClient();
 
+    // Optimistic UI update
+    setPages((prev) => {
+      const next = [...prev];
+      for (const update of result.updates) {
+        const idx = next.findIndex((p) => p.id === update.id);
+        if (idx !== -1) {
+          next[idx] = {
+            ...next[idx],
+            parent_id: update.parentId,
+            position: update.position,
+          };
+        }
+      }
+      return next;
+    });
+
+    // Expand target when dropping inside
     if (dropTarget.position === "inside") {
-      const newSiblings = pages.filter((p) => p.parent_id === targetPage.id);
-      const nextPos =
-        newSiblings.length > 0
-          ? Math.max(...newSiblings.map((p) => p.position)) + 1
-          : 0;
+      setExpanded((prev) => new Set(prev).add(dropTarget.id));
+    }
 
-      setPages((prev) =>
-        prev.map((p) =>
-          p.id === draggedId
-            ? { ...p, parent_id: targetPage.id, position: nextPos }
-            : p
-        )
-      );
-      setExpanded((prev) => new Set(prev).add(targetPage.id));
-
+    // Persist to database
+    for (const update of result.updates) {
       const { error } = await supabase
         .from("pages")
-        .update({ parent_id: targetPage.id, position: nextPos })
-        .eq("id", draggedId);
+        .update({ parent_id: update.parentId, position: update.position })
+        .eq("id", update.id);
 
       if (error) {
-        captureSupabaseError(error, "page-tree:drop-inside");
+        captureSupabaseError(error, "page-tree:drop-reorder");
         toast.error("Failed to move page", { duration: 8000 });
-      }
-    } else {
-      const newParentId = targetPage.parent_id;
-      const siblings = pages
-        .filter((p) => p.parent_id === newParentId && p.id !== draggedId)
-        .sort((a, b) => a.position - b.position);
-
-      const targetIdx = siblings.findIndex((p) => p.id === targetPage.id);
-      const insertIdx =
-        dropTarget.position === "before" ? targetIdx : targetIdx + 1;
-
-      const reordered = [...siblings];
-      reordered.splice(insertIdx, 0, draggedPage);
-
-      setPages((prev) => {
-        const next = [...prev];
-        for (let i = 0; i < reordered.length; i++) {
-          const idx = next.findIndex((p) => p.id === reordered[i].id);
-          if (idx !== -1) {
-            next[idx] = {
-              ...next[idx],
-              parent_id: newParentId,
-              position: i,
-            };
-          }
-        }
-        return next;
-      });
-
-      for (let i = 0; i < reordered.length; i++) {
-        const { error } = await supabase
-          .from("pages")
-          .update({ parent_id: newParentId, position: i })
-          .eq("id", reordered[i].id);
-
-        if (error) {
-          captureSupabaseError(error, "page-tree:drop-reorder");
-          toast.error("Failed to move page", { duration: 8000 });
-          break;
-        }
+        break;
       }
     }
 
@@ -659,9 +554,7 @@ function PageTreeItem({
   const isDragged = draggedId === page.id;
   const isDropTarget = dropTarget?.id === page.id;
 
-  const siblings = pages
-    .filter((p) => p.parent_id === page.parent_id)
-    .sort((a, b) => a.position - b.position);
+  const siblings = getSortedSiblings(pages, page.parent_id);
   const siblingIdx = siblings.findIndex((p) => p.id === page.id);
   const canNest = siblingIdx > 0;
   const canUnnest = page.parent_id !== null;

--- a/src/lib/page-tree.test.ts
+++ b/src/lib/page-tree.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect } from "vitest";
+import type { Page } from "@/lib/types";
+import {
+  buildTree,
+  getDescendantIds,
+  findNode,
+  getNextSiblingPosition,
+  getSortedSiblings,
+  computeSwapPositions,
+  computeNest,
+  computeUnnest,
+  computeDrop,
+} from "./page-tree";
+
+/** Helper to create a minimal Page for testing. */
+function makePage(overrides: Partial<Page> & { id: string }): Page {
+  return {
+    workspace_id: "ws-1",
+    parent_id: null,
+    title: overrides.id,
+    content: null,
+    icon: null,
+    position: 0,
+    created_by: "user-1",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("buildTree", () => {
+  it("builds a flat list into root nodes sorted by position", () => {
+    const pages = [
+      makePage({ id: "b", position: 1 }),
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "c", position: 2 }),
+    ];
+
+    const tree = buildTree(pages);
+
+    expect(tree).toHaveLength(3);
+    expect(tree.map((n) => n.page.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("nests children under their parent", () => {
+    const pages = [
+      makePage({ id: "root", position: 0 }),
+      makePage({ id: "child-1", parent_id: "root", position: 0 }),
+      makePage({ id: "child-2", parent_id: "root", position: 1 }),
+    ];
+
+    const tree = buildTree(pages);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].page.id).toBe("root");
+    expect(tree[0].children).toHaveLength(2);
+    expect(tree[0].children[0].page.id).toBe("child-1");
+    expect(tree[0].children[1].page.id).toBe("child-2");
+  });
+
+  it("treats orphans (parent_id references missing page) as roots", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "orphan", parent_id: "nonexistent", position: 1 }),
+    ];
+
+    const tree = buildTree(pages);
+
+    expect(tree).toHaveLength(2);
+    expect(tree.map((n) => n.page.id)).toEqual(["a", "orphan"]);
+  });
+
+  it("sorts children by position at every level", () => {
+    const pages = [
+      makePage({ id: "root", position: 0 }),
+      makePage({ id: "c2", parent_id: "root", position: 2 }),
+      makePage({ id: "c0", parent_id: "root", position: 0 }),
+      makePage({ id: "c1", parent_id: "root", position: 1 }),
+      makePage({ id: "gc1", parent_id: "c1", position: 1 }),
+      makePage({ id: "gc0", parent_id: "c1", position: 0 }),
+    ];
+
+    const tree = buildTree(pages);
+    const root = tree[0];
+
+    expect(root.children.map((n) => n.page.id)).toEqual(["c0", "c1", "c2"]);
+    expect(root.children[1].children.map((n) => n.page.id)).toEqual([
+      "gc0",
+      "gc1",
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(buildTree([])).toEqual([]);
+  });
+});
+
+describe("getDescendantIds", () => {
+  it("returns all descendant IDs recursively", () => {
+    const pages = [
+      makePage({ id: "root", position: 0 }),
+      makePage({ id: "child", parent_id: "root", position: 0 }),
+      makePage({ id: "grandchild", parent_id: "child", position: 0 }),
+    ];
+
+    const tree = buildTree(pages);
+    const ids = getDescendantIds(tree[0]);
+
+    expect(ids).toEqual(["child", "grandchild"]);
+  });
+
+  it("returns empty array for leaf nodes", () => {
+    const pages = [makePage({ id: "leaf", position: 0 })];
+    const tree = buildTree(pages);
+
+    expect(getDescendantIds(tree[0])).toEqual([]);
+  });
+});
+
+describe("findNode", () => {
+  it("finds a root node", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+    ];
+    const tree = buildTree(pages);
+
+    expect(findNode(tree, "b")?.page.id).toBe("b");
+  });
+
+  it("finds a deeply nested node", () => {
+    const pages = [
+      makePage({ id: "root", position: 0 }),
+      makePage({ id: "child", parent_id: "root", position: 0 }),
+      makePage({ id: "deep", parent_id: "child", position: 0 }),
+    ];
+    const tree = buildTree(pages);
+
+    expect(findNode(tree, "deep")?.page.id).toBe("deep");
+  });
+
+  it("returns null for non-existent ID", () => {
+    const tree = buildTree([makePage({ id: "a", position: 0 })]);
+
+    expect(findNode(tree, "missing")).toBeNull();
+  });
+});
+
+describe("getNextSiblingPosition", () => {
+  it("returns 0 when there are no siblings", () => {
+    expect(getNextSiblingPosition([], null)).toBe(0);
+  });
+
+  it("returns max position + 1 among siblings", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 3 }),
+      makePage({ id: "c", position: 1 }),
+    ];
+
+    expect(getNextSiblingPosition(pages, null)).toBe(4);
+  });
+
+  it("scopes to the correct parent", () => {
+    const pages = [
+      makePage({ id: "root", position: 5 }),
+      makePage({ id: "child", parent_id: "root", position: 2 }),
+    ];
+
+    expect(getNextSiblingPosition(pages, "root")).toBe(3);
+    expect(getNextSiblingPosition(pages, null)).toBe(6);
+  });
+});
+
+describe("getSortedSiblings", () => {
+  it("returns siblings sorted by position", () => {
+    const pages = [
+      makePage({ id: "c", position: 2 }),
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+      makePage({ id: "child", parent_id: "a", position: 0 }),
+    ];
+
+    const siblings = getSortedSiblings(pages, null);
+
+    expect(siblings.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("computeSwapPositions", () => {
+  const pages = [
+    makePage({ id: "a", position: 0 }),
+    makePage({ id: "b", position: 1 }),
+    makePage({ id: "c", position: 2 }),
+  ];
+
+  it("swaps with the previous sibling when moving up", () => {
+    const result = computeSwapPositions(pages, "b", "up");
+
+    expect(result).toEqual({
+      updates: [
+        { id: "b", position: 0 },
+        { id: "a", position: 1 },
+      ],
+    });
+  });
+
+  it("swaps with the next sibling when moving down", () => {
+    const result = computeSwapPositions(pages, "b", "down");
+
+    expect(result).toEqual({
+      updates: [
+        { id: "b", position: 2 },
+        { id: "c", position: 1 },
+      ],
+    });
+  });
+
+  it("returns null when moving up the first sibling", () => {
+    expect(computeSwapPositions(pages, "a", "up")).toBeNull();
+  });
+
+  it("returns null when moving down the last sibling", () => {
+    expect(computeSwapPositions(pages, "c", "down")).toBeNull();
+  });
+
+  it("returns null for non-existent page", () => {
+    expect(computeSwapPositions(pages, "missing", "up")).toBeNull();
+  });
+});
+
+describe("computeNest", () => {
+  it("nests a page under its preceding sibling", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+    ];
+
+    const result = computeNest(pages, "b");
+
+    expect(result).toEqual({ parentId: "a", position: 0 });
+  });
+
+  it("places nested page after existing children of new parent", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+      makePage({ id: "a-child", parent_id: "a", position: 0 }),
+    ];
+
+    const result = computeNest(pages, "b");
+
+    expect(result).toEqual({ parentId: "a", position: 1 });
+  });
+
+  it("returns null for the first sibling (nothing above to nest under)", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+    ];
+
+    expect(computeNest(pages, "a")).toBeNull();
+  });
+
+  it("returns null for non-existent page", () => {
+    expect(computeNest([], "missing")).toBeNull();
+  });
+});
+
+describe("computeUnnest", () => {
+  it("moves a child to its parent's level, right after the parent", () => {
+    const pages = [
+      makePage({ id: "parent", position: 0 }),
+      makePage({ id: "child", parent_id: "parent", position: 0 }),
+      makePage({ id: "sibling", position: 1 }),
+    ];
+
+    const result = computeUnnest(pages, "child");
+
+    expect(result).toEqual({
+      pageUpdate: { parentId: null, position: 1 },
+      shiftUpdates: [{ id: "sibling", position: 2 }],
+    });
+  });
+
+  it("returns null for a root page", () => {
+    const pages = [makePage({ id: "root", position: 0 })];
+
+    expect(computeUnnest(pages, "root")).toBeNull();
+  });
+
+  it("returns null for non-existent page", () => {
+    expect(computeUnnest([], "missing")).toBeNull();
+  });
+
+  it("shifts multiple siblings when unnesting", () => {
+    const pages = [
+      makePage({ id: "parent", position: 0 }),
+      makePage({ id: "child", parent_id: "parent", position: 0 }),
+      makePage({ id: "sib1", position: 1 }),
+      makePage({ id: "sib2", position: 2 }),
+    ];
+
+    const result = computeUnnest(pages, "child");
+
+    expect(result).toEqual({
+      pageUpdate: { parentId: null, position: 1 },
+      shiftUpdates: [
+        { id: "sib1", position: 2 },
+        { id: "sib2", position: 3 },
+      ],
+    });
+  });
+
+  it("handles deeply nested unnest (child moves to grandparent level)", () => {
+    const pages = [
+      makePage({ id: "grandparent", position: 0 }),
+      makePage({ id: "parent", parent_id: "grandparent", position: 0 }),
+      makePage({ id: "child", parent_id: "parent", position: 0 }),
+    ];
+
+    const result = computeUnnest(pages, "child");
+
+    expect(result).toEqual({
+      pageUpdate: { parentId: "grandparent", position: 1 },
+      shiftUpdates: [],
+    });
+  });
+});
+
+describe("computeDrop", () => {
+  it("returns null when dragging onto self", () => {
+    const pages = [makePage({ id: "a", position: 0 })];
+    const tree = buildTree(pages);
+
+    expect(computeDrop(pages, tree, "a", "a", "inside")).toBeNull();
+  });
+
+  it("returns null when dropping parent onto its descendant", () => {
+    const pages = [
+      makePage({ id: "parent", position: 0 }),
+      makePage({ id: "child", parent_id: "parent", position: 0 }),
+    ];
+    const tree = buildTree(pages);
+
+    expect(computeDrop(pages, tree, "parent", "child", "inside")).toBeNull();
+  });
+
+  it("drops inside a target (makes it a child)", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+    ];
+    const tree = buildTree(pages);
+
+    const result = computeDrop(pages, tree, "b", "a", "inside");
+
+    expect(result).toEqual({
+      updates: [{ id: "b", parentId: "a", position: 0 }],
+    });
+  });
+
+  it("drops before a target (reorders siblings)", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+      makePage({ id: "c", position: 2 }),
+    ];
+    const tree = buildTree(pages);
+
+    const result = computeDrop(pages, tree, "c", "a", "before");
+
+    expect(result).toEqual({
+      updates: [
+        { id: "c", parentId: null, position: 0 },
+        { id: "a", parentId: null, position: 1 },
+        { id: "b", parentId: null, position: 2 },
+      ],
+    });
+  });
+
+  it("drops after a target (reorders siblings)", () => {
+    const pages = [
+      makePage({ id: "a", position: 0 }),
+      makePage({ id: "b", position: 1 }),
+      makePage({ id: "c", position: 2 }),
+    ];
+    const tree = buildTree(pages);
+
+    const result = computeDrop(pages, tree, "c", "a", "after");
+
+    expect(result).toEqual({
+      updates: [
+        { id: "a", parentId: null, position: 0 },
+        { id: "c", parentId: null, position: 1 },
+        { id: "b", parentId: null, position: 2 },
+      ],
+    });
+  });
+
+  it("drops across parents (moves to a different parent level)", () => {
+    const pages = [
+      makePage({ id: "root1", position: 0 }),
+      makePage({ id: "child", parent_id: "root1", position: 0 }),
+      makePage({ id: "root2", position: 1 }),
+    ];
+    const tree = buildTree(pages);
+
+    const result = computeDrop(pages, tree, "child", "root2", "after");
+
+    expect(result).toEqual({
+      updates: [
+        { id: "root1", parentId: null, position: 0 },
+        { id: "root2", parentId: null, position: 1 },
+        { id: "child", parentId: null, position: 2 },
+      ],
+    });
+  });
+
+  it("returns null for non-existent pages", () => {
+    const tree = buildTree([]);
+
+    expect(computeDrop([], tree, "a", "b", "inside")).toBeNull();
+  });
+});

--- a/src/lib/page-tree.ts
+++ b/src/lib/page-tree.ts
@@ -1,0 +1,224 @@
+// Pure functions for page tree manipulation.
+// No React or Supabase dependencies — all computation is side-effect-free.
+
+import type { Page } from "@/lib/types";
+
+export interface TreeNode {
+  page: Page;
+  children: TreeNode[];
+}
+
+/** Build a nested tree from a flat list of pages. Orphans become roots. */
+export function buildTree(pages: Page[]): TreeNode[] {
+  const map = new Map<string, TreeNode>();
+  const roots: TreeNode[] = [];
+
+  for (const page of pages) {
+    map.set(page.id, { page, children: [] });
+  }
+
+  for (const page of pages) {
+    const node = map.get(page.id)!;
+    if (page.parent_id && map.has(page.parent_id)) {
+      map.get(page.parent_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  function sortChildren(nodes: TreeNode[]) {
+    nodes.sort((a, b) => a.page.position - b.page.position);
+    for (const node of nodes) {
+      sortChildren(node.children);
+    }
+  }
+  sortChildren(roots);
+
+  return roots;
+}
+
+/** Collect all descendant IDs of a tree node (not including the node itself). */
+export function getDescendantIds(node: TreeNode): string[] {
+  const ids: string[] = [];
+  for (const child of node.children) {
+    ids.push(child.page.id);
+    ids.push(...getDescendantIds(child));
+  }
+  return ids;
+}
+
+/** Find a node by ID anywhere in the tree. Returns null if not found. */
+export function findNode(nodes: TreeNode[], id: string): TreeNode | null {
+  for (const node of nodes) {
+    if (node.page.id === id) return node;
+    const found = findNode(node.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Get the next available position among siblings of a given parent. */
+export function getNextSiblingPosition(
+  pages: Page[],
+  parentId: string | null,
+): number {
+  const siblings = pages.filter((p) => p.parent_id === parentId);
+  return siblings.length > 0
+    ? Math.max(...siblings.map((p) => p.position)) + 1
+    : 0;
+}
+
+/** Get sorted siblings for a page (pages sharing the same parent_id). */
+export function getSortedSiblings(pages: Page[], parentId: string | null): Page[] {
+  return pages
+    .filter((p) => p.parent_id === parentId)
+    .sort((a, b) => a.position - b.position);
+}
+
+/**
+ * Compute position swaps for moving a page up or down among siblings.
+ * Returns null if the move is not possible, otherwise returns the two
+ * page updates needed (swap positions of the two adjacent pages).
+ */
+export function computeSwapPositions(
+  pages: Page[],
+  pageId: string,
+  direction: "up" | "down",
+): { updates: Array<{ id: string; position: number }> } | null {
+  const page = pages.find((p) => p.id === pageId);
+  if (!page) return null;
+
+  const siblings = getSortedSiblings(pages, page.parent_id);
+  const idx = siblings.findIndex((p) => p.id === pageId);
+
+  if (direction === "up") {
+    if (idx <= 0) return null;
+    const other = siblings[idx - 1];
+    return {
+      updates: [
+        { id: page.id, position: other.position },
+        { id: other.id, position: page.position },
+      ],
+    };
+  } else {
+    if (idx < 0 || idx >= siblings.length - 1) return null;
+    const other = siblings[idx + 1];
+    return {
+      updates: [
+        { id: page.id, position: other.position },
+        { id: other.id, position: page.position },
+      ],
+    };
+  }
+}
+
+/**
+ * Compute the update needed to nest a page under its preceding sibling.
+ * Returns null if nesting is not possible (page is first among siblings).
+ */
+export function computeNest(
+  pages: Page[],
+  pageId: string,
+): { parentId: string; position: number } | null {
+  const page = pages.find((p) => p.id === pageId);
+  if (!page) return null;
+
+  const siblings = getSortedSiblings(pages, page.parent_id);
+  const idx = siblings.findIndex((p) => p.id === pageId);
+  if (idx <= 0) return null;
+
+  const newParent = siblings[idx - 1];
+  const position = getNextSiblingPosition(pages, newParent.id);
+
+  return { parentId: newParent.id, position };
+}
+
+/**
+ * Compute the updates needed to unnest a page (move it to its parent's level).
+ * Returns null if the page has no parent. The page is placed right after its
+ * former parent, and existing siblings at that level are shifted down.
+ */
+export function computeUnnest(
+  pages: Page[],
+  pageId: string,
+): {
+  pageUpdate: { parentId: string | null; position: number };
+  shiftUpdates: Array<{ id: string; position: number }>;
+} | null {
+  const page = pages.find((p) => p.id === pageId);
+  if (!page || !page.parent_id) return null;
+
+  const parent = pages.find((p) => p.id === page.parent_id);
+  if (!parent) return null;
+
+  const parentSiblings = getSortedSiblings(pages, parent.parent_id);
+  const nextPosition = parent.position + 1;
+
+  const toShift = parentSiblings.filter(
+    (p) => p.position >= nextPosition && p.id !== pageId,
+  );
+
+  return {
+    pageUpdate: { parentId: parent.parent_id, position: nextPosition },
+    shiftUpdates: toShift.map((s) => ({
+      id: s.id,
+      position: s.position + 1,
+    })),
+  };
+}
+
+export type DropPosition = "before" | "after" | "inside";
+
+/**
+ * Compute the updates needed after a drag-and-drop operation.
+ * Returns null if the drop is invalid (same page, or dropping onto a descendant).
+ */
+export function computeDrop(
+  pages: Page[],
+  tree: TreeNode[],
+  draggedId: string,
+  targetId: string,
+  position: DropPosition,
+): { updates: Array<{ id: string; parentId: string | null; position: number }> } | null {
+  if (draggedId === targetId) return null;
+
+  const draggedPage = pages.find((p) => p.id === draggedId);
+  const targetPage = pages.find((p) => p.id === targetId);
+  if (!draggedPage || !targetPage) return null;
+
+  // Prevent dropping a parent onto its own descendant
+  const draggedNode = findNode(tree, draggedId);
+  if (draggedNode) {
+    const descendantIds = getDescendantIds(draggedNode);
+    if (descendantIds.includes(targetId)) return null;
+  }
+
+  if (position === "inside") {
+    const nextPos = getNextSiblingPosition(pages, targetPage.id);
+    return {
+      updates: [
+        { id: draggedId, parentId: targetPage.id, position: nextPos },
+      ],
+    };
+  }
+
+  // "before" or "after" — reorder among target's siblings
+  const newParentId = targetPage.parent_id;
+  const siblings = pages
+    .filter((p) => p.parent_id === newParentId && p.id !== draggedId)
+    .sort((a, b) => a.position - b.position);
+
+  const targetIdx = siblings.findIndex((p) => p.id === targetPage.id);
+  const insertIdx = position === "before" ? targetIdx : targetIdx + 1;
+
+  const reordered = [...siblings];
+  reordered.splice(insertIdx, 0, draggedPage);
+
+  return {
+    updates: reordered.map((p, i) => ({
+      id: p.id,
+      parentId: newParentId,
+      position: i,
+    })),
+  };
+}


### PR DESCRIPTION
Closes #113

## What

Extracts pure tree-manipulation logic from `src/components/sidebar/page-tree.tsx` (836 lines) into `src/lib/page-tree.ts` — a side-effect-free utility module with no React or Supabase dependencies.

## How

**New file: `src/lib/page-tree.ts`** — 10 exported functions:
- `buildTree` — flat pages → nested `TreeNode[]` hierarchy
- `getDescendantIds` — collect all descendant IDs recursively
- `findNode` — locate a node by ID in the tree
- `getNextSiblingPosition` — next available position among siblings
- `getSortedSiblings` — siblings sorted by position
- `computeSwapPositions` — position swaps for move up/down
- `computeNest` — new parent_id and position for nesting under preceding sibling
- `computeUnnest` — parent_id, position, and sibling shifts for unnesting
- `computeDrop` — full update set for drag-and-drop (inside/before/after)
- `TreeNode` type export

**Updated: `src/components/sidebar/page-tree.tsx`** — imports and uses the extracted functions. All Supabase mutation calls remain in the component. Also improved the `fetchPages` effect to use an inline async function with cancellation cleanup (fixes a lint warning from `react-hooks/set-state-in-effect`).

**New file: `src/lib/page-tree.test.ts`** — 35 unit tests covering:
- Tree building: flat list → hierarchy, orphan handling, position sorting, empty input
- Descendant collection: recursive traversal, leaf nodes
- Node finding: root, nested, missing
- Position calculation: empty siblings, max+1, parent scoping
- Reorder: swap up/down, boundary cases, missing page
- Nest: under preceding sibling, after existing children, first sibling (impossible), missing page
- Unnest: to parent level with sibling shifts, root page (impossible), deep nesting
- Drop: self-drop, descendant prevention, inside/before/after, cross-parent moves

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 93 tests pass (35 new)
- `pnpm test:e2e` — 40 tests pass (including `page-crud.spec.ts` and `sidebar-drag.spec.ts`)