### PR TITLE
test: add unit tests for auth form validation (#121)

### DIFF
--- a/src/app/(auth)/sign-in/page.test.tsx
+++ b/src/app/(auth)/sign-in/page.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock next/link as a simple anchor
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock OAuthButtons to avoid tooltip provider dependency
+vi.mock("@/components/auth/oauth-buttons", () => ({
+  OAuthButtons: () => <div data-testid="oauth-buttons" />,
+}));
+
+// Supabase mock state
+const mockSignInWithPassword = vi.fn();
+const mockGetUser = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      signInWithPassword: mockSignInWithPassword,
+      getUser: mockGetUser,
+    },
+    from: mockFrom,
+  }),
+}));
+
+import SignInPage from "./page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SignInPage", () => {
+  it("renders email and password fields", () => {
+    render(<SignInPage />);
+
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign in/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("email field has type=email and is required", () => {
+    render(<SignInPage />);
+    const input = screen.getByLabelText("Email");
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("type", "email");
+  });
+
+  it("password field has minLength=6 and is required", () => {
+    render(<SignInPage />);
+    const input = screen.getByLabelText("Password");
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("type", "password");
+    expect(input).toHaveAttribute("minLength", "6");
+  });
+
+  it("shows error message when sign-in fails", async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      error: { message: "Invalid login credentials" },
+    });
+
+    const user = userEvent.setup();
+    render(<SignInPage />);
+
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "wrongpass");
+
+    const form = screen.getByRole("button", { name: /sign in/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Invalid login credentials"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("calls supabase.auth.signInWithPassword with correct parameters", async () => {
+    mockSignInWithPassword.mockResolvedValue({ error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockMaybeSingle = vi.fn().mockResolvedValue({
+      data: { workspace_id: "ws-1", workspaces: { slug: "jane" } },
+    });
+    const mockLimit = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEq = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const user = userEvent.setup();
+    render(<SignInPage />);
+
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign in/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(mockSignInWithPassword).toHaveBeenCalledWith({
+        email: "jane@example.com",
+        password: "password123",
+      });
+    });
+  });
+
+  it("redirects to workspace after successful sign-in", async () => {
+    mockSignInWithPassword.mockResolvedValue({ error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockMaybeSingle = vi.fn().mockResolvedValue({
+      data: { workspace_id: "ws-1", workspaces: { slug: "jane" } },
+    });
+    const mockLimit = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEq = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const user = userEvent.setup();
+    render(<SignInPage />);
+
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign in/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/jane");
+    });
+  });
+
+  it("redirects to root when no workspace found after sign-in", async () => {
+    mockSignInWithPassword.mockResolvedValue({ error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null });
+    const mockLimit = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEq = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const user = userEvent.setup();
+    render(<SignInPage />);
+
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign in/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("disables submit button while loading", async () => {
+    // Never resolve to keep loading state
+    mockSignInWithPassword.mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+    render(<SignInPage />);
+
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const submitButton = screen.getByRole("button", { name: /sign in/i });
+    const form = submitButton.closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /signing in/i }),
+      ).toBeDisabled();
+    });
+  });
+});

--- a/src/app/(auth)/sign-up/page.test.tsx
+++ b/src/app/(auth)/sign-up/page.test.tsx
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock next/link as a simple anchor
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock OAuthButtons to avoid tooltip provider dependency
+vi.mock("@/components/auth/oauth-buttons", () => ({
+  OAuthButtons: () => <div data-testid="oauth-buttons" />,
+}));
+
+// Supabase mock state
+const mockSignUp = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      signUp: mockSignUp,
+    },
+    from: mockFrom,
+  }),
+}));
+
+import SignUpPage from "./page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SignUpPage", () => {
+  it("renders all form fields", () => {
+    render(<SignUpPage />);
+
+    expect(screen.getByLabelText("Display name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /sign up/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("display name field is required", () => {
+    render(<SignUpPage />);
+    const input = screen.getByLabelText("Display name");
+    expect(input).toBeRequired();
+  });
+
+  it("email field has type=email and is required", () => {
+    render(<SignUpPage />);
+    const input = screen.getByLabelText("Email");
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("type", "email");
+  });
+
+  it("password field has minLength=6 and is required", () => {
+    render(<SignUpPage />);
+    const input = screen.getByLabelText("Password");
+    expect(input).toBeRequired();
+    expect(input).toHaveAttribute("type", "password");
+    expect(input).toHaveAttribute("minLength", "6");
+  });
+
+  it("shows error message when sign-up fails", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { user: null },
+      error: { message: "User already registered" },
+    });
+
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+
+    await user.type(screen.getByLabelText("Display name"), "Jane Doe");
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign up/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByText("User already registered")).toBeInTheDocument();
+    });
+  });
+
+  it("calls supabase.auth.signUp with correct parameters", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+      error: null,
+    });
+
+    const mockMaybeSingle = vi.fn().mockResolvedValue({
+      data: { workspace_id: "ws-1", workspaces: { slug: "jane" } },
+    });
+    const mockLimit = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEq = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+
+    await user.type(screen.getByLabelText("Display name"), "Jane Doe");
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign up/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(mockSignUp).toHaveBeenCalledWith({
+        email: "jane@example.com",
+        password: "password123",
+        options: {
+          data: {
+            display_name: "Jane Doe",
+          },
+        },
+      });
+    });
+  });
+
+  it("redirects to workspace after successful sign-up", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+      error: null,
+    });
+
+    const mockMaybeSingle = vi.fn().mockResolvedValue({
+      data: { workspace_id: "ws-1", workspaces: { slug: "jane" } },
+    });
+    const mockLimit = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEq = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+
+    await user.type(screen.getByLabelText("Display name"), "Jane Doe");
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign up/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/jane");
+    });
+  });
+
+  it("redirects to root when no workspace found after sign-up", async () => {
+    mockSignUp.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+      error: null,
+    });
+
+    const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null });
+    const mockLimit = vi.fn().mockReturnValue({ maybeSingle: mockMaybeSingle });
+    const mockEq = vi.fn().mockReturnValue({ limit: mockLimit });
+    const mockSelect = vi.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+
+    await user.type(screen.getByLabelText("Display name"), "Jane Doe");
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign up/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("disables submit button while loading", async () => {
+    // Never resolve to keep loading state
+    mockSignUp.mockReturnValue(new Promise(() => {}));
+
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+
+    await user.type(screen.getByLabelText("Display name"), "Jane Doe");
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const submitButton = screen.getByRole("button", { name: /sign up/i });
+    const form = submitButton.closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /creating account/i }),
+      ).toBeDisabled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #121

## What

Adds unit tests for the sign-in and sign-up form components, covering validation attributes, error display, Supabase auth method calls, and post-auth redirect logic.

## How

- **`src/app/(auth)/sign-up/page.test.tsx`** — 9 tests covering:
  - Form field rendering and validation attributes (required, type=email, minLength=6)
  - Display name required validation
  - Error message display on sign-up failure
  - `supabase.auth.signUp` called with correct email, password, and display_name
  - Redirect to workspace slug after successful sign-up
  - Fallback redirect to `/` when no workspace found
  - Submit button disabled during loading

- **`src/app/(auth)/sign-in/page.test.tsx`** — 8 tests covering:
  - Form field rendering and validation attributes (required, type=email, minLength=6)
  - Error message display on sign-in failure
  - `supabase.auth.signInWithPassword` called with correct email and password
  - Redirect to workspace slug after successful sign-in
  - Fallback redirect to `/` when no workspace found
  - Submit button disabled during loading

Both test files mock `@/lib/supabase/client`, `next/navigation`, `next/link`, and `@/components/auth/oauth-buttons` following the established pattern from `workspace-settings-form.test.tsx`.

## Testing

- `pnpm lint` — ✅ pass
- `pnpm typecheck` — ✅ pass
- `pnpm test` — ✅ 122 tests pass (16 files), including 17 new tests