### PR TITLE
fix: use exact match for Invite button selector in E2E tests (#133)

### DIFF
--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -93,7 +93,7 @@ test.describe("Workspace member management", () => {
     await page.fill("#invite-email", INVITE_EMAIL);
 
     // Submit the invite
-    await page.getByRole("button", { name: /invite/i }).click();
+    await page.getByRole("button", { name: "Invite", exact: true }).click();
 
     // Wait for success message
     await expect(page.locator("text=Invite sent.")).toBeVisible({
@@ -144,7 +144,7 @@ test.describe("Workspace member management", () => {
 
     // Re-invite the same email
     await page.fill("#invite-email", INVITE_EMAIL);
-    await page.getByRole("button", { name: /invite/i }).click();
+    await page.getByRole("button", { name: "Invite", exact: true }).click();
     await expect(page.locator("text=Invite sent.")).toBeVisible({
       timeout: 10_000,
     });


### PR DESCRIPTION
Closes #133

## What

The E2E test "owner can re-invite and invited user can accept" failed with a Playwright strict mode violation. The selector `getByRole('button', { name: /invite/i })` matched two buttons: the "Invite" submit button and the "Revoke invite for ..." button (whose accessible name also contains "invite"). This blocked the re-invite test and 3 dependent serial tests from running.

## How

Replaced the regex selector `/invite/i` with `{ name: 'Invite', exact: true }` at both call sites (lines 96 and 147) in `e2e/members.spec.ts`. The exact match targets only the submit button, avoiding collision with "Revoke invite" buttons.

## Testing

- All 42 E2E tests pass, including the previously failing `owner can re-invite and invited user can accept` and its 3 dependent tests (`owner can change a member's role`, `member role cannot access invite or remove controls`, `owner can remove a member`).
- `pnpm lint && pnpm typecheck && pnpm test` all pass.