### PR TITLE
fix: resolve E2E editor test strict mode violations from leftover content (#140)

### DIFF
--- a/e2e/editor-drag.spec.ts
+++ b/e2e/editor-drag.spec.ts
@@ -1,6 +1,23 @@
 import { test, expect } from "./fixtures/auth";
 import { navigateToEditorPage } from "./fixtures/editor-helpers";
 
+/**
+ * Move the cursor to the end of the editor and exit any active list context
+ * by pressing Enter twice (an empty list item exits the list in Lexical),
+ * leaving the cursor in a fresh paragraph block.
+ */
+async function moveToParagraphBlock(
+  page: import("@playwright/test").Page,
+  editor: import("@playwright/test").Locator,
+) {
+  await editor.click();
+  await page.keyboard.press("End");
+  // Press Enter twice: first creates a new list item (if inside a list),
+  // second exits the list and creates a paragraph.
+  await page.keyboard.press("Enter");
+  await page.keyboard.press("Enter");
+}
+
 test.describe("Editor drag-and-drop", () => {
   test("drag handle appears when hovering a block", async ({
     authenticatedPage: page,
@@ -10,19 +27,15 @@ test.describe("Editor drag-and-drop", () => {
     const editor = page.locator('[contenteditable="true"]');
     await expect(editor).toBeVisible({ timeout: 10_000 });
 
-    // Type unique content to avoid matching leftover text from previous runs
+    // Use unique text to avoid matching leftover content from previous runs
     const uid = Date.now().toString();
-    await editor.click();
-    await page.keyboard.press("End");
-    await page.keyboard.press("Enter");
-    await editor.pressSequentially(`DragTest ${uid}`);
+    const marker = `DragTest ${uid}`;
+    await moveToParagraphBlock(page, editor);
+    await page.keyboard.type(marker);
 
-    // Wait for content to render
-    await page.waitForTimeout(500);
-
-    // Find the block we just typed and hover it
-    const block = editor.locator("p").filter({ hasText: `DragTest ${uid}` });
-    await expect(block).toBeVisible();
+    // Wait for the paragraph with our unique text to render
+    const block = editor.locator("p").filter({ hasText: marker });
+    await expect(block).toBeVisible({ timeout: 3_000 });
     await block.hover();
 
     // The drag handle should become visible
@@ -38,13 +51,14 @@ test.describe("Editor drag-and-drop", () => {
     const editor = page.locator('[contenteditable="true"]');
     await expect(editor).toBeVisible({ timeout: 10_000 });
 
-    // Ensure there's content
-    await editor.click();
-    await editor.pressSequentially("Drag test block");
-    await page.waitForTimeout(300);
+    // Use unique text so the locator doesn't match leftover content
+    const uid = Date.now().toString();
+    const marker = `DragStay ${uid}`;
+    await moveToParagraphBlock(page, editor);
+    await page.keyboard.type(marker);
 
-    const block = editor.locator("p").first();
-    await expect(block).toBeVisible();
+    const block = editor.locator("p").filter({ hasText: marker });
+    await expect(block).toBeVisible({ timeout: 3_000 });
 
     // Hover the block to show the drag handle
     const blockBox = await block.boundingBox();
@@ -81,19 +95,19 @@ test.describe("Editor drag-and-drop", () => {
     const editor = page.locator('[contenteditable="true"]');
     await expect(editor).toBeVisible({ timeout: 10_000 });
 
-    // Type content to create multiple blocks
-    await editor.click();
-    await page.keyboard.press("End");
+    // Use unique text to avoid matching leftover content from previous runs
+    const uid = Date.now().toString();
+    const markerOne = `BlockOne ${uid}`;
+    const markerTwo = `BlockTwo ${uid}`;
+    await moveToParagraphBlock(page, editor);
+    await page.keyboard.type(markerOne);
     await page.keyboard.press("Enter");
-    await editor.pressSequentially("Block one");
-    await page.keyboard.press("Enter");
-    await editor.pressSequentially("Block two");
+    await page.keyboard.type(markerTwo);
     await page.waitForTimeout(300);
 
-    // Hover the first typed block
-    const paragraphs = editor.locator("p");
-    const blockOne = paragraphs.filter({ hasText: "Block one" }).first();
-    await expect(blockOne).toBeVisible();
+    // Hover the first typed block using unique text
+    const blockOne = editor.locator("p").filter({ hasText: markerOne });
+    await expect(blockOne).toBeVisible({ timeout: 3_000 });
     await blockOne.hover();
     await page.waitForTimeout(200);
 

--- a/e2e/editor-slash-commands.spec.ts
+++ b/e2e/editor-slash-commands.spec.ts
@@ -49,6 +49,9 @@ test.describe("Editor slash commands", () => {
     const editor = page.locator('[contenteditable="true"]');
     await expect(editor).toBeVisible({ timeout: 10_000 });
 
+    // Count existing h1 elements before inserting so we can target the new one
+    const h1CountBefore = await editor.locator("h1").count();
+
     await editor.click();
     await page.keyboard.press("End");
     await page.keyboard.press("Enter");
@@ -59,9 +62,13 @@ test.describe("Editor slash commands", () => {
     await expect(heading1Option).toBeVisible({ timeout: 3_000 });
     await heading1Option.click();
 
-    // A heading element should now exist in the editor
-    const heading = editor.locator("h1");
+    // The newly inserted heading — use .last() to avoid matching pre-existing h1s
+    const heading = editor.locator("h1").last();
     await expect(heading).toBeVisible({ timeout: 2_000 });
+
+    // Verify a new h1 was actually added
+    const h1CountAfter = await editor.locator("h1").count();
+    expect(h1CountAfter).toBeGreaterThan(h1CountBefore);
   });
 
   test("slash menu is keyboard navigable", async ({

--- a/e2e/editor-toolbar.spec.ts
+++ b/e2e/editor-toolbar.spec.ts
@@ -37,13 +37,16 @@ test.describe("Editor floating toolbar", () => {
     const editor = page.locator('[contenteditable="true"]');
     await expect(editor).toBeVisible({ timeout: 10_000 });
 
+    // Use unique text to avoid matching leftover bold content from previous runs
+    const uid = Date.now().toString();
+    const marker = `boldme ${uid}`;
     await editor.click();
     await page.keyboard.press("End");
     await page.keyboard.press("Enter");
-    await editor.pressSequentially("bold me");
+    await page.keyboard.type(marker);
     await page.waitForTimeout(200);
 
-    // Select "bold me"
+    // Select the text we just typed
     await page.keyboard.down("Shift");
     await page.keyboard.press("Home");
     await page.keyboard.up("Shift");
@@ -58,9 +61,9 @@ test.describe("Editor floating toolbar", () => {
     // The bold button should now be active (pressed)
     await expect(boldBtn).toHaveAttribute("aria-pressed", "true");
 
-    // The text should be wrapped in a bold element
-    const boldText = editor.locator("strong");
-    await expect(boldText).toContainText("bold me");
+    // The text should be wrapped in a bold element — filter by our unique text
+    const boldText = editor.locator("strong").filter({ hasText: marker });
+    await expect(boldText).toBeVisible({ timeout: 2_000 });
   });
 
   test("toolbar disappears when selection is collapsed", async ({
@@ -97,10 +100,13 @@ test.describe("Editor floating toolbar", () => {
     const editor = page.locator('[contenteditable="true"]');
     await expect(editor).toBeVisible({ timeout: 10_000 });
 
+    // Use unique text to avoid matching leftover bold content from previous runs
+    const uid = Date.now().toString();
+    const marker = `kbdbold ${uid}`;
     await editor.click();
     await page.keyboard.press("End");
     await page.keyboard.press("Enter");
-    await editor.pressSequentially("shortcut bold");
+    await page.keyboard.type(marker);
     await page.waitForTimeout(200);
 
     // Select text
@@ -112,7 +118,8 @@ test.describe("Editor floating toolbar", () => {
     await page.keyboard.press(`${mod}+b`);
     await page.waitForTimeout(200);
 
-    const boldText = editor.locator("strong");
-    await expect(boldText).toContainText("shortcut bold");
+    // Filter by our unique text to avoid matching pre-existing bold elements
+    const boldText = editor.locator("strong").filter({ hasText: marker });
+    await expect(boldText).toBeVisible({ timeout: 2_000 });
   });
 });


### PR DESCRIPTION
Closes #140

## What

5 E2E editor tests failed against production due to Playwright strict mode violations and element-not-found errors. Tests typed content into the editor but used locators that either matched multiple elements (pre-existing bold text, headings from prior runs) or targeted the wrong element type (looking for `<p>` when text landed inside `<li>` within a bullet list).

## How

Three fixes across the three affected test files:

- **editor-drag.spec.ts**: Added a `moveToParagraphBlock` helper that presses Enter twice to exit any active list context before typing. Used unique `Date.now()` markers in all three drag tests so locators never match leftover content. Switched from `pressSequentially` to `page.keyboard.type()` for reliability.
- **editor-slash-commands.spec.ts**: Changed `editor.locator("h1")` to `editor.locator("h1").last()` so the assertion targets the newly inserted heading instead of matching a pre-existing one. Added a count-before/count-after check to verify insertion.
- **editor-toolbar.spec.ts**: Both bold tests now use unique `Date.now()` markers and filter the `strong` locator with `.filter({ hasText: marker })` to avoid matching pre-existing bold elements from prior runs.

## Testing

All 11 tests in the three affected files pass locally (previously 3 drag + 1 slash command + 2 toolbar = 5 failures). Full CI suite: `pnpm lint && pnpm typecheck && pnpm test` all pass. E2E run: 11/11 passed.