### PR TITLE
fix(editor): align placeholder with content area

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -182,7 +182,7 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
                 className="outline-none min-h-[200px] text-sm"
                 aria-placeholder="Type '/' for commands"
                 placeholder={
-                  <div className="pointer-events-none absolute top-0 left-0 text-sm text-muted-foreground">
+                  <div className="pointer-events-none absolute top-0.5 left-8 text-sm text-muted-foreground">
                     Type &apos;/&apos; for commands
                   </div>
                 }


### PR DESCRIPTION
The editor placeholder ("Type '/' for commands") was positioned at `left-0` of the anchor container, which includes the `-ml-8` drag handle gutter. This placed it 32px left of where text actually renders, overlapping the drag handle and misaligning with the page title.

**Changes:**
- `left-0` → `left-8` to match the `pl-8` content padding on the anchor container
- `top-0` → `top-0.5` to match the paragraph `mt-0.5` theme class

Closes #182