### PR TITLE
fix(e2e): create fresh page in navigateToEditorPage to prevent parallel test interference (#187)

### DIFF
--- a/e2e/fixtures/editor-helpers.ts
+++ b/e2e/fixtures/editor-helpers.ts
@@ -2,42 +2,30 @@ import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 /**
- * Navigate to a page that has an editor. Waits for the sidebar page tree to
- * load, then clicks an existing page. If no pages exist, creates one via the
- * sidebar "New Page" button.
+ * Navigate to a page that has an editor. Always creates a fresh page via the
+ * sidebar "New Page" button so each test gets its own isolated page. This
+ * prevents parallel tests (e.g. the delete test) from interfering by deleting
+ * a shared page mid-test.
  *
  * Returns once `[contenteditable="true"]` is visible.
  */
 export async function navigateToEditorPage(page: Page): Promise<void> {
   const sidebar = page.getByRole("complementary");
 
-  // The page tree loads asynchronously: fetches workspace ID, then pages.
-  // While loading it shows skeleton pulse divs. Once loaded it renders either
-  // role="tree" with role="treeitem" children (pages exist) or "No pages yet".
-  // Wait for tree items to appear — this is the most reliable signal that
-  // the async data has loaded and the sidebar is interactive.
-  const treeItem = sidebar.locator('[role="treeitem"]').first();
-  try {
-    await expect(treeItem).toBeVisible({ timeout: 10_000 });
-  } catch {
-    // Tree loaded but has no pages, or workspace has no pages yet
-  }
+  // The page tree loads asynchronously: workspace ID lookup → page fetch.
+  // The "New Page" button silently no-ops if the workspace ID hasn't resolved
+  // yet, so we must wait for the tree to finish loading before clicking it.
+  // The tree renders either treeitem elements (pages exist) or "No pages yet"
+  // once loading completes. Wait for either signal.
+  const treeLoaded = sidebar
+    .locator('[role="treeitem"], :text("No pages yet")')
+    .first();
+  await expect(treeLoaded).toBeVisible({ timeout: 10_000 });
 
-  if ((await treeItem.count()) > 0) {
-    // The tree item row contains: grip icon, expand button, file icon, title button, action buttons.
-    // The title button has class "flex-1 truncate text-left" and triggers navigation.
-    // Use text-left as a more specific selector since it's unique to the title button.
-    const titleBtn = treeItem.locator("button.text-left");
-    if ((await titleBtn.count()) > 0) {
-      await titleBtn.click();
-    } else {
-      // Fallback: click the last button in the tree item (the title button)
-      await treeItem.locator("button").last().click();
-    }
-  } else {
-    // No pages exist — create one via the sidebar "New Page" button
-    await sidebar.getByRole("button", { name: /new page/i }).click();
-  }
+  // Create a fresh page so this test owns it and parallel tests cannot
+  // delete or modify it underneath us.
+  const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+  await newPageBtn.click();
 
   // Wait for the editor to appear (works for both hard and soft navigation)
   const editor = page.locator('[contenteditable="true"]');


### PR DESCRIPTION
Closes #187

## What

The `navigateToEditorPage` E2E helper navigated to the first existing page in the sidebar tree. When tests ran in parallel (`fullyParallel: true`), the page-crud delete test could delete that same page between the sidebar load and the server-side route query, causing a 404 in any test that happened to click the same tree item.

## How

Changed `navigateToEditorPage` to always create a fresh page via the sidebar "New Page" button instead of clicking an existing one. This gives each test its own isolated page that no parallel test can delete or modify. The helper still waits for the page tree to finish loading (workspace ID resolution) before clicking "New Page" to avoid the silent no-op when `workspaceId` is null.

## Testing

- Full E2E suite passes (47/47) with no page-icon test failures
- Ran the full suite multiple times to confirm the parallel interference is resolved
- `pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e` all pass