### PR TITLE
fix(editor): move page icon above title for proper alignment

### DIFF
--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -44,24 +44,44 @@ export function PageIcon({ pageId, initialIcon }: PageIconProps) {
     saveIcon(null);
   }, [saveIcon]);
 
+  if (icon) {
+    return (
+      <div className="mb-2">
+        <EmojiPicker
+          open={open}
+          onOpenChange={setOpen}
+          onSelect={handleSelect}
+          onRemove={handleRemove}
+          hasIcon
+        >
+          <button
+            className="flex h-10 w-10 items-center justify-center rounded-sm text-4xl leading-none hover:bg-white/[0.04]"
+            aria-label={`Page icon: ${icon}. Click to change`}
+          >
+            {icon}
+          </button>
+        </EmojiPicker>
+      </div>
+    );
+  }
+
   return (
-    <EmojiPicker
-      open={open}
-      onOpenChange={setOpen}
-      onSelect={handleSelect}
-      onRemove={handleRemove}
-      hasIcon={icon !== null}
-    >
-      <button
-        className="flex h-9 w-9 shrink-0 items-center justify-center text-muted-foreground hover:bg-white/[0.04]"
-        aria-label={icon ? `Page icon: ${icon}. Click to change` : "Add page icon"}
+    <div className="mb-1 opacity-0 group-hover/page-header:opacity-100 transition-opacity">
+      <EmojiPicker
+        open={open}
+        onOpenChange={setOpen}
+        onSelect={handleSelect}
+        onRemove={handleRemove}
+        hasIcon={false}
       >
-        {icon ? (
-          <span className="text-2xl leading-none">{icon}</span>
-        ) : (
-          <SmilePlus className="h-5 w-5 opacity-0 group-hover/page-icon:opacity-100" />
-        )}
-      </button>
-    </EmojiPicker>
+        <button
+          className="flex h-7 items-center gap-1 rounded-sm px-1.5 text-xs text-muted-foreground hover:bg-white/[0.04]"
+          aria-label="Add page icon"
+        >
+          <SmilePlus className="h-3.5 w-3.5" />
+          <span>Add icon</span>
+        </button>
+      </EmojiPicker>
+    </div>
   );
 }

--- a/src/components/page-view-client.tsx
+++ b/src/components/page-view-client.tsx
@@ -30,19 +30,21 @@ export function PageViewClient({
 
   return (
     <div className="mx-auto max-w-3xl p-6">
-      <div className="group/page-icon flex items-start gap-2">
+      <div className="group/page-header">
         <PageIcon key={`icon-${pageId}`} pageId={pageId} initialIcon={pageIcon} />
-        <div className="min-w-0 flex-1">
-          <PageTitle key={pageId} pageId={pageId} initialTitle={pageTitle} />
+        <div className="flex items-start gap-2">
+          <div className="min-w-0 flex-1">
+            <PageTitle key={pageId} pageId={pageId} initialTitle={pageTitle} />
+          </div>
+          <PageMenu
+            pageId={pageId}
+            pageTitle={pageTitle}
+            workspaceId={workspaceId}
+            workspaceSlug={workspaceSlug}
+            userId={userId}
+            editorRef={editorRef}
+          />
         </div>
-        <PageMenu
-          pageId={pageId}
-          pageTitle={pageTitle}
-          workspaceId={workspaceId}
-          workspaceSlug={workspaceSlug}
-          userId={userId}
-          editorRef={editorRef}
-        />
       </div>
       <div className="mt-4">
         <Editor


### PR DESCRIPTION
The emoji picker was rendered inline with the title, pushing it out of alignment with the editor content below.

**Changes:**
- Move the page icon to render as a block element above the title row instead of inline beside it
- When an icon is set: display it at a larger size (`text-4xl`) above the title, clickable to change/remove
- When no icon is set: show a small "Add icon" button (icon + label) that appears on hover

**Files changed:**
- `src/components/page-view-client.tsx` — restructured layout so `PageIcon` sits above the title+menu row
- `src/components/page-icon.tsx` — two render paths for icon-present vs no-icon states