### PR TITLE
fix: flaky E2E tests for invite revocation and search (#118)

### DIFF
--- a/src/components/members/members-page.tsx
+++ b/src/components/members/members-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { Separator } from "@/components/ui/separator";
@@ -31,7 +31,13 @@ export function MembersPage({
 }: MembersPageProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
+  const [invites, setInvites] = useState(initialInvites);
   const isAdmin = currentUserRole === "owner" || currentUserRole === "admin";
+
+  // Sync local invite state when server data changes (e.g. after sending a new invite)
+  useEffect(() => {
+    setInvites(initialInvites);
+  }, [initialInvites]);
 
   async function handleRoleChange(memberId: string, newRole: MemberRole) {
     setError(null);
@@ -71,12 +77,17 @@ export function MembersPage({
     setError(null);
     const supabase = createClient();
 
+    // Optimistically remove the invite so the UI updates immediately
+    setInvites((prev) => prev.filter((i) => i.id !== inviteId));
+
     const { error: deleteError } = await supabase
       .from("workspace_invites")
       .delete()
       .eq("id", inviteId);
 
     if (deleteError) {
+      // Revert optimistic removal on failure
+      setInvites(initialInvites);
       setError(deleteError.message);
       return;
     }
@@ -109,11 +120,11 @@ export function MembersPage({
         onRemove={handleRemoveMember}
       />
 
-      {isAdmin && initialInvites.length > 0 && (
+      {isAdmin && invites.length > 0 && (
         <>
           <Separator className="bg-white/[0.06]" />
           <PendingInviteList
-            invites={initialInvites}
+            invites={invites}
             onRevoke={handleRevokeInvite}
           />
         </>

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -27,6 +27,7 @@ export function PageSearch() {
   const [open, setOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [workspaceResolved, setWorkspaceResolved] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -35,9 +36,11 @@ export function PageSearch() {
   useEffect(() => {
     if (!params.workspaceSlug) {
       setWorkspaceId(null);
+      setWorkspaceResolved(true);
       return;
     }
 
+    setWorkspaceResolved(false);
     const supabase = createClient();
     supabase
       .from("workspaces")
@@ -47,9 +50,11 @@ export function PageSearch() {
       .then(({ data, error }) => {
         if (error) {
           captureSupabaseError(error, "page-search:workspace-lookup");
+          setWorkspaceResolved(true);
           return;
         }
         setWorkspaceId(data?.id ?? null);
+        setWorkspaceResolved(true);
       });
   }, [params.workspaceSlug]);
 
@@ -83,7 +88,7 @@ export function PageSearch() {
     [workspaceId]
   );
 
-  // Debounced search (300ms)
+  // Debounced search (300ms) — waits for workspaceId to resolve before firing
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
@@ -92,6 +97,11 @@ export function PageSearch() {
     if (!query.trim()) {
       setResults([]);
       setLoading(false);
+      return;
+    }
+
+    if (!workspaceResolved) {
+      setLoading(true);
       return;
     }
 
@@ -105,7 +115,7 @@ export function PageSearch() {
         clearTimeout(debounceRef.current);
       }
     };
-  }, [query, search]);
+  }, [query, search, workspaceResolved]);
 
   // Close on click outside
   useEffect(() => {


### PR DESCRIPTION
Closes #118

## What

Three E2E tests were failing intermittently against production: member invite revocation, search result display, and search empty state. The root causes were race conditions in client-side state management, not test flakiness.

**Invite revocation:** `MembersPage` relied solely on `router.refresh()` after deleting an invite. Since `router.refresh()` is fire-and-forget, the invite row stayed visible until the server re-render completed — causing the E2E assertion to time out.

**Search results:** `PageSearch` resolves `workspaceId` asynchronously from the URL slug. If the user typed a query before the workspace ID resolved, the search function returned early with empty results and `loading = false`, causing a false empty state to flash. When `workspaceId` later resolved, the debounce effect re-triggered, but the intermediate state confused assertions.

## How

**Invite revocation:** Track pending invites in local state and optimistically remove the revoked invite before the API call completes. On failure, revert to the server-provided list. A `useEffect` syncs local state when server props change (e.g. after sending a new invite).

**Search:** Added a `workspaceResolved` flag to distinguish "not yet resolved" from "resolved to null." The debounce effect now holds in a loading state until the workspace ID is available, preventing false empty states and ensuring the search fires exactly once with the correct workspace ID.

## Testing

- All 7 `e2e/members.spec.ts` tests pass (including the previously failing "owner can revoke a pending invite" and the 4 dependent serial tests that were blocked)
- All 5 `e2e/search.spec.ts` tests pass (including "typing in search input shows matching results" and "search with no matches shows empty state")
- Full suite: `pnpm lint && pnpm typecheck && pnpm test` pass, 42/42 E2E tests pass (1 pre-existing flaky editor-link test unrelated to this change)