### PR TITLE
fix: replace abort-signal staleness check with generation counter in search (#144)

### DIFF
--- a/src/components/sidebar/page-search.test.tsx
+++ b/src/components/sidebar/page-search.test.tsx
@@ -212,6 +212,73 @@ describe("PageSearch", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows empty state even when aborted fetch finally block races with new cycle", async () => {
+    // Regression test for the microtask ordering bug: when the debounce
+    // effect re-runs (e.g. because workspaceId resolved), it aborts the
+    // old controller and sets loading=true synchronously. The aborted
+    // fetch's finally block runs later as a microtask. If the finally
+    // block used signal.aborted to decide whether to clear loading, a
+    // race could leave loading=true permanently. The generation counter
+    // prevents this.
+
+    // First fetch resolves synchronously (simulating a fetch that
+    // completes at the same tick the abort fires)
+    let fetchCallCount = 0;
+    fetchMock.mockImplementation((_url: string | URL | Request, init?: RequestInit) => {
+      fetchCallCount++;
+      const signal = init?.signal;
+      if (fetchCallCount === 1) {
+        // First fetch: resolve immediately so its finally block runs
+        // in the same microtask queue as the abort
+        return Promise.resolve(new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }));
+      }
+      // Second fetch: also resolves, but check abort
+      return new Promise<Response>((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException("Aborted", "AbortError"));
+          return;
+        }
+        resolve(new Response(JSON.stringify({ results: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }));
+      });
+    });
+
+    // Start with workspace already resolved
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    // Wait for workspace resolution
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "test");
+
+    // Advance past debounce — first fetch fires and resolves immediately
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // The empty state should be visible (not stuck on skeletons)
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+
+    const searchResults = screen.getByRole("listbox");
+    const skeletons = searchResults.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBe(0);
+  });
+
   it("shows skeletons while workspace is resolving even after search completes", async () => {
     // Make workspace resolution hang
     let resolveWorkspace: (value: unknown) => void;

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -34,6 +34,12 @@ export function PageSearch() {
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // Generation counter: incremented each search cycle so async callbacks
+  // can detect whether they belong to the current cycle or a stale one.
+  // Unlike AbortSignal checks, reading the ref at state-update time avoids
+  // microtask ordering issues where an aborted fetch's finally block runs
+  // after the next cycle has already set loading=true.
+  const searchGenRef = useRef(0);
 
   // Resolve workspace slug to ID
   useEffect(() => {
@@ -70,9 +76,9 @@ export function PageSearch() {
   }, [params.workspaceSlug]);
 
   const search = useCallback(
-    async (q: string, signal: AbortSignal) => {
+    async (q: string, gen: number, signal: AbortSignal) => {
       if (!q.trim() || !workspaceId) {
-        if (!signal.aborted) {
+        if (searchGenRef.current === gen) {
           setResults([]);
           setLoading(false);
         }
@@ -84,21 +90,21 @@ export function PageSearch() {
           `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(workspaceId)}`,
           { signal }
         );
-        if (signal.aborted) return;
+        if (searchGenRef.current !== gen) return;
         if (response.ok) {
           const data = (await response.json()) as { results: SearchResult[] };
-          if (signal.aborted) return;
+          if (searchGenRef.current !== gen) return;
           setResults(data.results);
           setSelectedIndex(0);
         } else {
           setResults([]);
         }
       } catch (error) {
-        if (signal.aborted) return;
+        if (searchGenRef.current !== gen) return;
         Sentry.captureException(error);
         setResults([]);
       } finally {
-        if (!signal.aborted) {
+        if (searchGenRef.current === gen) {
           setLoading(false);
           setSearched(true);
         }
@@ -107,9 +113,18 @@ export function PageSearch() {
     [workspaceId]
   );
 
-  // Debounced search with abort support. Cancels any in-flight fetch when
-  // the query or search callback changes, preventing stale responses from
-  // overwriting the current state.
+  // Debounced search with abort + generation counter. The abort signal
+  // cancels the network request for efficiency. The generation counter
+  // (searchGenRef) determines whether async callbacks should update state.
+  // This avoids a microtask ordering bug: when the effect re-runs, it
+  // aborts the old controller and sets loading=true synchronously, but the
+  // aborted fetch's finally block runs later as a microtask. If that
+  // finally block used signal.aborted to decide whether to set
+  // loading=false, it would correctly skip — but if the abort races with
+  // fetch completion (signal not yet aborted when finally runs), it could
+  // set loading=false and then the new cycle's loading=true would be
+  // undone. The generation counter is immune to this because it is
+  // incremented synchronously before the microtask runs.
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
@@ -121,12 +136,14 @@ export function PageSearch() {
     }
 
     if (!query.trim()) {
+      searchGenRef.current += 1;
       setResults([]);
       setLoading(false);
       setSearched(false);
       return;
     }
 
+    const gen = ++searchGenRef.current;
     setLoading(true);
     setSearched(false);
     const controller = new AbortController();
@@ -134,7 +151,7 @@ export function PageSearch() {
 
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
-      search(query, controller.signal);
+      search(query, gen, controller.signal);
     }, 300);
 
     return () => {


### PR DESCRIPTION
Closes #144

## What

The search empty state ("No pages match your search") never renders when searching for a nonsense string. Instead, skeleton loading placeholders show indefinitely. This bug persisted across three previous fix attempts (#126, #136, #146) because the root cause — a microtask ordering race between the AbortSignal and React state updates — was never addressed.

## How

Replaced the `signal.aborted` guard in the search callback's `finally` block with a generation counter ref (`searchGenRef`). Each search cycle increments the counter synchronously in the debounce effect. Async callbacks only update state when their captured generation matches the current ref value.

The previous approach checked `signal.aborted` in the `finally` block to decide whether to clear `loading`. This failed because: when the debounce effect re-runs, it aborts the old controller and sets `loading=true` synchronously, but the aborted fetch's `finally` block runs later as a microtask. If the abort races with fetch completion (signal not yet aborted when `finally` runs), the `finally` block could set `loading=false`, undoing the new cycle's `loading=true`. The generation counter is immune to this because it is incremented synchronously before any microtask from the previous cycle can run.

The `AbortController` is retained for network efficiency (cancelling in-flight requests), but state management decisions are now driven entirely by the generation counter.

## Testing

- Added regression test "shows empty state even when aborted fetch finally block races with new cycle" that exercises the exact race condition with an immediately-resolving fetch
- All 174 unit tests pass (`pnpm test`)
- All 42 E2E tests pass (`pnpm test:e2e`), including the previously failing `search with no matches shows empty state`
- `pnpm lint && pnpm typecheck` pass