### PR TITLE
docs: fix quality.md header to reflect actual update pattern

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -1,6 +1,6 @@
 # Quality Grades
 
-Updated weekly by the Automation Auditor. Tracks code quality per domain.
+Tracks code quality per domain. Updated by automations as a side effect of feature and test PRs, and through dedicated staleness issues when grades drift from reality.
 
 ## Grading Scale
 


### PR DESCRIPTION
The header claimed "Updated weekly by the Automation Auditor" — but the Automation Auditor has never run. In practice, quality.md is updated by multiple automations as a side effect of feature/test PRs (e.g., #114, #147), and through dedicated staleness issues (#108, #119, #155) when grades drift from reality.

Updates the header to match the actual behavior.