### PR TITLE
fix: unify search debounce and workspace resolution into single effect (#181)

### DIFF
--- a/src/components/sidebar/page-search.test.tsx
+++ b/src/components/sidebar/page-search.test.tsx
@@ -364,14 +364,13 @@ describe("PageSearch", () => {
     await user.click(input);
     await user.type(input, "test query");
 
-    // Advance past debounce — search fires but workspaceId is null so it
-    // returns immediately with searchStatus="done"
+    // Advance time — the unified effect stays in "loading" because
+    // workspace hasn't resolved (no fetch fires).
     await act(async () => {
       await vi.advanceTimersByTimeAsync(350);
     });
 
-    // Even though search is done, workspace hasn't resolved so skeletons
-    // should still show (not the empty state)
+    // Skeletons should show while workspace is resolving
     const searchResults = screen.getByRole("listbox");
     const skeletons = searchResults.querySelectorAll(".animate-pulse");
     expect(skeletons.length).toBeGreaterThan(0);
@@ -379,14 +378,21 @@ describe("PageSearch", () => {
       screen.queryByText("No pages match your search")
     ).not.toBeInTheDocument();
 
-    // Now resolve the workspace — the workspace-resolved effect
-    // re-triggers the search immediately (no debounce).
+    // No fetch should have been made (workspace not resolved)
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Resolve workspace — let the promise settle and React re-render.
     await act(async () => {
       resolveWorkspace!({
         data: { id: "ws-uuid-123" },
         error: null,
       });
       await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // Advance past the 300ms debounce so the search fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
     });
 
     // Now the empty state should show
@@ -397,10 +403,8 @@ describe("PageSearch", () => {
 
   it("shows empty state when workspace resolves to null (workspace not found)", async () => {
     // Regression test for #162: when workspaceId is null and
-    // workspaceResolved is true, the old code left `searched=false`
-    // in the early return path, causing neither skeletons nor empty
-    // state to render. The new searchStatus="done" transition in the
-    // early return path fixes this.
+    // workspaceResolved is true, the unified effect transitions
+    // directly to "done" without firing a fetch.
     mockMaybeSingle.mockResolvedValue({
       data: null,
       error: null,
@@ -421,10 +425,10 @@ describe("PageSearch", () => {
     await user.click(input);
     await user.type(input, "zzzyyyxxxnonexistent999");
 
-    // Advance past debounce — search fires, workspaceId is null,
-    // early return sets searchStatus="done"
+    // The unified effect sees workspaceResolved=true but workspaceId=null,
+    // so it transitions directly to "done" (no debounce, no fetch).
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(350);
+      await vi.advanceTimersByTimeAsync(50);
     });
 
     // The empty state should show (not stuck in a blank dropdown)
@@ -507,13 +511,10 @@ describe("PageSearch", () => {
   });
 
   it("shows empty state when workspace resolves after debounce fires (#178)", async () => {
-    // Regression test for #178: when workspace resolution is slow and
-    // completes after the debounce timer fires, the old code re-ran the
-    // debounce effect (because the search callback changed identity),
-    // creating a cascade of loading→done→loading transitions that could
-    // leave searchStatus stuck at "loading". The fix decouples the search
-    // callback from workspaceId by using a ref, and adds a dedicated
-    // effect to re-trigger search when the workspace resolves.
+    // Regression test for #178/#181: when workspace resolution is slow,
+    // the unified effect stays in "loading" until the workspace resolves.
+    // Once resolved, the effect re-runs, debounces, and fires the search.
+    // This eliminates the two-effect race condition that caused #178/#181.
 
     // Make workspace resolution slow
     let resolveWorkspace: (value: unknown) => void;
@@ -533,24 +534,32 @@ describe("PageSearch", () => {
     await user.click(input);
     await user.type(input, "zzzyyyxxxnonexistent999");
 
-    // Advance past debounce — search fires but workspaceId is null
+    // Advance time — the unified effect stays in "loading" because
+    // workspace hasn't resolved (no fetch fires).
     await act(async () => {
       await vi.advanceTimersByTimeAsync(350);
     });
 
-    // Skeletons should show (workspace not resolved)
+    // Skeletons should show (workspace not resolved, status is "loading")
     const searchResults = screen.getByRole("listbox");
     expect(searchResults.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
     expect(screen.queryByText("No pages match your search")).not.toBeInTheDocument();
 
-    // Resolve workspace — the workspace-resolved effect fires a new
-    // search immediately (no 300ms debounce delay).
+    // No fetch yet
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Resolve workspace — let the promise settle and React re-render.
     await act(async () => {
       resolveWorkspace!({
         data: { id: "ws-uuid-123" },
         error: null,
       });
       await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // Advance past the 300ms debounce so the search fires.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
     });
 
     // The fetch should have been called with the workspace ID
@@ -567,9 +576,9 @@ describe("PageSearch", () => {
   });
 
   it("shows empty state when workspace resolution rejects (#178)", async () => {
-    // Regression test for #178: the old code had no .catch() on the
-    // workspace resolution promise. If retryOnNetworkError rejected,
-    // workspaceResolved stayed false forever, causing infinite skeletons.
+    // Regression test for #178: if retryOnNetworkError rejects,
+    // workspaceResolved is set to true (from .catch()) and workspaceId
+    // stays null. The unified effect transitions directly to "done".
     const captureException = vi.mocked(
       (await import("@sentry/nextjs")).captureException
     );
@@ -593,9 +602,10 @@ describe("PageSearch", () => {
     await user.click(input);
     await user.type(input, "zzzyyyxxxnonexistent999");
 
-    // Advance past debounce
+    // The unified effect sees workspaceResolved=true but workspaceId=null,
+    // so it transitions directly to "done" (no debounce, no fetch).
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(350);
+      await vi.advanceTimersByTimeAsync(50);
     });
 
     // The error should have been captured in Sentry
@@ -603,8 +613,7 @@ describe("PageSearch", () => {
       expect.objectContaining({ message: "Unexpected Supabase error" })
     );
 
-    // Empty state should show (workspaceResolved=true from .catch(),
-    // workspaceId=null, so search early-returns with done status)
+    // Empty state should show (workspaceResolved=true, workspaceId=null)
     expect(
       screen.getByText("No pages match your search")
     ).toBeInTheDocument();
@@ -612,5 +621,61 @@ describe("PageSearch", () => {
     // No skeletons
     const searchResults = screen.getByRole("listbox");
     expect(searchResults.querySelectorAll(".animate-pulse").length).toBe(0);
+  });
+
+  it("never leaves skeletons stuck when workspace resolves mid-debounce (#181)", async () => {
+    // Regression test for #181: the two-effect architecture (debounce +
+    // re-trigger) could leave searchStatus stuck at "loading" when the
+    // workspace resolved at specific timings. The unified effect approach
+    // eliminates this by handling workspace resolution as a dependency
+    // change that naturally re-runs the effect.
+
+    // Make workspace resolution resolve after 150ms (mid-debounce)
+    mockMaybeSingle.mockReturnValue(
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({ data: { id: "ws-uuid-123" }, error: null });
+        }, 150);
+      })
+    );
+
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+
+    render(<PageSearch />);
+
+    const input = screen.getByRole("combobox", { name: /search pages/i });
+    await user.click(input);
+    await user.type(input, "zzzyyyxxxnonexistent999");
+
+    // At this point: query is set, workspace is resolving, effect is
+    // in "loading" state waiting for workspace.
+
+    // Advance 150ms — workspace resolves mid-debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    // Skeletons should still show (debounce hasn't fired yet)
+    const searchResults = screen.getByRole("listbox");
+    expect(searchResults.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+
+    // Advance past the 300ms debounce
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    // Empty state should show — skeletons must NOT be stuck
+    expect(
+      screen.getByText("No pages match your search")
+    ).toBeInTheDocument();
+    expect(searchResults.querySelectorAll(".animate-pulse").length).toBe(0);
+
+    // Fetch should have been called with the workspace ID
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("workspace_id=ws-uuid-123"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 });

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -23,7 +23,7 @@ interface SearchResult {
 /**
  * Search display status — a single discriminated value that eliminates
  * the class of race conditions where independent flags get out of sync
- * (the root cause of issues #118, #126, #136, #144, #162, #178).
+ * (the root cause of issues #118, #126, #136, #144, #162, #178, #181).
  *
  * - "idle"    — no query entered or query was cleared
  * - "loading" — a search is in-flight (show skeleton placeholders)
@@ -46,23 +46,10 @@ export function PageSearch() {
   const inputRef = useRef<HTMLInputElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  // Ref mirror of workspaceId so the search callback can read the
-  // latest value without being recreated when it changes. This
-  // decouples workspace resolution from the debounce effect and
-  // eliminates the cascade of effect re-runs that caused issues
-  // #118, #126, #136, #144, #162, #178.
-  const workspaceIdRef = useRef<string | null>(null);
-  // Ref mirror of query so the workspace-resolved effect can read
-  // the current query without adding it as a dependency.
-  const queryRef = useRef("");
   // Generation counter: incremented each search cycle so stale async
   // callbacks never update state. Immune to microtask ordering because
   // the counter is incremented synchronously before any async work.
   const searchGenRef = useRef(0);
-
-  // Keep refs in sync with state.
-  workspaceIdRef.current = workspaceId;
-  queryRef.current = query;
 
   // Register the search input ref so the sidebar context can focus it via ⌘+K
   useEffect(() => {
@@ -109,23 +96,14 @@ export function PageSearch() {
     };
   }, [params.workspaceSlug]);
 
-  // Stable search function — reads workspaceId from a ref so it never
-  // changes identity. The debounce effect depends only on `query`.
+  // Stable search function — accepts wsId as a parameter so the
+  // callback identity never changes.
   const search = useCallback(
-    async (q: string, gen: number, signal: AbortSignal) => {
-      const wsId = workspaceIdRef.current;
-      if (!q.trim() || !wsId) {
-        if (searchGenRef.current === gen) {
-          setResults([]);
-          setSearchStatus("done");
-        }
-        return;
-      }
-
+    async (q: string, wsId: string, gen: number, signal: AbortSignal) => {
       try {
         const response = await fetch(
           `/api/search?q=${encodeURIComponent(q.trim())}&workspace_id=${encodeURIComponent(wsId)}`,
-          { signal }
+          { signal },
         );
         if (searchGenRef.current !== gen) return;
         if (response.ok) {
@@ -150,12 +128,14 @@ export function PageSearch() {
         }
       }
     },
-    [] // stable — reads workspaceId from ref
+    [],
   );
 
-  // Debounced search — depends only on `query`. Decoupled from
-  // workspace resolution so the effect never re-runs when
-  // workspaceId changes.
+  // Unified debounced search effect. Depends on query, workspaceId,
+  // and workspaceResolved so it naturally re-runs when the workspace
+  // resolves — no separate re-trigger effect needed. This eliminates
+  // the class of race conditions caused by two effects competing over
+  // the same abort controller and generation counter (#178, #181).
   useEffect(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
@@ -174,13 +154,30 @@ export function PageSearch() {
     }
 
     const gen = ++searchGenRef.current;
+
+    // If workspace hasn't resolved yet, stay in loading state.
+    // When it resolves, this effect re-runs and fires the search.
+    if (!workspaceResolved) {
+      setSearchStatus("loading");
+      return;
+    }
+
+    // Workspace resolved but no workspace found — can't search.
+    // Transition directly to done (empty state).
+    if (!workspaceId) {
+      setResults([]);
+      setSearchStatus("done");
+      return;
+    }
+
     setSearchStatus("loading");
+
     const controller = new AbortController();
     abortRef.current = controller;
 
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
-      search(query, gen, controller.signal);
+      search(query, workspaceId, gen, controller.signal);
     }, 300);
 
     return () => {
@@ -190,38 +187,7 @@ export function PageSearch() {
       }
       controller.abort();
     };
-  }, [query, search]);
-
-  // When workspaceId resolves and there is an active query whose
-  // search returned early (because workspaceId was null), re-trigger
-  // the search immediately so the user sees real results.
-  useEffect(() => {
-    if (!workspaceId || !workspaceResolved) return;
-    const q = queryRef.current;
-    if (!q.trim()) return;
-    // Only re-search if a search cycle is active (not idle).
-    if (searchStatus === "idle") return;
-
-    // Cancel any in-flight request from the debounce effect.
-    if (abortRef.current) {
-      abortRef.current.abort();
-      abortRef.current = null;
-    }
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = null;
-    }
-
-    const gen = ++searchGenRef.current;
-    setSearchStatus("loading");
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    // Fire immediately — no debounce needed since the user already
-    // waited for the workspace to resolve.
-    search(q, gen, controller.signal);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId, workspaceResolved]);
+  }, [query, workspaceId, workspaceResolved, search]);
 
   // Close on click outside
   useEffect(() => {
@@ -325,22 +291,14 @@ export function PageSearch() {
 
   const showResults = open && query.trim().length > 0;
 
-  // Show skeletons when a search is in-flight, OR when the workspace
-  // hasn't resolved yet (so we can't search). The `searchStatus === "done"`
-  // check with `!workspaceResolved` handles the case where the search
-  // callback returned early because workspaceId was null — we still want
-  // skeletons until the workspace resolves and a real search can fire.
-  const showSkeleton =
-    results.length === 0 &&
-    (searchStatus === "loading" ||
-      (!workspaceResolved && searchStatus !== "idle"));
+  // Show skeletons while a search is in-flight (includes waiting for
+  // workspace resolution — the unified effect stays in "loading" until
+  // the workspace resolves and the search completes).
+  const showSkeleton = results.length === 0 && searchStatus === "loading";
 
-  // Show empty state only when the search completed AND the workspace
-  // is resolved (so we know the empty result is real, not just because
-  // we couldn't search yet).
+  // Show empty state when the search completed with no results.
   const showEmpty =
     searchStatus === "done" &&
-    workspaceResolved &&
     results.length === 0 &&
     query.trim().length > 0;
 


### PR DESCRIPTION
Closes #181

## What

The search empty state ("No pages match your search") never renders in production when searching for a nonsense string. Instead, skeleton loading placeholders display indefinitely. This is a regression from PR #179, which introduced a two-effect architecture (debounce effect + workspace-resolved re-trigger effect) that created timing-dependent race conditions between the two effects competing over the same abort controller and generation counter.

## How

Replaced the two-effect architecture with a single unified debounce effect that depends on `query`, `workspaceId`, and `workspaceResolved`. When the workspace hasn't resolved yet, the effect stays in "loading" state without firing a fetch. When the workspace resolves, React naturally re-runs the effect (dependency changed), which then debounces and fires the search. This eliminates the entire class of race conditions caused by two effects interacting.

Key changes:
- Removed `workspaceIdRef` and `queryRef` refs (no longer needed)
- Removed the separate workspace-resolved re-trigger effect
- The `search` callback now accepts `wsId` as a parameter instead of reading from a ref
- Simplified `showSkeleton` to just `searchStatus === "loading"` (the unified effect handles all transitions)
- Simplified `showEmpty` to not require `workspaceResolved` check (the effect handles this)
- When workspace resolves to null (not found), the effect transitions directly to "done"

## Testing

- Added regression test "never leaves skeletons stuck when workspace resolves mid-debounce (#181)" that verifies the exact timing scenario
- Updated 4 existing tests to match the new unified effect behavior
- All 207 unit tests pass
- All 5 search E2E tests pass (including "search with no matches shows empty state")
- `pnpm lint && pnpm typecheck && pnpm test` all pass