### PR TITLE
fix: search empty state never renders for no-match queries (#126)

### DIFF
--- a/src/components/sidebar/page-search.test.tsx
+++ b/src/components/sidebar/page-search.test.tsx
@@ -1,0 +1,202 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- Mocks -----------------------------------------------------------
+
+const mockWorkspaceSlug = "test-workspace";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useParams: () => ({ workspaceSlug: mockWorkspaceSlug }),
+}));
+
+// Supabase mock: workspace lookup returns a valid ID
+const mockMaybeSingle = vi.fn().mockResolvedValue({
+  data: { id: "ws-uuid-123" },
+  error: null,
+});
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: mockMaybeSingle,
+        }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+// Track fetch calls
+let fetchMock: ReturnType<typeof vi.fn<typeof globalThis.fetch>>;
+
+import { PageSearch } from "./page-search";
+
+describe("PageSearch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ results: [] }),
+    });
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("shows empty state when search returns no results", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    // Wait for workspace resolution (async .then callback)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "zzzyyyxxxnonexistent999");
+
+    // Advance past the 300ms debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // The fetch should have been called
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("zzzyyyxxxnonexistent999")
+    );
+
+    // The empty state message should be visible
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+
+    // Skeleton loaders should NOT be visible
+    const searchResults = screen.getByRole("listbox");
+    const skeletons = searchResults.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBe(0);
+  });
+
+  it("shows skeleton loaders while search is in progress", async () => {
+    // Make fetch hang (never resolve)
+    let resolveFetch: (value: Response | PromiseLike<Response>) => void;
+    fetchMock.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    // Wait for workspace resolution
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "test query");
+
+    // Advance past debounce but fetch is still pending
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // Skeleton loaders should be visible while loading
+    const searchResults = screen.getByRole("listbox");
+    const skeletons = searchResults.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    // Now resolve the fetch with empty results
+    await act(async () => {
+      resolveFetch!(new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // Empty state should now show
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+  });
+
+  it("shows skeletons while workspace is resolving even after search completes", async () => {
+    // Make workspace resolution hang
+    let resolveWorkspace: (value: unknown) => void;
+    mockMaybeSingle.mockReturnValue(
+      new Promise((resolve) => {
+        resolveWorkspace = resolve;
+      })
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "test query");
+
+    // Advance past debounce — search fires but workspaceId is null so it
+    // returns immediately with loading=false
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // Even though loading is false, workspace hasn't resolved so skeletons
+    // should still show (not the empty state)
+    const searchResults = screen.getByRole("listbox");
+    const skeletons = searchResults.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+    expect(
+      screen.queryByText("No pages match your search")
+    ).not.toBeInTheDocument();
+
+    // Now resolve the workspace — this triggers a new search via the
+    // search callback getting a new workspaceId reference
+    await act(async () => {
+      resolveWorkspace!({
+        data: { id: "ws-uuid-123" },
+        error: null,
+      });
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // Debounce effect re-runs because search changed (new workspaceId).
+    // Advance past the new 300ms debounce.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // Now the empty state should show
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -41,6 +41,7 @@ export function PageSearch() {
     }
 
     setWorkspaceResolved(false);
+    let cancelled = false;
     const supabase = createClient();
     supabase
       .from("workspaces")
@@ -48,6 +49,7 @@ export function PageSearch() {
       .eq("slug", params.workspaceSlug)
       .maybeSingle()
       .then(({ data, error }) => {
+        if (cancelled) return;
         if (error) {
           captureSupabaseError(error, "page-search:workspace-lookup");
           setWorkspaceResolved(true);
@@ -56,6 +58,10 @@ export function PageSearch() {
         setWorkspaceId(data?.id ?? null);
         setWorkspaceResolved(true);
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [params.workspaceSlug]);
 
   const search = useCallback(
@@ -66,7 +72,6 @@ export function PageSearch() {
         return;
       }
 
-      setLoading(true);
       try {
         const response = await fetch(
           `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(workspaceId)}`
@@ -88,10 +93,14 @@ export function PageSearch() {
     [workspaceId]
   );
 
-  // Debounced search (300ms) — waits for workspaceId to resolve before firing
+  // Debounced search (300ms). The timer always fires; the search callback
+  // handles the case where workspaceId is not yet available by clearing
+  // loading. The rendering layer uses workspaceResolved to decide whether
+  // to show skeletons or the empty-state message.
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
+      debounceRef.current = null;
     }
 
     if (!query.trim()) {
@@ -100,22 +109,19 @@ export function PageSearch() {
       return;
     }
 
-    if (!workspaceResolved) {
-      setLoading(true);
-      return;
-    }
-
     setLoading(true);
     debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
       search(query);
     }, 300);
 
     return () => {
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
+        debounceRef.current = null;
       }
     };
-  }, [query, search, workspaceResolved]);
+  }, [query, search]);
 
   // Close on click outside
   useEffect(() => {
@@ -262,7 +268,7 @@ export function PageSearch() {
           role="listbox"
           className="absolute left-0 right-0 top-full z-50 mt-1 max-h-[300px] overflow-y-auto border border-white/[0.06] bg-muted rounded-sm shadow-md"
         >
-          {loading && results.length === 0 && (
+          {(loading || !workspaceResolved) && results.length === 0 && (
             <div className="flex flex-col">
               {Array.from({ length: 3 }).map((_, i) => (
                 <div key={i} className="flex flex-col gap-1 px-3 py-2">
@@ -276,7 +282,7 @@ export function PageSearch() {
             </div>
           )}
 
-          {!loading && results.length === 0 && query.trim().length > 0 && (
+          {!loading && workspaceResolved && results.length === 0 && query.trim().length > 0 && (
             <div className="px-3 py-4 text-center text-xs text-muted-foreground">
               No pages match your search
             </div>


### PR DESCRIPTION
Closes #126

## What

After PR #123 added a `workspaceResolved` guard to the search debounce effect, the "No pages match your search" empty state stopped appearing for zero-result queries. The debounce effect's early return when `!workspaceResolved` set `loading = true` without starting a timer, and a race condition between `workspaceResolved` and `search` dependency changes could leave `loading` stuck at `true` — preventing the empty-state condition (`!loading && results.length === 0`) from ever becoming true.

## How

Moved the `workspaceResolved` check from the debounce effect to the rendering layer. The debounce timer now always fires; the `search` callback handles `workspaceId === null` by clearing loading. The skeleton/empty-state rendering conditions use `workspaceResolved` directly:

- Skeletons show when `loading || !workspaceResolved` (preserves PR #123's intent of not flashing "No pages match" while the workspace is still resolving)
- Empty state shows only when `!loading && workspaceResolved && results.length === 0`

Also added a cleanup function to the workspace resolution effect to prevent stale callbacks in Strict Mode, and removed a redundant `setLoading(true)` from the `search` callback.

## Testing

- Added 3 unit tests in `page-search.test.tsx`:
  - Empty state renders after search returns no results
  - Skeleton loaders show while search is in progress
  - Skeletons persist while workspace is resolving (not the empty state)
- All 107 unit tests pass (`pnpm test`)
- All 42 E2E tests pass (`pnpm test:e2e`), including the previously failing `search with no matches shows empty state`
- `pnpm lint && pnpm typecheck` clean