### PR TITLE
feat: add page icon emoji picker (#174)

### DIFF
--- a/e2e/page-icon.spec.ts
+++ b/e2e/page-icon.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from "./fixtures/auth";
+import { navigateToEditorPage } from "./fixtures/editor-helpers";
+
+test.describe("Page Icon Emoji Picker", () => {
+  test("user can set a page icon via emoji picker", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToEditorPage(page);
+
+    // Find the page icon button (either shows an emoji or the "Add page icon" label)
+    const iconButton = page.getByRole("button", { name: /page icon|add page icon/i });
+    await expect(iconButton).toBeVisible({ timeout: 5_000 });
+
+    // Click to open the emoji picker
+    await iconButton.click();
+
+    // The emoji picker dialog should appear
+    const picker = page.getByRole("dialog", { name: /emoji picker/i });
+    await expect(picker).toBeVisible({ timeout: 3_000 });
+
+    // Filter input should be focused
+    const filterInput = picker.getByRole("textbox", { name: /filter/i });
+    await expect(filterInput).toBeVisible();
+
+    // Select an emoji (the rocket emoji from Symbols category)
+    const rocketButton = picker.getByRole("button", { name: /select 🚀/i });
+    await rocketButton.click();
+
+    // Picker should close
+    await expect(picker).not.toBeVisible({ timeout: 2_000 });
+
+    // The icon button should now show the selected emoji
+    const updatedButton = page.getByRole("button", { name: /page icon: 🚀/i });
+    await expect(updatedButton).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("user can remove a page icon", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToEditorPage(page);
+
+    // First set an icon
+    const iconButton = page.getByRole("button", { name: /page icon|add page icon/i });
+    await expect(iconButton).toBeVisible({ timeout: 5_000 });
+    await iconButton.click();
+
+    const picker = page.getByRole("dialog", { name: /emoji picker/i });
+    await expect(picker).toBeVisible({ timeout: 3_000 });
+
+    // Select a star emoji
+    const starButton = picker.getByRole("button", { name: /select ⭐/i });
+    await starButton.click();
+    await expect(picker).not.toBeVisible({ timeout: 2_000 });
+
+    // Now reopen the picker
+    const iconWithEmoji = page.getByRole("button", { name: /page icon: ⭐/i });
+    await expect(iconWithEmoji).toBeVisible({ timeout: 3_000 });
+    await iconWithEmoji.click();
+
+    const picker2 = page.getByRole("dialog", { name: /emoji picker/i });
+    await expect(picker2).toBeVisible({ timeout: 3_000 });
+
+    // Click "Remove icon"
+    const removeButton = picker2.getByRole("button", { name: /remove icon/i });
+    await expect(removeButton).toBeVisible();
+    await removeButton.click();
+
+    // Picker should close and icon should be removed
+    await expect(picker2).not.toBeVisible({ timeout: 2_000 });
+
+    // The button should revert to "Add page icon"
+    const addIconButton = page.getByRole("button", { name: /add page icon/i });
+    await expect(addIconButton).toBeVisible({ timeout: 3_000 });
+  });
+
+  test("emoji picker closes on Escape", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToEditorPage(page);
+
+    const iconButton = page.getByRole("button", { name: /page icon|add page icon/i });
+    await expect(iconButton).toBeVisible({ timeout: 5_000 });
+    await iconButton.click();
+
+    const picker = page.getByRole("dialog", { name: /emoji picker/i });
+    await expect(picker).toBeVisible({ timeout: 3_000 });
+
+    // Press Escape to close
+    await page.keyboard.press("Escape");
+    await expect(picker).not.toBeVisible({ timeout: 2_000 });
+  });
+
+  test("emoji picker can filter by category", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToEditorPage(page);
+
+    const iconButton = page.getByRole("button", { name: /page icon|add page icon/i });
+    await expect(iconButton).toBeVisible({ timeout: 5_000 });
+    await iconButton.click();
+
+    const picker = page.getByRole("dialog", { name: /emoji picker/i });
+    await expect(picker).toBeVisible({ timeout: 3_000 });
+
+    // Type a filter term
+    const filterInput = picker.getByRole("textbox", { name: /filter/i });
+    await filterInput.fill("Animals");
+
+    // Animals category should be visible
+    await expect(picker.getByText("Animals")).toBeVisible();
+
+    // Other categories should not be visible
+    await expect(picker.getByText("Smileys")).not.toBeVisible();
+    await expect(picker.getByText("Objects")).not.toBeVisible();
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -48,6 +48,7 @@ export default async function PageView({
     <PageViewClient
       pageId={page.id}
       pageTitle={page.title}
+      pageIcon={page.icon ?? null}
       initialContent={initialContent}
       workspaceId={workspace.id}
       workspaceSlug={workspaceSlug}

--- a/src/components/emoji-picker.tsx
+++ b/src/components/emoji-picker.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  computePosition,
+  offset,
+  flip,
+  shift,
+  autoUpdate,
+} from "@floating-ui/react";
+
+const EMOJI_CATEGORIES: { label: string; emojis: string[] }[] = [
+  {
+    label: "Smileys",
+    emojis: [
+      "😀", "😃", "😄", "😁", "😆", "😅", "🤣", "😂",
+      "🙂", "😊", "😇", "🥰", "😍", "🤩", "😘", "😎",
+    ],
+  },
+  {
+    label: "Gestures",
+    emojis: [
+      "👋", "🤚", "✋", "🖖", "👌", "🤌", "✌️", "🤞",
+      "👍", "👎", "👏", "🙌", "🤝", "🙏", "💪", "🫶",
+    ],
+  },
+  {
+    label: "Objects",
+    emojis: [
+      "📄", "📝", "📋", "📌", "📎", "🔗", "📐", "📏",
+      "📁", "📂", "🗂️", "📊", "📈", "📉", "🗒️", "🗓️",
+    ],
+  },
+  {
+    label: "Symbols",
+    emojis: [
+      "⭐", "🌟", "💡", "🔥", "❤️", "💎", "🎯", "🏆",
+      "✅", "❌", "⚠️", "💬", "🔔", "🚀", "⚡", "🎉",
+    ],
+  },
+  {
+    label: "Nature",
+    emojis: [
+      "🌱", "🌿", "🍀", "🌸", "🌺", "🌻", "🌈", "☀️",
+      "🌙", "⛅", "🌊", "🍎", "🍊", "🍋", "🫐", "🍇",
+    ],
+  },
+  {
+    label: "Animals",
+    emojis: [
+      "🐶", "🐱", "🐭", "🐹", "🐰", "🦊", "🐻", "🐼",
+      "🐸", "🐵", "🐔", "🐧", "🐦", "🦅", "🦋", "🐝",
+    ],
+  },
+];
+
+interface EmojiPickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (emoji: string) => void;
+  onRemove?: () => void;
+  hasIcon: boolean;
+  children: React.ReactElement;
+}
+
+export function EmojiPicker({
+  open,
+  onOpenChange,
+  onSelect,
+  onRemove,
+  hasIcon,
+  children,
+}: EmojiPickerProps) {
+  const [filter, setFilter] = useState("");
+  const referenceRef = useRef<HTMLDivElement>(null);
+  const floatingRef = useRef<HTMLDivElement>(null);
+  const filterInputRef = useRef<HTMLInputElement>(null);
+
+  // Position the floating element
+  useEffect(() => {
+    if (!open) return;
+
+    const reference = referenceRef.current;
+    const floating = floatingRef.current;
+    if (!reference || !floating) return;
+
+    const cleanup = autoUpdate(reference, floating, () => {
+      computePosition(reference, floating, {
+        placement: "bottom-start",
+        middleware: [offset(4), flip(), shift({ padding: 8 })],
+      }).then(({ x, y }) => {
+        Object.assign(floating.style, {
+          left: `${x}px`,
+          top: `${y}px`,
+        });
+      }).catch(() => {
+        // Position computation can fail if elements are removed during update
+      });
+    });
+
+    return cleanup;
+  }, [open]);
+
+  // Focus filter input when opened
+  useEffect(() => {
+    if (!open) return;
+    const timer = setTimeout(() => filterInputRef.current?.focus(), 50);
+    return () => clearTimeout(timer);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onOpenChange(false);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onOpenChange]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!open) return;
+
+    function handleMouseDown(e: MouseEvent) {
+      const target = e.target;
+      if (!(target instanceof Node)) return;
+
+      const floating = floatingRef.current;
+      const reference = referenceRef.current;
+      if (
+        floating && !floating.contains(target) &&
+        reference && !reference.contains(target)
+      ) {
+        onOpenChange(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [open, onOpenChange]);
+
+  const handleSelect = useCallback(
+    (emoji: string) => {
+      onSelect(emoji);
+      onOpenChange(false);
+    },
+    [onSelect, onOpenChange]
+  );
+
+  const handleRemove = useCallback(() => {
+    onRemove?.();
+    onOpenChange(false);
+  }, [onRemove, onOpenChange]);
+
+  const handleToggle = useCallback(() => {
+    if (!open) {
+      setFilter("");
+    }
+    onOpenChange(!open);
+  }, [open, onOpenChange]);
+
+  const filteredCategories = filter
+    ? EMOJI_CATEGORIES.map((cat) => ({
+        ...cat,
+        emojis: cat.emojis.filter(() =>
+          cat.label.toLowerCase().includes(filter.toLowerCase())
+        ),
+      })).filter((cat) => cat.emojis.length > 0)
+    : EMOJI_CATEGORIES;
+
+  return (
+    <>
+      <div ref={referenceRef} onClick={handleToggle}>
+        {children}
+      </div>
+      {open && (
+        <div
+          ref={floatingRef}
+          className="fixed z-50 w-72 rounded-sm border border-white/[0.06] bg-popover p-2 shadow-md"
+          role="dialog"
+          aria-label="Emoji picker"
+        >
+          <input
+            ref={filterInputRef}
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter..."
+            className="mb-2 w-full bg-muted px-2 py-1 text-sm text-foreground placeholder:text-muted-foreground outline-none"
+            aria-label="Filter emojis"
+          />
+          {hasIcon && onRemove && (
+            <button
+              onClick={handleRemove}
+              className="mb-2 w-full px-2 py-1 text-left text-xs text-muted-foreground hover:bg-white/[0.04]"
+            >
+              Remove icon
+            </button>
+          )}
+          <div className="max-h-60 overflow-y-auto">
+            {filteredCategories.map((category) => (
+              <div key={category.label}>
+                <div className="px-1 py-1 text-xs tracking-widest uppercase text-white/30">
+                  {category.label}
+                </div>
+                <div className="grid grid-cols-8 gap-0.5">
+                  {category.emojis.map((emoji) => (
+                    <button
+                      key={emoji}
+                      onClick={() => handleSelect(emoji)}
+                      className="flex h-8 w-8 items-center justify-center text-lg hover:bg-white/[0.04]"
+                      aria-label={`Select ${emoji}`}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { SmilePlus } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
+import { EmojiPicker } from "@/components/emoji-picker";
+
+interface PageIconProps {
+  pageId: string;
+  initialIcon: string | null;
+}
+
+export function PageIcon({ pageId, initialIcon }: PageIconProps) {
+  const [icon, setIcon] = useState<string | null>(initialIcon);
+  const [open, setOpen] = useState(false);
+
+  const saveIcon = useCallback(
+    async (value: string | null) => {
+      setIcon(value);
+      const supabase = createClient();
+      const { error } = await supabase
+        .from("pages")
+        .update({ icon: value })
+        .eq("id", pageId);
+
+      if (error) {
+        captureSupabaseError(error, "page.icon.save");
+        // Revert on failure
+        setIcon(initialIcon);
+      }
+    },
+    [pageId, initialIcon]
+  );
+
+  const handleSelect = useCallback(
+    (emoji: string) => {
+      saveIcon(emoji);
+    },
+    [saveIcon]
+  );
+
+  const handleRemove = useCallback(() => {
+    saveIcon(null);
+  }, [saveIcon]);
+
+  return (
+    <EmojiPicker
+      open={open}
+      onOpenChange={setOpen}
+      onSelect={handleSelect}
+      onRemove={handleRemove}
+      hasIcon={icon !== null}
+    >
+      <button
+        className="flex h-9 w-9 shrink-0 items-center justify-center text-muted-foreground hover:bg-white/[0.04]"
+        aria-label={icon ? `Page icon: ${icon}. Click to change` : "Add page icon"}
+      >
+        {icon ? (
+          <span className="text-2xl leading-none">{icon}</span>
+        ) : (
+          <SmilePlus className="h-5 w-5 opacity-0 group-hover/page-icon:opacity-100" />
+        )}
+      </button>
+    </EmojiPicker>
+  );
+}

--- a/src/components/page-view-client.tsx
+++ b/src/components/page-view-client.tsx
@@ -3,12 +3,14 @@
 import { useRef } from "react";
 import type { LexicalEditor, SerializedEditorState } from "lexical";
 import { PageTitle } from "@/components/page-title";
+import { PageIcon } from "@/components/page-icon";
 import { Editor } from "@/components/editor/editor";
 import { PageMenu } from "@/components/page-menu";
 
 interface PageViewClientProps {
   pageId: string;
   pageTitle: string;
+  pageIcon: string | null;
   initialContent: SerializedEditorState | null;
   workspaceId: string;
   workspaceSlug: string;
@@ -18,6 +20,7 @@ interface PageViewClientProps {
 export function PageViewClient({
   pageId,
   pageTitle,
+  pageIcon,
   initialContent,
   workspaceId,
   workspaceSlug,
@@ -27,7 +30,8 @@ export function PageViewClient({
 
   return (
     <div className="mx-auto max-w-3xl p-6">
-      <div className="flex items-start gap-2">
+      <div className="group/page-icon flex items-start gap-2">
+        <PageIcon key={`icon-${pageId}`} pageId={pageId} initialIcon={pageIcon} />
         <div className="min-w-0 flex-1">
           <PageTitle key={pageId} pageId={pageId} initialTitle={pageTitle} />
         </div>


### PR DESCRIPTION
Closes #174

## What

Adds a page icon emoji picker that lets users set, change, or remove an emoji icon for any page. The icon appears next to the page title and in the sidebar page tree.

## How

- **`EmojiPicker`** (`src/components/emoji-picker.tsx`) — Reusable floating emoji grid with 6 categories (96 emojis), category-based filtering, keyboard dismiss (Escape), and click-outside dismiss. Positioned with `@floating-ui/react` `computePosition` + `autoUpdate` (same pattern as the existing floating toolbar and link editor).
- **`PageIcon`** (`src/components/page-icon.tsx`) — Wraps `EmojiPicker` with Supabase persistence. Optimistically updates the icon state, reverts on error. Shows a `SmilePlus` placeholder on hover when no icon is set.
- **`PageViewClient`** — Updated to render `PageIcon` next to `PageTitle`, passing the `pageIcon` prop from the server page data.
- **Server page** — Passes `page.icon` through to `PageViewClient`.
- The sidebar page tree already renders `page.icon` when present (no changes needed).

## Testing

- 4 new Playwright E2E tests covering: set icon, remove icon, Escape to close, category filtering
- All 206 unit tests pass
- All 47 E2E tests pass (including the 4 new ones)
- `pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e` all green