### PR TITLE
feat: add loading skeletons for workspace home and app shell (#173)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/loading.test.ts
+++ b/src/app/(app)/[workspaceSlug]/loading.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("[workspaceSlug] route loading state", () => {
+  it("loading.tsx exists for the workspace route segment", () => {
+    expect(existsSync(resolve(DIR, "loading.tsx"))).toBe(true);
+  });
+
+  it("loading skeleton uses the same layout container as workspace-home", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("mx-auto max-w-3xl p-6");
+  });
+
+  it("loading skeleton includes animate-pulse elements", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("animate-pulse");
+  });
+
+  it("skeleton elements use bg-muted per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("bg-muted");
+  });
+
+  it("skeleton elements use sharp corners per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    const lines = loading.split("\n");
+    const skeletonLines = lines.filter((l) => l.includes("animate-pulse"));
+    expect(skeletonLines.length).toBeGreaterThan(0);
+    for (const line of skeletonLines) {
+      expect(line).not.toMatch(/\brounded\b/);
+    }
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/loading.tsx
+++ b/src/app/(app)/[workspaceSlug]/loading.tsx
@@ -1,0 +1,27 @@
+export default function WorkspaceLoading() {
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <div className="flex items-center justify-between">
+        {/* Workspace name heading */}
+        <div className="h-8 w-48 animate-pulse bg-muted" />
+        {/* "New Page" button */}
+        <div className="h-8 w-24 animate-pulse bg-muted" />
+      </div>
+      <div className="mt-6 flex flex-col gap-0.5">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2 px-3 py-2">
+            {/* Page icon */}
+            <div className="h-4 w-4 shrink-0 animate-pulse bg-muted" />
+            {/* Page title */}
+            <div
+              className="h-4 flex-1 animate-pulse bg-muted"
+              style={{ maxWidth: `${60 + ((i * 17) % 30)}%` }}
+            />
+            {/* Timestamp */}
+            <div className="h-3 w-12 shrink-0 animate-pulse bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/loading.test.ts
+++ b/src/app/(app)/loading.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("(app) route loading state", () => {
+  it("loading.tsx exists for the app route segment", () => {
+    expect(existsSync(resolve(DIR, "loading.tsx"))).toBe(true);
+  });
+
+  it("loading skeleton includes animate-pulse elements", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("animate-pulse");
+  });
+
+  it("skeleton elements use bg-muted per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("bg-muted");
+  });
+
+  it("skeleton elements use sharp corners per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    const lines = loading.split("\n");
+    const skeletonLines = lines.filter((l) => l.includes("animate-pulse"));
+    expect(skeletonLines.length).toBeGreaterThan(0);
+    for (const line of skeletonLines) {
+      expect(line).not.toMatch(/\brounded\b/);
+    }
+  });
+});

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,0 +1,23 @@
+export default function AppLoading() {
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      {/* Heading row skeleton */}
+      <div className="flex items-center justify-between">
+        <div className="h-8 w-40 animate-pulse bg-muted" />
+        <div className="h-8 w-20 animate-pulse bg-muted" />
+      </div>
+      {/* Content area skeleton */}
+      <div className="mt-6 space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2 px-3 py-2">
+            <div className="h-4 w-4 shrink-0 animate-pulse bg-muted" />
+            <div
+              className="h-4 flex-1 animate-pulse bg-muted"
+              style={{ maxWidth: `${55 + ((i * 13) % 35)}%` }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #173

## What

Adds `loading.tsx` files for the workspace home route (`[workspaceSlug]`) and the app-level route (`(app)`), eliminating blank flashes during navigation.

## How

- **`src/app/(app)/[workspaceSlug]/loading.tsx`** — skeleton matching the `WorkspaceHome` layout: heading + button row, then 6 page list rows with icon, title, and timestamp placeholders. Uses the same `mx-auto max-w-3xl p-6` container and `gap-0.5` row spacing.
- **`src/app/(app)/loading.tsx`** — skeleton for the main content area during app-level route transitions. Shows a generic heading row + content rows. The sidebar is already rendered by the `(app)/layout.tsx`, so this skeleton only fills the `{children}` slot.
- All skeleton elements use `bg-muted animate-pulse` with sharp corners per design spec.
- Varying widths on skeleton rows prevent a uniform/artificial look.

## Note on initial app load

The `(app)/layout.tsx` accesses runtime data (`cookies()`, `auth.getUser()`), so per Next.js behavior, `loading.tsx` at this level does not show during the initial layout render — navigation blocks until the layout resolves. The skeleton activates during subsequent client-side navigations within the app shell (e.g., switching workspaces).

## Testing

- 9 new static analysis tests (5 for workspace skeleton, 4 for app skeleton) verifying file existence, correct container classes, `animate-pulse` usage, `bg-muted` usage, and sharp corners.
- `pnpm lint && pnpm typecheck && pnpm test` — 199/199 tests pass.