### PR TITLE
fix: wrap search E2E tests with toPass retry for read-replica lag (#199)

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -151,21 +151,28 @@ test.describe("Sidebar search", () => {
     await page.goto(`/${workspaceSlug}`);
     await waitForSidebarReady(page);
 
-    // Search for the page
+    // Search for the page. Use expect.toPass to retry the entire search
+    // flow — Supabase read-replicas may have a short replication lag after
+    // the title save, causing the first search attempt to return no results.
     const searchInput = page.getByRole("combobox", { name: /search pages/i });
     await expect(searchInput).toBeVisible({ timeout: 5_000 });
-    await searchInput.click();
-    await searchInput.fill(navUniqueWord);
 
-    // Wait for results
+    await expect(async () => {
+      await searchInput.click();
+      await searchInput.fill(navUniqueWord);
+
+      // Wait for debounce (300ms) + network response
+      const resultsList = page.locator("#search-results");
+      await expect(resultsList).toBeVisible({ timeout: 5_000 });
+
+      const resultOption = resultsList.locator('[role="option"]').first();
+      await expect(resultOption).toBeVisible({ timeout: 5_000 });
+      await expect(resultOption).toContainText("Navigate");
+    }).toPass({ timeout: 15_000, intervals: [2_000, 3_000, 5_000] });
+
+    // Click the result (outside toPass — we only need to retry the search)
     const resultsList = page.locator("#search-results");
-    await expect(resultsList).toBeVisible({ timeout: 5_000 });
-
     const resultOption = resultsList.locator('[role="option"]').first();
-    await expect(resultOption).toBeVisible({ timeout: 5_000 });
-    await expect(resultOption).toContainText("Navigate");
-
-    // Click the result
     await resultOption.click();
 
     // Should navigate to the page URL containing the page ID
@@ -216,20 +223,30 @@ test.describe("Sidebar search", () => {
     const scopeTitle = `Scoped ${scopeWord} Page`;
     await createPageWithTitle(page, scopeTitle);
 
-    // Search for the page — it should appear since it's in the current workspace
+    // Search for the page. Use expect.toPass to retry the entire search
+    // flow — Supabase read-replicas may lag after the title save.
     const searchInput = page.getByRole("combobox", { name: /search pages/i });
     await expect(searchInput).toBeVisible({ timeout: 5_000 });
-    await searchInput.click();
-    await searchInput.fill(scopeWord);
 
+    await expect(async () => {
+      await searchInput.click();
+      await searchInput.fill(scopeWord);
+
+      // Wait for debounce (300ms) + network response
+      const resultsList = page.locator("#search-results");
+      await expect(resultsList).toBeVisible({ timeout: 5_000 });
+
+      // Verify the search API was called with a workspace_id parameter
+      // by checking that results appear (the API requires workspace_id)
+      const resultOptions = resultsList.locator('[role="option"]');
+      await expect(resultOptions.first()).toBeVisible({ timeout: 5_000 });
+      await expect(resultOptions.first()).toContainText("Scoped");
+    }).toPass({ timeout: 15_000, intervals: [2_000, 3_000, 5_000] });
+
+    // Verify all results are scoped to the current workspace (outside toPass
+    // since the search results are now confirmed visible above).
     const resultsList = page.locator("#search-results");
-    await expect(resultsList).toBeVisible({ timeout: 5_000 });
-
-    // Verify the search API was called with a workspace_id parameter
-    // by checking that results appear (the API requires workspace_id)
     const resultOptions = resultsList.locator('[role="option"]');
-    await expect(resultOptions.first()).toBeVisible({ timeout: 5_000 });
-    await expect(resultOptions.first()).toContainText("Scoped");
 
     // The search component resolves workspace_id from the URL's workspaceSlug
     // and passes it to /api/search?workspace_id=. If workspace scoping were


### PR DESCRIPTION
Closes #199

## What

The "clicking a search result navigates to the correct page" E2E test intermittently timed out waiting for `[role="option"]` elements to appear in the search dropdown. The search feature itself works — the flake was caused by Supabase read-replica lag after a title save, where the first search query returns no results because the full-text search vector hasn't propagated yet.

## How

Wrapped the search-and-wait-for-results flow in `expect(...).toPass()` with retry intervals (`[2s, 3s, 5s]` over a 15s timeout), matching the pattern already used successfully in the "typing in search input shows matching results" test. Applied the same fix to the "search is scoped to the current workspace" test which had the same vulnerability.

## Testing

- All 5 search E2E tests pass consistently, including the previously flaky navigation test
- Full E2E suite: 46/47 passed (the 1 failure is a pre-existing flake in `members.spec.ts`, unrelated to search)
- `pnpm lint && pnpm typecheck && pnpm test` all pass (215 unit tests)