### PR TITLE
fix: filter Next.js router state header parse errors in Sentry (#132)

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { isNextjsInternalNoise } from "@/lib/sentry";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
@@ -7,4 +8,11 @@ Sentry.init({
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
 
   enableLogs: true,
+
+  beforeSend(event) {
+    if (isNextjsInternalNoise(event)) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { isNextjsInternalNoise } from "@/lib/sentry";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
@@ -9,4 +10,11 @@ Sentry.init({
   includeLocalVariables: true,
 
   enableLogs: true,
+
+  beforeSend(event) {
+    if (isNextjsInternalNoise(event)) {
+      return null;
+    }
+    return event;
+  },
 });

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,5 +1,31 @@
 import * as Sentry from "@sentry/nextjs";
+import type { ErrorEvent } from "@sentry/nextjs";
 import { PostgrestError } from "@supabase/supabase-js";
+
+/**
+ * Error messages from Next.js internals that are caused by clients sending
+ * malformed headers (e.g. RSC router state). These are not application bugs —
+ * they originate from bots, crawlers, or browser quirks (Mobile Safari 17).
+ */
+const NEXTJS_INTERNAL_NOISE_PATTERNS = [
+  "The router state header was sent but could not be parsed",
+];
+
+/**
+ * Returns true when the Sentry event represents a Next.js internal error
+ * caused by malformed client headers. These are not actionable and should
+ * be dropped from Sentry to reduce noise.
+ */
+export function isNextjsInternalNoise(event: ErrorEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) return false;
+
+  return values.some((ex) =>
+    NEXTJS_INTERNAL_NOISE_PATTERNS.some(
+      (pattern) => ex.value?.includes(pattern),
+    ),
+  );
+}
 
 /**
  * True when the error is a transient network failure (e.g. offline, DNS

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ErrorEvent } from "@sentry/nextjs";
 import { PostgrestError } from "@supabase/supabase-js";
 
 const captureExceptionMock = vi.fn();
@@ -7,7 +8,11 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: (...args: unknown[]) => captureExceptionMock(...args),
 }));
 
-import { isTransientNetworkError, captureSupabaseError } from "./sentry";
+import {
+  isTransientNetworkError,
+  captureSupabaseError,
+  isNextjsInternalNoise,
+} from "./sentry";
 
 function makePostgrestError(
   overrides: Partial<PostgrestError> = {},
@@ -131,5 +136,70 @@ describe("captureSupabaseError", () => {
     const [, opts] = captureExceptionMock.mock.calls[0];
     expect(opts.extra.code).toBe("23505");
     expect(opts.extra.details).toBe("Key (id)=(abc) already exists.");
+  });
+});
+
+function makeSentryEvent(
+  exceptionValues: Array<{ value?: string; type?: string }>,
+): ErrorEvent {
+  return {
+    type: undefined,
+    exception: { values: exceptionValues },
+  } as ErrorEvent;
+}
+
+describe("isNextjsInternalNoise", () => {
+  it("detects router state header parse error", () => {
+    const event = makeSentryEvent([
+      {
+        type: "Error",
+        value: "The router state header was sent but could not be parsed.",
+      },
+    ]);
+    expect(isNextjsInternalNoise(event)).toBe(true);
+  });
+
+  it("detects the error when it appears as a substring", () => {
+    const event = makeSentryEvent([
+      {
+        type: "Error",
+        value:
+          "Error: The router state header was sent but could not be parsed. Value: corrupted",
+      },
+    ]);
+    expect(isNextjsInternalNoise(event)).toBe(true);
+  });
+
+  it("detects the error in any exception value (chained exceptions)", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Some wrapper error" },
+      {
+        type: "Error",
+        value: "The router state header was sent but could not be parsed.",
+      },
+    ]);
+    expect(isNextjsInternalNoise(event)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    const event = makeSentryEvent([
+      { type: "TypeError", value: "Cannot read properties of undefined" },
+    ]);
+    expect(isNextjsInternalNoise(event)).toBe(false);
+  });
+
+  it("returns false when exception values are empty", () => {
+    const event = makeSentryEvent([]);
+    expect(isNextjsInternalNoise(event)).toBe(false);
+  });
+
+  it("returns false when exception is missing", () => {
+    const event = { type: undefined } as ErrorEvent;
+    expect(isNextjsInternalNoise(event)).toBe(false);
+  });
+
+  it("returns false when exception value is undefined", () => {
+    const event = makeSentryEvent([{ type: "Error" }]);
+    expect(isNextjsInternalNoise(event)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #132

## What

Next.js throws `Error: The router state header was sent but could not be parsed` when a client sends a malformed `Next-Router-State-Tree` RSC header. This was observed from Mobile Safari 17 on iOS — likely a bot or crawler. The stack trace is entirely within Next.js internals with no first-party code involved. The error is not actionable and creates noise in Sentry.

## How

Added a `beforeSend` filter in both `sentry.server.config.ts` and `sentry.edge.config.ts` that drops events matching known Next.js internal noise patterns. The filter logic lives in `src/lib/sentry.ts` as `isNextjsInternalNoise()` — it checks exception values against a list of known non-actionable Next.js error messages. The pattern list is extensible for future similar errors.

## Testing

Added 7 unit tests in `src/lib/sentry.unit.test.ts` covering:
- Exact match of the router state header error message
- Substring match (error with additional context)
- Chained exceptions (error in any position)
- Negative cases: unrelated errors, empty values, missing exception, undefined value

All checks pass: `pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e` (166 unit tests, 42 E2E tests).