### PR TITLE
feat: add ⌘+N global shortcut to create a new page (#172)

### DIFF
--- a/e2e/page-crud.spec.ts
+++ b/e2e/page-crud.spec.ts
@@ -37,6 +37,40 @@ test.describe("Page CRUD", () => {
     await expect(editor).toBeVisible({ timeout: 10_000 });
   });
 
+  test("user can create a new page with ⌘+N shortcut", async ({
+    authenticatedPage: page,
+  }) => {
+    const sidebar = page.getByRole("complementary");
+
+    // Wait for the page tree to load
+    const treeItem = sidebar.locator('[role="treeitem"]').first();
+    try {
+      await expect(treeItem).toBeVisible({ timeout: 10_000 });
+    } catch {
+      // Tree loaded but empty — that's fine
+    }
+
+    // Record the URL before the shortcut
+    const urlBefore = page.url();
+
+    // Press ⌘+N / Ctrl+N
+    await page.keyboard.press(`${mod}+n`);
+
+    // Wait for navigation to a page route (URL has at least 2 path segments)
+    await page.waitForURL(
+      (url) => url.pathname.split("/").filter(Boolean).length >= 2,
+      { timeout: 10_000 },
+    );
+
+    // URL should have changed (navigated to the new page)
+    expect(page.url()).not.toBe(urlBefore);
+
+    // The page title input should be focused (empty title auto-focuses)
+    const titleInput = page.locator('input[aria-label="Page title"]');
+    await expect(titleInput).toBeVisible({ timeout: 10_000 });
+    await expect(titleInput).toBeFocused({ timeout: 5_000 });
+  });
+
   test("user can navigate to a page via sidebar", async ({
     authenticatedPage: page,
   }) => {

--- a/src/components/sidebar/page-tree-shortcut.test.tsx
+++ b/src/components/sidebar/page-tree-shortcut.test.tsx
@@ -1,0 +1,220 @@
+import "@testing-library/jest-dom/vitest";
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- Mocks ---------------------------------------------------------------
+
+const mockPush = vi.fn();
+const mockWorkspaceSlug = "test-workspace";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ workspaceSlug: mockWorkspaceSlug }),
+}));
+
+const mockInsertSingle = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "workspaces") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({
+                  data: { id: "ws-uuid-123" },
+                  error: null,
+                }),
+            }),
+          }),
+        };
+      }
+      if (table === "pages") {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: () =>
+                Promise.resolve({ data: [], error: null }),
+            }),
+          }),
+          insert: () => ({
+            select: () => ({
+              single: mockInsertSingle,
+            }),
+          }),
+        };
+      }
+      return {};
+    },
+  }),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: vi.fn(),
+  isTransientNetworkError: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { PageTree } from "./page-tree";
+
+function createMockMatchMedia(matches: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe("PageTree ⌘+N shortcut", () => {
+  beforeEach(() => {
+    vi.stubGlobal("matchMedia", createMockMatchMedia(false));
+    mockPush.mockClear();
+    mockInsertSingle.mockReset();
+    mockInsertSingle.mockResolvedValue({
+      data: {
+        id: "new-page-id",
+        workspace_id: "ws-uuid-123",
+        parent_id: null,
+        title: "",
+        position: 0,
+        created_by: "user-123",
+      },
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("⌘+N creates a new page and navigates to it", async () => {
+    render(<PageTree userId="user-123" />);
+
+    // Wait for workspace resolution and page fetch
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "n",
+          metaKey: true,
+          bubbles: true,
+        }),
+      );
+      // Allow the async handleCreate to complete
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockInsertSingle).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(
+      `/${mockWorkspaceSlug}/new-page-id`,
+    );
+  });
+
+  it("Ctrl+N creates a new page and navigates to it", async () => {
+    render(<PageTree userId="user-123" />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "n",
+          ctrlKey: true,
+          bubbles: true,
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockInsertSingle).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(
+      `/${mockWorkspaceSlug}/new-page-id`,
+    );
+  });
+
+  it("ignores N keydown without meta or ctrl modifier", async () => {
+    render(<PageTree userId="user-123" />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "n",
+          bubbles: true,
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockInsertSingle).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("ignores ⌘+Shift+N (does not intercept browser new-window-incognito)", async () => {
+    render(<PageTree userId="user-123" />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "n",
+          metaKey: true,
+          shiftKey: true,
+          bubbles: true,
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockInsertSingle).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("calls preventDefault to suppress browser default new-window behavior", async () => {
+    render(<PageTree userId="user-123" />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "n",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+
+    await act(async () => {
+      window.dispatchEvent(event);
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -142,39 +142,54 @@ export function PageTree({ userId }: PageTreeProps) {
     });
   }, []);
 
-  async function handleCreate(parentId: string | null) {
-    if (!workspaceId || !workspaceSlug) return;
+  const handleCreate = useCallback(
+    async (parentId: string | null) => {
+      if (!workspaceId || !workspaceSlug) return;
 
-    const nextPosition = getNextSiblingPosition(pages, parentId);
+      const nextPosition = getNextSiblingPosition(pages, parentId);
 
-    const supabase = createClient();
-    const { data: newPage, error } = await supabase
-      .from("pages")
-      .insert({
-        workspace_id: workspaceId,
-        parent_id: parentId,
-        title: "",
-        position: nextPosition,
-        created_by: userId,
-      })
-      .select()
-      .single();
+      const supabase = createClient();
+      const { data: newPage, error } = await supabase
+        .from("pages")
+        .insert({
+          workspace_id: workspaceId,
+          parent_id: parentId,
+          title: "",
+          position: nextPosition,
+          created_by: userId,
+        })
+        .select()
+        .single();
 
-    if (error) {
-      captureSupabaseError(error, "page-tree:create-page");
-      toast.error("Failed to create page", { duration: 8000 });
-      return;
+      if (error) {
+        captureSupabaseError(error, "page-tree:create-page");
+        toast.error("Failed to create page", { duration: 8000 });
+        return;
+      }
+      if (!newPage) return;
+
+      setPages((prev) => [...prev, newPage]);
+
+      if (parentId) {
+        setExpanded((prev) => new Set(prev).add(parentId));
+      }
+
+      router.push(`/${workspaceSlug}/${newPage.id}`);
+    },
+    [workspaceId, workspaceSlug, pages, userId, router],
+  );
+
+  // ⌘+N / Ctrl+N global shortcut to create a new page
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "n" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        handleCreate(null);
+      }
     }
-    if (!newPage) return;
-
-    setPages((prev) => [...prev, newPage]);
-
-    if (parentId) {
-      setExpanded((prev) => new Set(prev).add(parentId));
-    }
-
-    router.push(`/${workspaceSlug}/${newPage.id}`);
-  }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleCreate]);
 
   async function handleDelete() {
     if (!deleteTarget) return;


### PR DESCRIPTION
Closes #172

## What

Adds a global `⌘+N` (Mac) / `Ctrl+N` (Windows/Linux) keyboard shortcut that creates a new page at the root level and navigates to it. The page title input auto-focuses so the user can immediately start typing.

## How

- Converted `handleCreate` in `PageTree` from a plain function to `useCallback` so it can be a stable dependency for the shortcut's `useEffect`.
- Added a `useEffect` in `PageTree` that registers a global `keydown` listener for `⌘+N` / `Ctrl+N`, calling `handleCreate(null)` to create a root-level page. Explicitly checks `!e.shiftKey && !e.altKey` to avoid intercepting `⌘+Shift+N` (incognito window).
- `e.preventDefault()` suppresses the browser's default new-window behavior.
- Title auto-focus is handled by the existing `PageTitle` component which focuses when `initialTitle` is empty.

## Testing

- **Unit tests** (`page-tree-shortcut.test.tsx`): 5 tests covering `⌘+N`, `Ctrl+N`, no-modifier ignored, `⌘+Shift+N` ignored, and `preventDefault` called.
- **E2E test** (`page-crud.spec.ts`): verifies the shortcut creates a page, navigates to it, and focuses the title input.
- `pnpm lint && pnpm typecheck && pnpm test` — all 191 tests pass.
- `pnpm test:e2e -- e2e/page-crud.spec.ts` — all 5 tests pass.