### PR TITLE
fix: downgrade transient network errors to warning and add retry (#131)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -141,6 +141,30 @@ The helper accepts `PostgrestError` (from query results) and generic `Error` (fr
 catch blocks). It tags the Sentry event with the operation name, error code, and
 message so errors are filterable in the Sentry dashboard.
 
+Transient network errors (`TypeError: Failed to fetch`, `Load failed`, etc.) are
+automatically captured at `warning` level instead of `error` — they are not
+application bugs and should not trigger error-level alerts.
+
+### Retrying transient network errors
+
+Client-side Supabase queries that run on page load (e.g. workspace lookup, page
+list fetch) should use `retryOnNetworkError` from `@/lib/retry` to retry on
+transient network failures before reporting to Sentry:
+
+```typescript
+import { retryOnNetworkError } from "@/lib/retry";
+
+const { data, error } = await retryOnNetworkError(() => {
+  const supabase = createClient();
+  return supabase.from("workspaces").select("id").eq("slug", slug).maybeSingle();
+});
+```
+
+This retries up to 2 times with exponential backoff (500ms, 1s). Only transient
+network errors are retried — application errors (RLS violations, constraint errors)
+are returned immediately. Do **not** wrap user-initiated mutations (create, update,
+delete) in retry — those should fail fast and show a toast.
+
 ### Disambiguating Supabase joins
 
 When a table has multiple foreign keys to the same target table, PostgREST cannot

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -13,6 +13,7 @@ import {
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { captureSupabaseError } from "@/lib/sentry";
+import { retryOnNetworkError } from "@/lib/retry";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -69,19 +70,27 @@ export function PageTree({ userId }: PageTreeProps) {
   useEffect(() => {
     if (!workspaceSlug) return;
 
-    const supabase = createClient();
-    supabase
-      .from("workspaces")
-      .select("id")
-      .eq("slug", workspaceSlug)
-      .maybeSingle()
-      .then(({ data, error }) => {
-        if (error) {
-          captureSupabaseError(error, "page-tree:workspace-lookup");
-          return;
-        }
-        if (data) setWorkspaceId(data.id);
-      });
+    let cancelled = false;
+
+    retryOnNetworkError(() => {
+      const supabase = createClient();
+      return supabase
+        .from("workspaces")
+        .select("id")
+        .eq("slug", workspaceSlug)
+        .maybeSingle();
+    }).then(({ data, error }) => {
+      if (cancelled) return;
+      if (error) {
+        captureSupabaseError(error, "page-tree:workspace-lookup");
+        return;
+      }
+      if (data) setWorkspaceId(data.id);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [workspaceSlug]);
 
   useEffect(() => {
@@ -90,12 +99,14 @@ export function PageTree({ userId }: PageTreeProps) {
     let cancelled = false;
 
     async function fetchPages() {
-      const supabase = createClient();
-      const { data, error } = await supabase
-        .from("pages")
-        .select("*")
-        .eq("workspace_id", workspaceId)
-        .order("position", { ascending: true });
+      const { data, error } = await retryOnNetworkError(() => {
+        const supabase = createClient();
+        return supabase
+          .from("pages")
+          .select("*")
+          .eq("workspace_id", workspaceId)
+          .order("position", { ascending: true });
+      });
 
       if (cancelled) return;
 

--- a/src/lib/retry.test.ts
+++ b/src/lib/retry.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PostgrestError } from "@supabase/supabase-js";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import { retryOnNetworkError } from "./retry";
+
+function makePostgrestError(
+  overrides: Partial<PostgrestError> = {},
+): PostgrestError {
+  return new PostgrestError({
+    message: overrides.message ?? "some error",
+    details: overrides.details ?? "",
+    hint: overrides.hint ?? "",
+    code: overrides.code ?? "PGRST000",
+  });
+}
+
+function networkError(): PostgrestError {
+  return makePostgrestError({
+    message: "TypeError: Failed to fetch",
+    details: "TypeError: Failed to fetch",
+  });
+}
+
+describe("retryOnNetworkError", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("returns immediately on success (no retries)", async () => {
+    const fn = vi.fn().mockResolvedValue({ data: { id: "ws-1" }, error: null });
+
+    const promise = retryOnNetworkError(fn, { baseDelayMs: 100 });
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(result).toEqual({ data: { id: "ws-1" }, error: null });
+  });
+
+  it("returns immediately on non-network error (no retries)", async () => {
+    const rlsError = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    const fn = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: rlsError });
+
+    const promise = retryOnNetworkError(fn, { baseDelayMs: 100 });
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(result.error?.code).toBe("42501");
+  });
+
+  it("retries on transient network error and succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({ data: null, error: networkError() })
+      .mockResolvedValueOnce({ data: { id: "ws-1" }, error: null });
+
+    const promise = retryOnNetworkError(fn, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+    });
+
+    // First call happens immediately, then waits 100ms before retry
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ data: { id: "ws-1" }, error: null });
+  });
+
+  it("retries up to maxRetries and returns last error", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: networkError() });
+
+    const promise = retryOnNetworkError(fn, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+    });
+
+    // Retry 1 after 100ms
+    await vi.advanceTimersByTimeAsync(100);
+    // Retry 2 after 200ms (exponential backoff)
+    await vi.advanceTimersByTimeAsync(200);
+
+    const result = await promise;
+
+    // 1 initial + 2 retries = 3 calls
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(result.error?.message).toBe("TypeError: Failed to fetch");
+  });
+
+  it("uses exponential backoff between retries", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: networkError() });
+
+    const promise = retryOnNetworkError(fn, {
+      maxRetries: 3,
+      baseDelayMs: 100,
+    });
+
+    // After initial call, first retry at 100ms
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // Second retry at 200ms (100 * 2^1)
+    await vi.advanceTimersByTimeAsync(200);
+    expect(fn).toHaveBeenCalledTimes(3);
+
+    // Third retry at 400ms (100 * 2^2)
+    await vi.advanceTimersByTimeAsync(400);
+    expect(fn).toHaveBeenCalledTimes(4);
+
+    await promise;
+  });
+
+  it("defaults to 2 retries and 500ms base delay", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({ data: null, error: networkError() })
+      .mockResolvedValueOnce({ data: null, error: networkError() })
+      .mockResolvedValueOnce({ data: { id: "ws-1" }, error: null });
+
+    const promise = retryOnNetworkError(fn);
+
+    await vi.advanceTimersByTimeAsync(500); // first retry
+    await vi.advanceTimersByTimeAsync(1000); // second retry
+
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({ data: { id: "ws-1" }, error: null });
+  });
+});

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,0 +1,45 @@
+import { isTransientNetworkError } from "@/lib/sentry";
+import { PostgrestError } from "@supabase/supabase-js";
+
+interface RetryOptions {
+  /** Maximum number of retry attempts (default: 2). */
+  maxRetries?: number;
+  /** Base delay in ms before the first retry (default: 500). Doubles each attempt. */
+  baseDelayMs?: number;
+}
+
+/** Any Supabase query result shape — the only requirement is an `error` field. */
+type SupabaseResult = { error: PostgrestError | null };
+
+/**
+ * Retry a Supabase query when it fails with a transient network error.
+ *
+ * Returns the first successful result, or the last error after all retries
+ * are exhausted. Only retries on transient network errors — application-level
+ * Supabase errors (e.g. RLS violations) are returned immediately.
+ *
+ * Accepts both `Promise` and `PromiseLike` return types — Supabase query
+ * builders implement `PromiseLike` but not full `Promise`.
+ */
+export async function retryOnNetworkError<T extends SupabaseResult>(
+  fn: () => PromiseLike<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { maxRetries = 2, baseDelayMs = 500 } = options;
+
+  let lastResult = await fn();
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    if (!lastResult.error || !isTransientNetworkError(lastResult.error)) {
+      return lastResult;
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, baseDelayMs * 2 ** attempt),
+    );
+
+    lastResult = await fn();
+  }
+
+  return lastResult;
+}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -2,11 +2,35 @@ import * as Sentry from "@sentry/nextjs";
 import { PostgrestError } from "@supabase/supabase-js";
 
 /**
+ * True when the error is a transient network failure (e.g. offline, DNS
+ * timeout, connection reset). These are not application bugs and should be
+ * reported at warning level so they don't trigger error-level alerts.
+ */
+export function isTransientNetworkError(error: PostgrestError | Error): boolean {
+  const msg = error.message;
+  const details =
+    error instanceof PostgrestError ? error.details : "";
+
+  return (
+    msg === "TypeError: Failed to fetch" ||
+    details === "TypeError: Failed to fetch" ||
+    msg === "Failed to fetch" ||
+    msg === "Load failed" ||
+    msg === "NetworkError when attempting to fetch resource." ||
+    msg === "The Internet connection appears to be offline." ||
+    msg === "Network request failed"
+  );
+}
+
+/**
  * Report a Supabase error to Sentry with structured context.
  *
  * Accepts both PostgrestError (from query/mutation results) and generic Error
  * (from catch blocks). The `operation` tag makes it easy to filter in Sentry
  * by the database operation that failed.
+ *
+ * Transient network errors (e.g. `TypeError: Failed to fetch`) are captured at
+ * `warning` level to reduce noise — they are not application bugs.
  */
 export function captureSupabaseError(
   error: PostgrestError | Error,
@@ -21,6 +45,11 @@ export function captureSupabaseError(
     extra.code = error.code;
     extra.details = error.details;
     extra.hint = error.hint;
+  }
+
+  if (isTransientNetworkError(error)) {
+    Sentry.captureException(error, { extra, level: "warning" });
+    return;
   }
 
   Sentry.captureException(error, { extra });

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PostgrestError } from "@supabase/supabase-js";
+
+const captureExceptionMock = vi.fn();
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: (...args: unknown[]) => captureExceptionMock(...args),
+}));
+
+import { isTransientNetworkError, captureSupabaseError } from "./sentry";
+
+function makePostgrestError(
+  overrides: Partial<PostgrestError> = {},
+): PostgrestError {
+  const err = new PostgrestError({
+    message: overrides.message ?? "some error",
+    details: overrides.details ?? "",
+    hint: overrides.hint ?? "",
+    code: overrides.code ?? "PGRST000",
+  });
+  return err;
+}
+
+describe("isTransientNetworkError", () => {
+  it("detects 'TypeError: Failed to fetch' in message", () => {
+    const error = new Error("TypeError: Failed to fetch");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'Failed to fetch' in message", () => {
+    const error = new Error("Failed to fetch");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'Load failed' (Safari)", () => {
+    const error = new Error("Load failed");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'NetworkError when attempting to fetch resource.' (Firefox)", () => {
+    const error = new Error(
+      "NetworkError when attempting to fetch resource.",
+    );
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'The Internet connection appears to be offline.'", () => {
+    const error = new Error(
+      "The Internet connection appears to be offline.",
+    );
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'Network request failed'", () => {
+    const error = new Error("Network request failed");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'TypeError: Failed to fetch' in PostgrestError details", () => {
+    const error = makePostgrestError({
+      message: "some wrapper message",
+      details: "TypeError: Failed to fetch",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns false for a regular PostgrestError", () => {
+    const error = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    expect(isTransientNetworkError(error)).toBe(false);
+  });
+
+  it("returns false for a generic application error", () => {
+    const error = new Error("Something went wrong");
+    expect(isTransientNetworkError(error)).toBe(false);
+  });
+});
+
+describe("captureSupabaseError", () => {
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+  });
+
+  it("captures transient network errors at warning level", () => {
+    const error = new Error("Failed to fetch");
+    captureSupabaseError(error, "page-tree:workspace-lookup");
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("page-tree:workspace-lookup");
+  });
+
+  it("captures PostgrestError with network details at warning level", () => {
+    const error = makePostgrestError({
+      message: "request failed",
+      details: "TypeError: Failed to fetch",
+    });
+    captureSupabaseError(error, "page-tree:fetch-pages");
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+  });
+
+  it("captures non-network errors at default (error) level", () => {
+    const error = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    captureSupabaseError(error, "pages.insert");
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBeUndefined();
+    expect(opts.extra.operation).toBe("pages.insert");
+    expect(opts.extra.code).toBe("42501");
+  });
+
+  it("includes PostgrestError fields in extra", () => {
+    const error = makePostgrestError({
+      message: "duplicate key",
+      code: "23505",
+      details: "Key (id)=(abc) already exists.",
+      hint: "",
+    });
+    captureSupabaseError(error, "pages.insert");
+
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.extra.code).toBe("23505");
+    expect(opts.extra.details).toBe("Key (id)=(abc) already exists.");
+  });
+});


### PR DESCRIPTION
Closes #131

## What

`captureSupabaseError` reported all Supabase errors at Sentry `error` level, including transient network failures like `TypeError: Failed to fetch`. These are not application bugs — they occur when the user's connection drops momentarily — but they triggered error-level alerts and created noise in Sentry (9 events, 6 users on MEMO-9).

Additionally, the page-tree workspace lookup and page fetch had no retry logic, so a single transient failure would immediately surface as a Sentry error and leave the page tree empty.

## How

1. **`src/lib/sentry.ts`**: Added `isTransientNetworkError()` to detect common browser network error messages across Chrome, Safari, and Firefox. `captureSupabaseError` now captures these at `warning` level instead of `error`.

2. **`src/lib/retry.ts`**: New `retryOnNetworkError()` utility that retries a Supabase query up to 2 times with exponential backoff (500ms, 1s) when it fails with a transient network error. Non-network errors (RLS violations, constraint errors) are returned immediately without retry.

3. **`src/components/sidebar/page-tree.tsx`**: Wrapped the workspace-lookup and fetch-pages queries in `retryOnNetworkError`. Also added a missing cleanup function (`cancelled` flag) to the workspace-lookup effect.

4. **`.agents/conventions.md`**: Added conventions for transient network error handling and when to use `retryOnNetworkError`.

## Testing

- **`src/lib/sentry.unit.test.ts`** (13 tests): Covers `isTransientNetworkError` detection for all browser error variants, and verifies `captureSupabaseError` uses `warning` level for network errors and default level for application errors.
- **`src/lib/retry.test.ts`** (6 tests): Covers immediate success, immediate non-network error, retry-then-success, retry exhaustion, exponential backoff timing, and default options.
- All 151 unit tests pass, all 42 E2E tests pass, lint and typecheck clean.