### PR TITLE
fix: add retry on network errors to page-search workspace lookup (#149)

### DIFF
--- a/src/components/sidebar/page-search.test.tsx
+++ b/src/components/sidebar/page-search.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/lib/supabase/client", () => ({
 
 vi.mock("@/lib/sentry", () => ({
   captureSupabaseError: vi.fn(),
+  isTransientNetworkError: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock("@sentry/nextjs", () => ({

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -7,6 +7,7 @@ import * as Sentry from "@sentry/nextjs";
 import { Input } from "@/components/ui/input";
 import { createClient } from "@/lib/supabase/client";
 import { captureSupabaseError } from "@/lib/sentry";
+import { retryOnNetworkError } from "@/lib/retry";
 
 interface SearchResult {
   id: string;
@@ -44,22 +45,24 @@ export function PageSearch() {
 
     setWorkspaceResolved(false);
     let cancelled = false;
-    const supabase = createClient();
-    supabase
-      .from("workspaces")
-      .select("id")
-      .eq("slug", params.workspaceSlug)
-      .maybeSingle()
-      .then(({ data, error }) => {
-        if (cancelled) return;
-        if (error) {
-          captureSupabaseError(error, "page-search:workspace-lookup");
-          setWorkspaceResolved(true);
-          return;
-        }
-        setWorkspaceId(data?.id ?? null);
+
+    retryOnNetworkError(() => {
+      const supabase = createClient();
+      return supabase
+        .from("workspaces")
+        .select("id")
+        .eq("slug", params.workspaceSlug)
+        .maybeSingle();
+    }).then(({ data, error }) => {
+      if (cancelled) return;
+      if (error) {
+        captureSupabaseError(error, "page-search:workspace-lookup");
         setWorkspaceResolved(true);
-      });
+        return;
+      }
+      setWorkspaceId(data?.id ?? null);
+      setWorkspaceResolved(true);
+    });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
Closes #149

## What

PR #145 added `retryOnNetworkError` to `page-tree.tsx` but missed the identical pattern in `page-search.tsx`. The page-search workspace lookup (`page-search:workspace-lookup`) still made a single Supabase call without retry, causing transient network errors to immediately surface in Sentry (MEMO-9).

Sentry issue: https://ona-2j.sentry.io/issues/MEMO-9

## Root Cause

The fix in PR #145 was incomplete — it wrapped the page-tree workspace lookup in `retryOnNetworkError` but left the page-search workspace lookup unprotected.

## Changes

1. **`src/components/sidebar/page-search.tsx`**: Wrapped the workspace slug → ID lookup in `retryOnNetworkError`, matching the pattern in `page-tree.tsx`.
2. **`src/components/sidebar/page-search.test.tsx`**: Added `isTransientNetworkError` to the `@/lib/sentry` mock so `retryOnNetworkError` resolves correctly in tests.

## Testing

- All 166 unit tests pass
- Lint and typecheck clean