### PR TITLE
fix(automation): incident responder missing Sentry issues

### DIFF
--- a/.ona/automations/incident-responder.yaml
+++ b/.ona/automations/incident-responder.yaml
@@ -21,11 +21,17 @@ action:
 
                 ## Check for New Errors
 
-                1. Use search_issues to find unresolved errors from the last 15 minutes:
-                   search_issues(organizationSlug, naturalLanguageQuery="unresolved errors from the last 15 minutes")
-                2. If no new unresolved issues, stop — do nothing.
-                3. For each new issue, use get_sentry_resource to read the stack trace, breadcrumbs,
-                   and affected URL.
+                1. Use search_issues to find unresolved issues first seen in the last 24 hours.
+                   IMPORTANT: Use the word "issues" (not "errors") to avoid filtering by issueCategory.
+                   search_issues(organizationSlug="ona-2j", projectSlugOrId="memo",
+                     naturalLanguageQuery="unresolved issues first seen in the last 24 hours",
+                     regionUrl="https://de.sentry.io")
+                2. If no unresolved issues, stop — do nothing.
+                3. Check which Sentry issue short IDs (e.g., MEMO-9) already have a corresponding
+                   GitHub issue by searching: github_search_issues(query="Sentry MEMO- in:title", owner="gitpod-io", repo="memo").
+                   Skip any Sentry issue that already has a GitHub issue.
+                4. For each NEW (un-triaged) issue, use get_sentry_resource to read the stack trace,
+                   breadcrumbs, and affected URL.
 
                 ## Triage
 


### PR DESCRIPTION
## Problem

The Incident Responder automation found zero Sentry issues on every run, despite 7 unresolved issues visible in the dashboard (MEMO-3 through MEMO-9).

## Root Cause

Three compounding bugs:

1. **`issueCategory:error` filter** — The prompt queried `"unresolved errors from the last 15 minutes"`. The `search_issues` tool translated "errors" into `issueCategory:error`, which excluded issues Sentry categorized as `default` or `frontend`.

2. **15-minute window race condition** — The cron runs every 15 min and queried `lastSeen:-15m`. Any timing skew created gaps. One-shot errors had exactly one window to be caught.

3. **No deduplication** — No mechanism to skip already-triaged Sentry issues, so widening the window alone would cause re-processing.

## Fix

- Changed query to `"unresolved issues first seen in the last 24 hours"` — avoids the category filter and uses a wider, overlap-safe window.
- Added a dedup step: check GitHub for existing issues matching the Sentry short ID before triaging.
- Hardcoded `organizationSlug`, `projectSlugOrId`, and `regionUrl` in the prompt to avoid lookup failures.

The live Ona automation has already been updated via `ona ai automation update`.