### PR TITLE
fix: decouple search callback from workspace state to prevent race conditions (#178)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -117,6 +117,40 @@ The `updateSession` function in `src/lib/supabase/proxy.ts` creates a server cli
 that reads cookies from the request and writes refreshed cookies to the response.
 It calls `supabase.auth.getUser()` to trigger the refresh.
 
+## Async State in Effects
+
+When a `useCallback` closes over async state (e.g. a resolved ID), putting that
+state in the dependency array causes the callback reference to change whenever the
+state resolves. If a `useEffect` depends on that callback, the effect re-runs,
+creating a cascade of state transitions that race with each other.
+
+**Pattern:** store async state in a ref and read it inside the callback so the
+callback identity is stable. Use a separate effect to re-trigger work when the
+async state resolves.
+
+```typescript
+// ❌ Bad — callback changes when workspaceId resolves, re-triggering the effect
+const search = useCallback(async (q) => {
+  fetch(`/api?ws=${workspaceId}`);
+}, [workspaceId]);
+
+useEffect(() => { /* debounce */ search(query); }, [query, search]);
+
+// ✅ Good — callback is stable, dedicated effect handles late resolution
+const wsRef = useRef(workspaceId);
+wsRef.current = workspaceId;
+
+const search = useCallback(async (q) => {
+  fetch(`/api?ws=${wsRef.current}`);
+}, []);
+
+useEffect(() => { /* debounce */ search(query); }, [query, search]);
+useEffect(() => { if (workspaceId) search(query); }, [workspaceId]);
+```
+
+Also: always add `.catch()` to fire-and-forget promises in effects. An unhandled
+rejection silently prevents state transitions, leaving the UI stuck.
+
 ## Error Handling
 
 All errors must reach Sentry. `console.error` alone is never sufficient — always

--- a/src/components/sidebar/page-search.test.tsx
+++ b/src/components/sidebar/page-search.test.tsx
@@ -379,20 +379,14 @@ describe("PageSearch", () => {
       screen.queryByText("No pages match your search")
     ).not.toBeInTheDocument();
 
-    // Now resolve the workspace — this triggers a new search via the
-    // search callback getting a new workspaceId reference
+    // Now resolve the workspace — the workspace-resolved effect
+    // re-triggers the search immediately (no debounce).
     await act(async () => {
       resolveWorkspace!({
         data: { id: "ws-uuid-123" },
         error: null,
       });
       await vi.advanceTimersByTimeAsync(50);
-    });
-
-    // Debounce effect re-runs because search changed (new workspaceId).
-    // Advance past the new 300ms debounce.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(350);
     });
 
     // Now the empty state should show
@@ -510,5 +504,113 @@ describe("PageSearch", () => {
 
     // AbortError should NOT have been sent to Sentry
     expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("shows empty state when workspace resolves after debounce fires (#178)", async () => {
+    // Regression test for #178: when workspace resolution is slow and
+    // completes after the debounce timer fires, the old code re-ran the
+    // debounce effect (because the search callback changed identity),
+    // creating a cascade of loading→done→loading transitions that could
+    // leave searchStatus stuck at "loading". The fix decouples the search
+    // callback from workspaceId by using a ref, and adds a dedicated
+    // effect to re-trigger search when the workspace resolves.
+
+    // Make workspace resolution slow
+    let resolveWorkspace: (value: unknown) => void;
+    mockMaybeSingle.mockReturnValue(
+      new Promise((resolve) => {
+        resolveWorkspace = resolve;
+      })
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "zzzyyyxxxnonexistent999");
+
+    // Advance past debounce — search fires but workspaceId is null
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // Skeletons should show (workspace not resolved)
+    const searchResults = screen.getByRole("listbox");
+    expect(searchResults.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.queryByText("No pages match your search")).not.toBeInTheDocument();
+
+    // Resolve workspace — the workspace-resolved effect fires a new
+    // search immediately (no 300ms debounce delay).
+    await act(async () => {
+      resolveWorkspace!({
+        data: { id: "ws-uuid-123" },
+        error: null,
+      });
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // The fetch should have been called with the workspace ID
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("workspace_id=ws-uuid-123"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+
+    // Empty state should now show (not stuck on skeletons)
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+    expect(searchResults.querySelectorAll(".animate-pulse").length).toBe(0);
+  });
+
+  it("shows empty state when workspace resolution rejects (#178)", async () => {
+    // Regression test for #178: the old code had no .catch() on the
+    // workspace resolution promise. If retryOnNetworkError rejected,
+    // workspaceResolved stayed false forever, causing infinite skeletons.
+    const captureException = vi.mocked(
+      (await import("@sentry/nextjs")).captureException
+    );
+
+    mockMaybeSingle.mockImplementation(() => {
+      throw new Error("Unexpected Supabase error");
+    });
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    // Wait for workspace resolution to reject and .catch() to fire
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "zzzyyyxxxnonexistent999");
+
+    // Advance past debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // The error should have been captured in Sentry
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Unexpected Supabase error" })
+    );
+
+    // Empty state should show (workspaceResolved=true from .catch(),
+    // workspaceId=null, so search early-returns with done status)
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+
+    // No skeletons
+    const searchResults = screen.getByRole("listbox");
+    expect(searchResults.querySelectorAll(".animate-pulse").length).toBe(0);
   });
 });

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -21,10 +21,9 @@ interface SearchResult {
 }
 
 /**
- * Search display status — a single discriminated value replaces the
- * previous independent `loading` + `searched` booleans. This eliminates
- * the class of race conditions where the two flags get out of sync
- * (the root cause of issues #118, #126, #136, #144, #162).
+ * Search display status — a single discriminated value that eliminates
+ * the class of race conditions where independent flags get out of sync
+ * (the root cause of issues #118, #126, #136, #144, #162, #178).
  *
  * - "idle"    — no query entered or query was cleared
  * - "loading" — a search is in-flight (show skeleton placeholders)
@@ -47,10 +46,23 @@ export function PageSearch() {
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // Ref mirror of workspaceId so the search callback can read the
+  // latest value without being recreated when it changes. This
+  // decouples workspace resolution from the debounce effect and
+  // eliminates the cascade of effect re-runs that caused issues
+  // #118, #126, #136, #144, #162, #178.
+  const workspaceIdRef = useRef<string | null>(null);
+  // Ref mirror of query so the workspace-resolved effect can read
+  // the current query without adding it as a dependency.
+  const queryRef = useRef("");
   // Generation counter: incremented each search cycle so stale async
   // callbacks never update state. Immune to microtask ordering because
   // the counter is incremented synchronously before any async work.
   const searchGenRef = useRef(0);
+
+  // Keep refs in sync with state.
+  workspaceIdRef.current = workspaceId;
+  queryRef.current = query;
 
   // Register the search input ref so the sidebar context can focus it via ⌘+K
   useEffect(() => {
@@ -75,30 +87,36 @@ export function PageSearch() {
         .select("id")
         .eq("slug", params.workspaceSlug)
         .maybeSingle();
-    }).then(({ data, error }) => {
-      if (cancelled) return;
-      if (error) {
-        captureSupabaseError(error, "page-search:workspace-lookup");
+    })
+      .then(({ data, error }) => {
+        if (cancelled) return;
+        if (error) {
+          captureSupabaseError(error, "page-search:workspace-lookup");
+          setWorkspaceResolved(true);
+          return;
+        }
+        setWorkspaceId(data?.id ?? null);
         setWorkspaceResolved(true);
-        return;
-      }
-      setWorkspaceId(data?.id ?? null);
-      setWorkspaceResolved(true);
-    });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        Sentry.captureException(error);
+        setWorkspaceResolved(true);
+      });
 
     return () => {
       cancelled = true;
     };
   }, [params.workspaceSlug]);
 
+  // Stable search function — reads workspaceId from a ref so it never
+  // changes identity. The debounce effect depends only on `query`.
   const search = useCallback(
     async (q: string, gen: number, signal: AbortSignal) => {
-      if (!q.trim() || !workspaceId) {
+      const wsId = workspaceIdRef.current;
+      if (!q.trim() || !wsId) {
         if (searchGenRef.current === gen) {
           setResults([]);
-          // Mark as done — the search resolved (even without a fetch).
-          // The render logic uses `workspaceResolved` to decide whether
-          // to show skeletons or the empty state.
           setSearchStatus("done");
         }
         return;
@@ -106,7 +124,7 @@ export function PageSearch() {
 
       try {
         const response = await fetch(
-          `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(workspaceId)}`,
+          `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(wsId)}`,
           { signal }
         );
         if (searchGenRef.current !== gen) return;
@@ -132,10 +150,12 @@ export function PageSearch() {
         }
       }
     },
-    [workspaceId]
+    [] // stable — reads workspaceId from ref
   );
 
-  // Debounced search with abort + generation counter.
+  // Debounced search — depends only on `query`. Decoupled from
+  // workspace resolution so the effect never re-runs when
+  // workspaceId changes.
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
@@ -171,6 +191,37 @@ export function PageSearch() {
       controller.abort();
     };
   }, [query, search]);
+
+  // When workspaceId resolves and there is an active query whose
+  // search returned early (because workspaceId was null), re-trigger
+  // the search immediately so the user sees real results.
+  useEffect(() => {
+    if (!workspaceId || !workspaceResolved) return;
+    const q = queryRef.current;
+    if (!q.trim()) return;
+    // Only re-search if a search cycle is active (not idle).
+    if (searchStatus === "idle") return;
+
+    // Cancel any in-flight request from the debounce effect.
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+
+    const gen = ++searchGenRef.current;
+    setSearchStatus("loading");
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    // Fire immediately — no debounce needed since the user already
+    // waited for the workspace to resolve.
+    search(q, gen, controller.signal);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, workspaceResolved]);
 
   // Close on click outside
   useEffect(() => {


### PR DESCRIPTION
Closes #178

## What

The search empty state ("No pages match your search") never rendered reliably when searching for a nonsense string. Skeleton loading placeholders showed indefinitely instead. This is the same class of bug previously tracked in #126, #136, #144, and #162 — each fix addressed a specific race condition but the underlying architecture remained fragile.

The root cause: the `search` callback depended on `workspaceId` via `useCallback`, so its reference changed whenever the workspace resolved. This caused the debounce effect (which depended on `[query, search]`) to re-run, creating a cascade of `loading→done→loading` state transitions that could race with each other. Additionally, the workspace resolution promise had no `.catch()` handler — if it rejected, `workspaceResolved` stayed `false` forever, causing infinite skeletons.

## How

1. **Decoupled the search callback from workspace state** — `workspaceId` is now read from a ref (`workspaceIdRef`) inside the callback, making the callback identity stable (empty dependency array). The debounce effect depends only on `query`, so it never re-runs when the workspace resolves.

2. **Added a dedicated workspace-resolved effect** — when `workspaceId` resolves and there's an active query, this effect re-triggers the search immediately (no debounce delay) so the user sees real results instead of skeletons.

3. **Added `.catch()` to the workspace resolution promise** — if `retryOnNetworkError` rejects, `workspaceResolved` is set to `true` and the error is captured in Sentry, preventing the UI from getting stuck on skeletons.

4. **Added convention to `.agents/conventions.md`** — documents the ref-based pattern for async state in effect dependencies to prevent this class of bug from recurring.

## Testing

- Added regression test "shows empty state when workspace resolves after debounce fires (#178)" — simulates slow workspace resolution completing after the search debounce fires, verifying the workspace-resolved effect re-triggers the search and the empty state renders.
- Added regression test "shows empty state when workspace resolution rejects (#178)" — verifies the `.catch()` handler sets `workspaceResolved=true` and the error reaches Sentry.
- All 8 existing page-search unit tests continue to pass.
- All 5 E2E search tests pass locally, including the previously failing "search with no matches shows empty state".
- `pnpm lint && pnpm typecheck && pnpm test` all pass (206 tests).