### PR TITLE
fix(ui): remove rounded corners from page loading skeletons (#165)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/[pageId]/loading.test.ts
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/loading.test.ts
@@ -28,6 +28,18 @@ describe("[pageId] route loading state", () => {
     expect(loading).toContain("animate-pulse");
   });
 
+  it("skeleton elements use sharp corners per design spec (#165)", () => {
+    const loading = readFileSync(resolve(PAGE_DIR, "loading.tsx"), "utf-8");
+    // Design spec: skeletons must have sharp corners — no rounded classes
+    // except the explicit exceptions listed in the Corners section.
+    const lines = loading.split("\n");
+    const skeletonLines = lines.filter((l) => l.includes("animate-pulse"));
+    expect(skeletonLines.length).toBeGreaterThan(0);
+    for (const line of skeletonLines) {
+      expect(line).not.toMatch(/\brounded\b/);
+    }
+  });
+
   it("page.tsx parallelizes auth and workspace queries", () => {
     const page = readFileSync(resolve(PAGE_DIR, "page.tsx"), "utf-8");
     // The auth check and workspace lookup should run in parallel

--- a/src/app/(app)/[workspaceSlug]/[pageId]/loading.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/loading.tsx
@@ -4,18 +4,18 @@ export default function PageLoading() {
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">
           {/* Title skeleton — matches the h1/input height in PageTitle */}
-          <div className="h-9 w-1/3 animate-pulse rounded bg-muted" />
+          <div className="h-9 w-1/3 animate-pulse bg-muted" />
         </div>
         {/* Menu button placeholder */}
-        <div className="h-8 w-8 animate-pulse rounded bg-muted" />
+        <div className="h-8 w-8 animate-pulse bg-muted" />
       </div>
       <div className="mt-4 space-y-3">
         {/* Editor content skeleton lines */}
-        <div className="h-4 w-full animate-pulse rounded bg-muted" />
-        <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
-        <div className="h-4 w-4/6 animate-pulse rounded bg-muted" />
-        <div className="h-4 w-full animate-pulse rounded bg-muted" />
-        <div className="h-4 w-3/6 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-full animate-pulse bg-muted" />
+        <div className="h-4 w-5/6 animate-pulse bg-muted" />
+        <div className="h-4 w-4/6 animate-pulse bg-muted" />
+        <div className="h-4 w-full animate-pulse bg-muted" />
+        <div className="h-4 w-3/6 animate-pulse bg-muted" />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #165

## What

The page loading skeleton in `loading.tsx` used `rounded` on all 7 skeleton `<div>` elements, violating the design spec which requires sharp corners on skeletons (`bg-muted animate-pulse`, no border-radius).

## How

Removed the `rounded` class from all skeleton elements in `src/app/(app)/[workspaceSlug]/[pageId]/loading.tsx`. This aligns with existing skeletons in `page-tree.tsx` and `page-search.tsx` which already use sharp corners.

## Testing

Added a regression test in `loading.test.ts` that verifies no `animate-pulse` skeleton element contains a `rounded` class. All 185 unit tests and 42 E2E tests pass.