### PR TITLE
fix: root redirect should prefer personal workspace (#152)

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Track redirect calls — next/navigation redirect throws to halt execution
+const mockRedirect = vi.fn((url: string) => {
+  throw new Error(`NEXT_REDIRECT:${url}`);
+});
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import Home from "./page";
+import { createClient } from "@/lib/supabase/server";
+
+const mockedCreateClient = vi.mocked(createClient);
+
+/** Build a chainable Supabase query mock that resolves to `data`. */
+function buildQueryChain(data: unknown) {
+  const maybeSingle = vi.fn().mockResolvedValue({ data });
+  const limit = vi.fn().mockReturnValue({ maybeSingle });
+  const eq = vi.fn().mockImplementation(() => ({ eq, limit }));
+  const select = vi.fn().mockReturnValue({ eq });
+  return { select, eq, limit, maybeSingle };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Home (root page redirect)", () => {
+  it("redirects to personal workspace when one exists", async () => {
+    const personalChain = buildQueryChain({
+      workspace_id: "ws-personal",
+      workspaces: { slug: "my-personal" },
+    });
+
+    const mockFrom = vi.fn().mockReturnValue(personalChain);
+
+    mockedCreateClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: mockFrom,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    await expect(Home()).rejects.toThrow("NEXT_REDIRECT:/my-personal");
+    expect(mockRedirect).toHaveBeenCalledWith("/my-personal");
+
+    // Verify the first query uses !inner join for is_personal filtering
+    expect(personalChain.select).toHaveBeenCalledWith(
+      "workspace_id, workspaces!inner(slug)",
+    );
+  });
+
+  it("falls back to any workspace when no personal workspace exists", async () => {
+    const personalChain = buildQueryChain(null);
+    const fallbackChain = buildQueryChain({
+      workspace_id: "ws-team",
+      workspaces: { slug: "team-workspace" },
+    });
+
+    let callCount = 0;
+    const mockFrom = vi.fn().mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? personalChain : fallbackChain;
+    });
+
+    mockedCreateClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: mockFrom,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    await expect(Home()).rejects.toThrow("NEXT_REDIRECT:/team-workspace");
+    expect(mockRedirect).toHaveBeenCalledWith("/team-workspace");
+
+    // Two queries: personal (with !inner) then fallback
+    expect(mockFrom).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders landing page for unauthenticated users", async () => {
+    mockedCreateClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: null },
+        }),
+      },
+      from: vi.fn(),
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    // Should not throw (no redirect)
+    const result = await Home();
+    expect(result).toBeDefined();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("renders landing page when user has no workspaces", async () => {
+    const emptyChain = buildQueryChain(null);
+    const mockFrom = vi.fn().mockReturnValue(emptyChain);
+
+    mockedCreateClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: mockFrom,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const result = await Home();
+    expect(result).toBeDefined();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,14 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 
+/** Supabase may return the joined workspace as an object or array — normalise to a slug. */
+function extractSlug(
+  workspaces: { slug: string } | { slug: string }[] | null | undefined,
+): string | undefined {
+  if (Array.isArray(workspaces)) return workspaces[0]?.slug;
+  return workspaces?.slug;
+}
+
 export default async function Home() {
   const supabase = await createClient();
   const {
@@ -9,25 +17,32 @@ export default async function Home() {
   } = await supabase.auth.getUser();
 
   if (user) {
-    // Redirect authenticated users to their first workspace
-    const { data: membership } = await supabase
+    // Redirect authenticated users to their personal workspace.
+    // Use !inner join so the is_personal filter excludes non-matching rows.
+    const { data: personalMembership } = await supabase
+      .from("members")
+      .select("workspace_id, workspaces!inner(slug)")
+      .eq("user_id", user.id)
+      .eq("workspaces.is_personal", true)
+      .limit(1)
+      .maybeSingle();
+
+    const personalSlug = extractSlug(personalMembership?.workspaces);
+    if (personalSlug) {
+      redirect(`/${personalSlug}`);
+    }
+
+    // Fall back to any workspace if no personal workspace exists
+    const { data: anyMembership } = await supabase
       .from("members")
       .select("workspace_id, workspaces(slug)")
       .eq("user_id", user.id)
       .limit(1)
       .maybeSingle();
 
-    // Supabase types the joined relation based on schema — extract slug safely
-    const workspaces = membership?.workspaces as
-      | { slug: string }
-      | { slug: string }[]
-      | null
-      | undefined;
-    const slug = Array.isArray(workspaces)
-      ? workspaces[0]?.slug
-      : workspaces?.slug;
-    if (slug) {
-      redirect(`/${slug}`);
+    const anySlug = extractSlug(anyMembership?.workspaces);
+    if (anySlug) {
+      redirect(`/${anySlug}`);
     }
   }
 


### PR DESCRIPTION
Closes #152

## What

The root page (`/`) redirected authenticated users to whichever workspace Supabase returned first from an unfiltered `.limit(1).maybeSingle()` query on the `members` table. Depending on row ordering, this could land the user in a team workspace instead of their personal workspace.

## How

Changed the redirect query to first look for a membership whose joined workspace has `is_personal = true`, using a `workspaces!inner(slug)` join so the filter actually excludes non-matching parent rows. If no personal workspace exists (edge case), a second query falls back to any available workspace. Extracted a shared `extractSlug` helper to normalise the Supabase join result (object vs array).

## Testing

Added `src/app/page.test.tsx` with four regression tests:
- Redirects to personal workspace when one exists (verifies `!inner` join in select)
- Falls back to any workspace when no personal workspace exists (verifies two queries are made)
- Renders landing page for unauthenticated users
- Renders landing page when user has no workspaces at all

All existing tests continue to pass: `pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e` (178 unit tests, 42 E2E tests).