### PR TITLE
feat: add ⌘+K global shortcut to focus search input (#171)

### DIFF
--- a/src/components/sidebar/page-search.test.tsx
+++ b/src/components/sidebar/page-search.test.tsx
@@ -39,6 +39,13 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
+vi.mock("@/components/sidebar/sidebar-context", () => ({
+  useSidebar: () => ({
+    registerSearchRef: vi.fn(),
+    isMac: true,
+  }),
+}));
+
 // Track fetch calls
 let fetchMock: ReturnType<typeof vi.fn<typeof globalThis.fetch>>;
 

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { createClient } from "@/lib/supabase/client";
 import { captureSupabaseError } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
+import { useSidebar } from "@/components/sidebar/sidebar-context";
 
 interface SearchResult {
   id: string;
@@ -34,6 +35,7 @@ type SearchStatus = "idle" | "loading" | "done";
 export function PageSearch() {
   const router = useRouter();
   const params = useParams<{ workspaceSlug?: string }>();
+  const { registerSearchRef, isMac } = useSidebar();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [searchStatus, setSearchStatus] = useState<SearchStatus>("idle");
@@ -49,6 +51,11 @@ export function PageSearch() {
   // callbacks never update state. Immune to microtask ordering because
   // the counter is incremented synchronously before any async work.
   const searchGenRef = useRef(0);
+
+  // Register the search input ref so the sidebar context can focus it via ⌘+K
+  useEffect(() => {
+    registerSearchRef(inputRef);
+  }, [registerSearchRef]);
 
   // Resolve workspace slug to ID
   useEffect(() => {
@@ -293,7 +300,7 @@ export function PageSearch() {
         <Input
           ref={inputRef}
           type="text"
-          placeholder="Search pages…"
+          placeholder={`Search… ${isMac ? "⌘K" : "Ctrl+K"}`}
           value={query}
           onChange={(e) => {
             setQuery(e.target.value);

--- a/src/components/sidebar/sidebar-context.test.tsx
+++ b/src/components/sidebar/sidebar-context.test.tsx
@@ -5,11 +5,12 @@ import { SidebarProvider, useSidebar } from "./sidebar-context";
 
 // Helper component that exposes sidebar context values for assertions
 function SidebarConsumer() {
-  const { open, isMobile, setOpen, toggle } = useSidebar();
+  const { open, isMobile, isMac, setOpen, toggle } = useSidebar();
   return (
     <div>
       <span data-testid="open">{String(open)}</span>
       <span data-testid="is-mobile">{String(isMobile)}</span>
+      <span data-testid="is-mac">{String(isMac)}</span>
       <button data-testid="set-open-true" onClick={() => setOpen(true)}>
         Open
       </button>
@@ -215,6 +216,163 @@ describe("SidebarProvider", () => {
 
     // Should remain open — no modifier key
     expect(screen.getByTestId("open")).toHaveTextContent("true");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("⌘+K opens sidebar and focuses search input when sidebar is closed", async () => {
+    vi.stubGlobal("matchMedia", createMockMatchMedia(false));
+
+    const focusSpy = vi.fn();
+    const fakeInput = { focus: focusSpy } as unknown as HTMLInputElement;
+    const fakeRef = { current: fakeInput };
+
+    function SearchRegistrar() {
+      const { registerSearchRef } = useSidebar();
+      // Register on mount
+      registerSearchRef(fakeRef);
+      return null;
+    }
+
+    render(
+      <SidebarProvider>
+        <SidebarConsumer />
+        <SearchRegistrar />
+      </SidebarProvider>
+    );
+
+    // Close the sidebar first
+    act(() => {
+      screen.getByTestId("set-open-false").click();
+    });
+    expect(screen.getByTestId("open")).toHaveTextContent("false");
+
+    // Simulate ⌘+K
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "k",
+          metaKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    // Sidebar should open
+    expect(screen.getByTestId("open")).toHaveTextContent("true");
+
+    // Focus is deferred via rAF — flush it
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(focusSpy).toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("⌘+K does not fire when a Lexical editor element is focused", () => {
+    vi.stubGlobal("matchMedia", createMockMatchMedia(false));
+
+    render(
+      <SidebarProvider>
+        <SidebarConsumer />
+        {/* Simulate a Lexical editor element */}
+        <div data-lexical-editor="true">
+          <input data-testid="editor-input" />
+        </div>
+      </SidebarProvider>
+    );
+
+    // Close sidebar
+    act(() => {
+      screen.getByTestId("set-open-false").click();
+    });
+    expect(screen.getByTestId("open")).toHaveTextContent("false");
+
+    // Focus the editor input so document.activeElement is inside [data-lexical-editor]
+    const editorInput = screen.getByTestId("editor-input");
+    editorInput.focus();
+
+    // Simulate ⌘+K — should be ignored because editor is focused
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "k",
+          metaKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    // Sidebar should remain closed
+    expect(screen.getByTestId("open")).toHaveTextContent("false");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("Ctrl+K also triggers search focus (non-Mac)", () => {
+    vi.stubGlobal("matchMedia", createMockMatchMedia(false));
+
+    const focusSpy = vi.fn();
+    const fakeInput = { focus: focusSpy } as unknown as HTMLInputElement;
+    const fakeRef = { current: fakeInput };
+
+    function SearchRegistrar() {
+      const { registerSearchRef } = useSidebar();
+      registerSearchRef(fakeRef);
+      return null;
+    }
+
+    render(
+      <SidebarProvider>
+        <SidebarConsumer />
+        <SearchRegistrar />
+      </SidebarProvider>
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "k",
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    // Sidebar should remain open (was already open)
+    expect(screen.getByTestId("open")).toHaveTextContent("true");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("ignores K keydown without meta or ctrl modifier", () => {
+    vi.stubGlobal("matchMedia", createMockMatchMedia(false));
+
+    render(
+      <SidebarProvider>
+        <SidebarConsumer />
+      </SidebarProvider>
+    );
+
+    // Close sidebar
+    act(() => {
+      screen.getByTestId("set-open-false").click();
+    });
+    expect(screen.getByTestId("open")).toHaveTextContent("false");
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "k",
+          bubbles: true,
+        })
+      );
+    });
+
+    // Should remain closed — no modifier key
+    expect(screen.getByTestId("open")).toHaveTextContent("false");
 
     vi.unstubAllGlobals();
   });

--- a/src/components/sidebar/sidebar-context.tsx
+++ b/src/components/sidebar/sidebar-context.tsx
@@ -5,8 +5,10 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
   type ReactNode,
+  type RefObject,
 } from "react";
 
 interface SidebarContextValue {
@@ -14,15 +16,26 @@ interface SidebarContextValue {
   setOpen: (open: boolean) => void;
   toggle: () => void;
   isMobile: boolean;
+  isMac: boolean;
+  registerSearchRef: (ref: RefObject<HTMLInputElement | null>) => void;
+  focusSearch: () => void;
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
 
 const MOBILE_BREAKPOINT = 768;
 
+function isEditorFocused(): boolean {
+  return document.activeElement?.closest("[data-lexical-editor]") !== null;
+}
+
 export function SidebarProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(true);
   const [isMobile, setIsMobile] = useState(false);
+  const [isMac] = useState(
+    () => typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC")
+  );
+  const searchRef = useRef<RefObject<HTMLInputElement | null> | null>(null);
 
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
@@ -40,6 +53,21 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
 
   const toggle = useCallback(() => setOpen((prev) => !prev), []);
 
+  const registerSearchRef = useCallback(
+    (ref: RefObject<HTMLInputElement | null>) => {
+      searchRef.current = ref;
+    },
+    []
+  );
+
+  const focusSearch = useCallback(() => {
+    setOpen(true);
+    // Delay focus to allow the sidebar to render when opening from collapsed
+    requestAnimationFrame(() => {
+      searchRef.current?.current?.focus();
+    });
+  }, []);
+
   // ⌘+\ keyboard shortcut to toggle sidebar
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -52,8 +80,30 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [toggle]);
 
+  // ⌘+K keyboard shortcut to focus search — yields to editor's ⌘+K (link insertion)
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey) && !isEditorFocused()) {
+        e.preventDefault();
+        focusSearch();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [focusSearch]);
+
   return (
-    <SidebarContext.Provider value={{ open, setOpen, toggle, isMobile }}>
+    <SidebarContext.Provider
+      value={{
+        open,
+        setOpen,
+        toggle,
+        isMobile,
+        isMac,
+        registerSearchRef,
+        focusSearch,
+      }}
+    >
       {children}
     </SidebarContext.Provider>
   );


### PR DESCRIPTION
Closes #171

## What

Adds `⌘+K` (Mac) / `Ctrl+K` (Windows/Linux) as a global keyboard shortcut to focus the sidebar search input, matching the standard pattern in developer tools (VS Code, Linear, Notion).

## How

**`sidebar-context.tsx`**
- Added `focusSearch()` — opens the sidebar if collapsed, then focuses the search input via `requestAnimationFrame` (to allow the sidebar to render first).
- Added `registerSearchRef()` — lets `PageSearch` register its input ref with the context.
- Added `isMac` — computed once via lazy `useState` initializer for OS-aware shortcut display.
- Added `⌘+K` keydown listener that yields to the editor's `⌘+K` (link insertion) by checking `document.activeElement?.closest('[data-lexical-editor]')`.

**`page-search.tsx`**
- Registers its input ref with the sidebar context on mount.
- Updated placeholder to show the shortcut hint: `Search… ⌘K` or `Search… Ctrl+K`.

**Tests**
- 4 new tests in `sidebar-context.test.tsx`: shortcut opens sidebar + focuses search, suppressed when editor focused, Ctrl+K variant, ignored without modifier.
- Added `useSidebar` mock to `page-search.test.tsx` since `PageSearch` now depends on the sidebar context.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 190 tests pass ✅