### PR TITLE
fix: search empty state stuck on skeletons when workspace resolves late (#178)

### DIFF
--- a/src/components/sidebar/page-search.test.tsx
+++ b/src/components/sidebar/page-search.test.tsx
@@ -379,8 +379,8 @@ describe("PageSearch", () => {
       screen.queryByText("No pages match your search")
     ).not.toBeInTheDocument();
 
-    // Now resolve the workspace — this triggers a new search via the
-    // search callback getting a new workspaceId reference
+    // Now resolve the workspace — the workspaceId effect triggers an
+    // immediate re-search (no debounce) via the re-trigger effect.
     await act(async () => {
       resolveWorkspace!({
         data: { id: "ws-uuid-123" },
@@ -389,16 +389,77 @@ describe("PageSearch", () => {
       await vi.advanceTimersByTimeAsync(50);
     });
 
-    // Debounce effect re-runs because search changed (new workspaceId).
-    // Advance past the new 300ms debounce.
+    // Now the empty state should show — no extra 300ms debounce needed
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state immediately when workspace resolves after search debounce", async () => {
+    // Regression test for #178: when the workspace resolves after the
+    // search debounce already fired (with workspaceId=null), the search
+    // must re-fire immediately without an additional 300ms debounce.
+    // The old code recreated the search callback when workspaceId changed,
+    // which re-triggered the debounce effect with a fresh 300ms delay.
+    // With production latency this caused the total wait to exceed the
+    // E2E timeout, leaving skeletons visible indefinitely.
+    let resolveWorkspace: (value: unknown) => void;
+    mockMaybeSingle.mockReturnValue(
+      new Promise((resolve) => {
+        resolveWorkspace = resolve;
+      })
+    );
+
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "zzzyyyxxxnonexistent999");
+
+    // Advance past debounce — search fires but workspaceId is null
     await act(async () => {
       await vi.advanceTimersByTimeAsync(350);
     });
 
-    // Now the empty state should show
+    // Skeletons should show (workspace not resolved)
+    const searchResults = screen.getByRole("listbox");
+    expect(searchResults.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.queryByText("No pages match your search")).not.toBeInTheDocument();
+
+    // No fetch should have been made yet (workspaceId was null)
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Resolve workspace — search should re-fire immediately (no debounce)
+    await act(async () => {
+      resolveWorkspace!({
+        data: { id: "ws-uuid-123" },
+        error: null,
+      });
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // The fetch should have been called with the query
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("zzzyyyxxxnonexistent999"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+
+    // Empty state should show immediately — no extra 300ms debounce
     expect(
       screen.getByText("No pages match your search")
     ).toBeInTheDocument();
+    expect(searchResults.querySelectorAll(".animate-pulse").length).toBe(0);
   });
 
   it("shows empty state when workspace resolves to null (workspace not found)", async () => {

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -51,6 +51,10 @@ export function PageSearch() {
   // callbacks never update state. Immune to microtask ordering because
   // the counter is incremented synchronously before any async work.
   const searchGenRef = useRef(0);
+  // Ref mirrors workspaceId state so the search callback can read the
+  // latest value without being recreated (which would re-trigger the
+  // debounce effect and add an unnecessary 300ms delay).
+  const workspaceIdRef = useRef<string | null>(null);
 
   // Register the search input ref so the sidebar context can focus it via ⌘+K
   useEffect(() => {
@@ -60,6 +64,7 @@ export function PageSearch() {
   // Resolve workspace slug to ID
   useEffect(() => {
     if (!params.workspaceSlug) {
+      workspaceIdRef.current = null;
       setWorkspaceId(null);
       setWorkspaceResolved(true);
       return;
@@ -82,7 +87,9 @@ export function PageSearch() {
         setWorkspaceResolved(true);
         return;
       }
-      setWorkspaceId(data?.id ?? null);
+      const id = data?.id ?? null;
+      workspaceIdRef.current = id;
+      setWorkspaceId(id);
       setWorkspaceResolved(true);
     });
 
@@ -91,9 +98,14 @@ export function PageSearch() {
     };
   }, [params.workspaceSlug]);
 
+  // Reads workspaceIdRef (not the state) so the callback identity is stable
+  // and doesn't cause the debounce effect to re-run when the workspace
+  // resolves. A separate effect handles re-triggering the search when
+  // workspaceId becomes available.
   const search = useCallback(
     async (q: string, gen: number, signal: AbortSignal) => {
-      if (!q.trim() || !workspaceId) {
+      const wsId = workspaceIdRef.current;
+      if (!q.trim() || !wsId) {
         if (searchGenRef.current === gen) {
           setResults([]);
           // Mark as done — the search resolved (even without a fetch).
@@ -106,7 +118,7 @@ export function PageSearch() {
 
       try {
         const response = await fetch(
-          `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(workspaceId)}`,
+          `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(wsId)}`,
           { signal }
         );
         if (searchGenRef.current !== gen) return;
@@ -132,7 +144,7 @@ export function PageSearch() {
         }
       }
     },
-    [workspaceId]
+    []
   );
 
   // Debounced search with abort + generation counter.
@@ -171,6 +183,40 @@ export function PageSearch() {
       controller.abort();
     };
   }, [query, search]);
+
+  // When workspaceId becomes available and there is an active query,
+  // re-trigger the search immediately (no debounce). This covers the
+  // case where the initial search completed with workspaceId=null
+  // (early return → searchStatus="done") and the workspace resolved
+  // afterwards. Without this, the empty state would never show because
+  // the debounce effect wouldn't re-run (search callback is now stable).
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
+  useEffect(() => {
+    if (!workspaceId || !queryRef.current.trim()) return;
+
+    // Abort any in-flight request from the debounce effect
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+
+    const gen = ++searchGenRef.current;
+    setSearchStatus("loading");
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    search(queryRef.current, gen, controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, [workspaceId, search]);
 
   // Close on click outside
   useEffect(() => {


### PR DESCRIPTION
Closes #178

## What

The search empty state ("No pages match your search") never appeared when the workspace resolution was slow relative to the search debounce. The `search` callback depended on `workspaceId` via `useCallback`, so when the workspace resolved, the callback got a new identity, re-triggering the debounce effect with a fresh 300ms delay. With production network latency the total wait (workspace resolution + 300ms debounce + fetch) exceeded the E2E timeout, leaving skeleton loaders visible indefinitely.

## How

Store `workspaceId` in a ref (`workspaceIdRef`) so the `search` callback reads the latest value without being recreated. This makes the callback stable (`useCallback(fn, [])`) and prevents the debounce effect from re-running when the workspace resolves. A separate effect watches `workspaceId` state and immediately re-triggers the search (bypassing the 300ms debounce) when the workspace becomes available and there is an active query.

## Testing

- Added regression test "shows empty state immediately when workspace resolves after search debounce" that simulates slow workspace resolution: the workspace hangs while the user types, the debounce fires with `workspaceId=null`, then the workspace resolves — verifies the empty state appears immediately without an extra 300ms debounce.
- Updated existing test "shows skeletons while workspace is resolving" to reflect the faster re-trigger behavior (no extra 300ms wait after workspace resolves).
- All 205 unit tests pass, all 43 E2E tests pass, lint and typecheck clean.