### PR TITLE
fix: E2E member test flake from stale test data and unclosed dialog (#215)

### DIFF
--- a/e2e/fixtures/supabase-admin.ts
+++ b/e2e/fixtures/supabase-admin.ts
@@ -150,3 +150,34 @@ export async function cleanupInvitesForEmail(email: string): Promise<void> {
     .ilike("email", email)
     .is("accepted_at", null);
 }
+
+/**
+ * Removes stale test users that match a given display name.
+ * Used in beforeAll to clean up leftovers from previous test runs whose
+ * afterAll cleanup was interrupted (e.g. process killed, timeout).
+ * Skips the provided excludeUserId (the current test owner) to avoid
+ * accidentally deleting the primary test user.
+ */
+export async function cleanupStaleTestUsers(
+  displayName: string,
+  excludeUserId?: string
+): Promise<void> {
+  const admin = getAdminClient();
+
+  const query = admin
+    .from("profiles")
+    .select("id")
+    .eq("display_name", displayName);
+
+  const { data: staleProfiles } = excludeUserId
+    ? await query.neq("id", excludeUserId)
+    : await query;
+
+  if (!staleProfiles || staleProfiles.length === 0) return;
+
+  for (const profile of staleProfiles) {
+    await deleteTestUser(profile.id).catch((err) => {
+      console.warn(`Failed to clean up stale test user ${profile.id}: ${err}`);
+    });
+  }
+}

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -4,6 +4,7 @@ import {
   deleteTestUser,
   getInviteToken,
   cleanupInvitesForEmail,
+  cleanupStaleTestUsers,
 } from "./fixtures/supabase-admin";
 import { createClient } from "@supabase/supabase-js";
 import { type Browser, type Page } from "@playwright/test";
@@ -72,11 +73,21 @@ test.describe("Workspace member management", () => {
   let invitedUserId: string | undefined;
   let workspaceSlug: string;
 
+  // Remove stale test users from previous runs whose cleanup was interrupted.
+  // Without this, a leftover member with display_name "E2E Member" causes
+  // the re-invite test to find 2 matching elements (strict mode violation).
+  test.beforeAll(async () => {
+    await cleanupStaleTestUsers(INVITE_DISPLAY_NAME).catch(() => {});
+    await cleanupInvitesForEmail(INVITE_EMAIL).catch(() => {});
+  });
+
   test.afterAll(async () => {
     await cleanupInvitesForEmail(INVITE_EMAIL).catch(() => {});
     if (invitedUserId) {
       await deleteTestUser(invitedUserId).catch(() => {});
     }
+    // Fallback: clean up by display name in case invitedUserId was never set
+    await cleanupStaleTestUsers(INVITE_DISPLAY_NAME).catch(() => {});
   });
 
   test("owner can invite a user by email", async ({

--- a/src/components/members/member-list.tsx
+++ b/src/components/members/member-list.tsx
@@ -55,11 +55,18 @@ export function MemberList({
   onRemove,
 }: MemberListProps) {
   const [removingId, setRemovingId] = useState<string | null>(null);
+  // Track which member's remove dialog is open so we can close it after the
+  // async delete completes. AlertDialogAction is a plain Button in Base UI
+  // and does not auto-close the dialog.
+  const [openDialogMemberId, setOpenDialogMemberId] = useState<string | null>(
+    null
+  );
   const isAdmin = currentUserRole === "owner" || currentUserRole === "admin";
 
   async function handleRemove(memberId: string) {
     setRemovingId(memberId);
     await onRemove(memberId);
+    setOpenDialogMemberId(null);
     setRemovingId(null);
   }
 
@@ -130,7 +137,12 @@ export function MemberList({
               {isAdmin && (
                 <TableCell>
                   {canRemove(member) && (
-                    <AlertDialog>
+                    <AlertDialog
+                      open={openDialogMemberId === member.id}
+                      onOpenChange={(open) =>
+                        setOpenDialogMemberId(open ? member.id : null)
+                      }
+                    >
                       <AlertDialogTrigger
                         render={
                           <Button


### PR DESCRIPTION
Closes #215

## What

The E2E test "owner can re-invite and invited user can accept" fails with a strict mode violation because `locator('text=E2E Member')` resolves to 2 elements. The root cause is stale test data from previous runs whose `afterAll` cleanup was interrupted (process killed, timeout). A leftover user with display_name "E2E Member" remains as a member of the workspace, so the next run's newly invited user creates a second matching element.

A secondary flake in "owner can remove a member" was also fixed: the remove confirmation dialog did not close after clicking "Remove" because `AlertDialogAction` (Base UI) is a plain Button that does not auto-close the dialog.

## How

1. **Stale test data cleanup**: Added `cleanupStaleTestUsers()` helper that finds profiles by display name and deletes them via the existing `deleteTestUser` flow. Called in both `beforeAll` (defensive) and `afterAll` (fallback when `invitedUserId` is unset).

2. **Dialog close fix**: The `MemberList` component now controls the `AlertDialog` open state via `openDialogMemberId`. After the async `handleRemove` completes, the state is set to `null`, closing the dialog reliably regardless of `router.refresh()` timing.

## Testing

- All 54 E2E tests pass in the full parallel suite, including the previously flaky tests 38 and 45
- `pnpm lint && pnpm typecheck && pnpm test` all pass (226 unit tests)
- Member test file passes in isolation: `npx playwright test e2e/members.spec.ts` (7/7)