### PR TITLE
fix(editor): add Tab/Shift+Tab list indentation (#202)

### DIFF
--- a/e2e/editor-list-indent.spec.ts
+++ b/e2e/editor-list-indent.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "./fixtures/auth";
+import { navigateToEditorPage } from "./fixtures/editor-helpers";
+
+test.describe("Editor list indentation", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await navigateToEditorPage(page);
+  });
+
+  test("Tab indents a bullet list item into a nested list", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Create a bullet list with two items via slash command
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/");
+
+    const bulletOption = page
+      .locator('[role="option"]')
+      .filter({ hasText: "Bullet List" });
+    await expect(bulletOption).toBeVisible({ timeout: 3_000 });
+    await bulletOption.click();
+
+    await page.keyboard.type("First item");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Second item");
+
+    // Verify we start with a flat list (no nested <ul>)
+    await expect(editor.locator("ul ul")).not.toBeVisible();
+
+    // Press Tab to indent the second item
+    await page.keyboard.press("Tab");
+
+    // Lexical wraps the indented item in a nested <ul> inside a wrapper <li>
+    const nestedList = editor.locator("ul ul");
+    await expect(nestedList).toBeVisible();
+    await expect(nestedList.locator("> li")).toHaveCount(1);
+    await expect(nestedList.locator("> li")).toContainText("Second item");
+  });
+
+  test("Shift+Tab unindents a nested bullet list item", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Create a bullet list and indent the second item
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/");
+
+    const bulletOption = page
+      .locator('[role="option"]')
+      .filter({ hasText: "Bullet List" });
+    await expect(bulletOption).toBeVisible({ timeout: 3_000 });
+    await bulletOption.click();
+
+    await page.keyboard.type("First item");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Second item");
+    await page.keyboard.press("Tab");
+
+    // Verify it's nested
+    const nestedList = editor.locator("ul ul");
+    await expect(nestedList).toBeVisible();
+
+    // Now Shift+Tab to unindent
+    await page.keyboard.press("Shift+Tab");
+
+    // Should be back to a flat list with no nesting
+    await expect(nestedList).not.toBeVisible();
+  });
+
+  test("Tab indents a numbered list item into a nested list", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // Create a numbered list via slash command
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/");
+
+    const numberedOption = page
+      .locator('[role="option"]')
+      .filter({ hasText: "Numbered List" });
+    await expect(numberedOption).toBeVisible({ timeout: 3_000 });
+    await numberedOption.click();
+
+    await page.keyboard.type("First item");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Second item");
+
+    // Press Tab to indent
+    await page.keyboard.press("Tab");
+
+    // The second item should be nested inside the first
+    const nestedList = editor.locator("ol ol");
+    await expect(nestedList).toBeVisible();
+    await expect(nestedList.locator("> li")).toHaveCount(1);
+  });
+});

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -9,6 +9,7 @@ import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { CheckListPlugin } from "@lexical/react/LexicalCheckListPlugin";
+import { ListTabIndentationPlugin } from "@/components/editor/list-tab-indentation-plugin";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { ClickableLinkPlugin } from "@lexical/react/LexicalClickableLinkPlugin";
 import { HorizontalRulePlugin } from "@lexical/react/LexicalHorizontalRulePlugin";
@@ -194,6 +195,7 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
         <HistoryPlugin />
         <ListPlugin />
         <CheckListPlugin />
+        <ListTabIndentationPlugin />
         <LinkPlugin validateUrl={validateUrl} />
         <ClickableLinkPlugin />
         <HorizontalRulePlugin />

--- a/src/components/editor/list-tab-indentation-plugin.tsx
+++ b/src/components/editor/list-tab-indentation-plugin.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $isListItemNode } from "@lexical/list";
+import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils";
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_HIGH,
+  INDENT_CONTENT_COMMAND,
+  KEY_TAB_COMMAND,
+  OUTDENT_CONTENT_COMMAND,
+} from "lexical";
+
+const MAX_LIST_INDENT = 7;
+
+/**
+ * Handles Tab/Shift+Tab for list item indentation. Lexical's built-in
+ * TabIndentationPlugin only indents when the cursor is at block start
+ * or the node reports canIndent()=true. ListItemNode returns false for
+ * canIndent(), so Tab in the middle/end of a list item inserts a tab
+ * character instead of nesting. This plugin intercepts Tab at a higher
+ * priority and dispatches INDENT/OUTDENT commands when inside a list item.
+ */
+export function ListTabIndentationPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_TAB_COMMAND,
+      (event) => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return false;
+        }
+
+        const anchor = selection.anchor.getNode();
+        const block = $getNearestBlockElementAncestorOrThrow(anchor);
+
+        if (!$isListItemNode(block)) {
+          return false;
+        }
+
+        event.preventDefault();
+
+        editor.update(() => {
+          if (event.shiftKey) {
+            editor.dispatchCommand(OUTDENT_CONTENT_COMMAND, undefined);
+          } else {
+            if (block.getIndent() + 1 < MAX_LIST_INDENT) {
+              editor.dispatchCommand(INDENT_CONTENT_COMMAND, undefined);
+            }
+          }
+        });
+
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+  }, [editor]);
+
+  return null;
+}


### PR DESCRIPTION
Closes #202

## What
Pressing Tab inside a bullet or numbered list item did nothing — there was no way to create nested lists. Lexical's built-in `TabIndentationPlugin` doesn't work for list items because `ListItemNode.canIndent()` returns `false`, causing Tab to insert a tab character instead of indenting.

## How
Added a custom `ListTabIndentationPlugin` that intercepts `KEY_TAB_COMMAND` at high priority when the cursor is inside a `ListItemNode`. It dispatches `INDENT_CONTENT_COMMAND` (Tab) or `OUTDENT_CONTENT_COMMAND` (Shift+Tab) inside `editor.update()`, which Lexical's `RichTextPlugin` handler routes to `ListItemNode.setIndent()` to create/remove nested list levels. Max indent depth is capped at 7.

## Testing
Added 3 Playwright E2E tests in `e2e/editor-list-indent.spec.ts`:
- Tab indents a bullet list item into a nested list
- Shift+Tab unindents a nested bullet list item back to flat
- Tab indents a numbered list item into a nested list

All tests verify the DOM structure (nested `<ul>/<ol>` elements) after keyboard interaction.