### PR TITLE
fix(perf): add loading skeleton for page navigation (#160)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/[pageId]/loading.test.ts
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/loading.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression tests for issue #160: slow navigation when clicking a page.
+ *
+ * The [pageId] route must have a loading.tsx so Next.js shows an instant
+ * skeleton during client-side navigation instead of blocking until the
+ * server component finishes fetching data.
+ */
+
+const PAGE_DIR = resolve(__dirname);
+
+describe("[pageId] route loading state", () => {
+  it("loading.tsx exists for the [pageId] route segment", () => {
+    expect(existsSync(resolve(PAGE_DIR, "loading.tsx"))).toBe(true);
+  });
+
+  it("loading skeleton uses the same layout container as page-view-client", () => {
+    const loading = readFileSync(resolve(PAGE_DIR, "loading.tsx"), "utf-8");
+    // Must match the outer container from PageViewClient
+    expect(loading).toContain("mx-auto max-w-3xl p-6");
+  });
+
+  it("loading skeleton includes animate-pulse elements", () => {
+    const loading = readFileSync(resolve(PAGE_DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("animate-pulse");
+  });
+
+  it("page.tsx parallelizes auth and workspace queries", () => {
+    const page = readFileSync(resolve(PAGE_DIR, "page.tsx"), "utf-8");
+    // The auth check and workspace lookup should run in parallel
+    expect(page).toContain("Promise.all");
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/[pageId]/loading.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/loading.tsx
@@ -1,0 +1,22 @@
+export default function PageLoading() {
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          {/* Title skeleton — matches the h1/input height in PageTitle */}
+          <div className="h-9 w-1/3 animate-pulse rounded bg-muted" />
+        </div>
+        {/* Menu button placeholder */}
+        <div className="h-8 w-8 animate-pulse rounded bg-muted" />
+      </div>
+      <div className="mt-4 space-y-3">
+        {/* Editor content skeleton lines */}
+        <div className="h-4 w-full animate-pulse rounded bg-muted" />
+        <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-4/6 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-full animate-pulse rounded bg-muted" />
+        <div className="h-4 w-3/6 animate-pulse rounded bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -11,19 +11,20 @@ export default async function PageView({
   const { workspaceSlug, pageId } = await params;
   const supabase = await createClient();
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  // Run auth check and workspace lookup in parallel to reduce waterfall
+  const [{ data: authData }, { data: workspace }] = await Promise.all([
+    supabase.auth.getUser(),
+    supabase
+      .from("workspaces")
+      .select("id")
+      .eq("slug", workspaceSlug)
+      .maybeSingle(),
+  ]);
 
+  const user = authData.user;
   if (!user) {
     notFound();
   }
-
-  const { data: workspace } = await supabase
-    .from("workspaces")
-    .select("id")
-    .eq("slug", workspaceSlug)
-    .maybeSingle();
 
   if (!workspace) {
     notFound();


### PR DESCRIPTION
Closes #160

## What

Navigating to a page via the sidebar blocked for 1-2 seconds because the `[pageId]/page.tsx` server component made three sequential Supabase queries (auth, workspace, page) with no `loading.tsx` fallback. Next.js had no instant loading state to show during client-side navigation, so the old page stayed visible until all queries completed.

## How

1. **Added `loading.tsx`** for the `[pageId]` route segment with an animated skeleton that matches the page layout (title bar + editor content lines). Next.js automatically wraps the page in a `<Suspense>` boundary using this file, showing the skeleton instantly during navigation.
2. **Parallelized queries** in `page.tsx` — the auth check (`getUser()`) and workspace lookup now run via `Promise.all` instead of sequentially, eliminating one round-trip from the waterfall.

## Testing

- Added `loading.test.ts` with 4 static analysis tests that verify:
  - `loading.tsx` exists (prevents accidental deletion)
  - Skeleton uses the same layout container as `PageViewClient`
  - Skeleton includes `animate-pulse` elements
  - `page.tsx` uses `Promise.all` for parallel queries
- All existing tests pass: 182 unit tests, 42 E2E tests, lint, typecheck