### PR TITLE
test: add E2E tests for responsive sidebar behavior (#226)

### DIFF
--- a/e2e/sidebar-responsive.spec.ts
+++ b/e2e/sidebar-responsive.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from "./fixtures/auth";
+
+const MOBILE_VIEWPORT = { width: 375, height: 667 };
+const DESKTOP_VIEWPORT = { width: 1280, height: 720 };
+
+test.describe("Responsive sidebar behavior", () => {
+  test("mobile: sidebar is hidden by default and opens as a Sheet overlay", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT);
+
+    // Wait for the app to settle after viewport change
+    await page.waitForTimeout(500);
+
+    // Desktop aside should not be visible at mobile viewport
+    const aside = page.locator("aside");
+    await expect(aside).toHaveCount(0);
+
+    // The Sheet content should not be visible initially
+    const sheetContent = page.locator('[data-slot="sheet-content"]');
+    await expect(sheetContent).toBeHidden();
+
+    // Mobile header with hamburger button should be visible
+    const toggleButton = page.getByRole("button", { name: "Toggle sidebar" });
+    await expect(toggleButton).toBeVisible({ timeout: 5_000 });
+
+    // Click the hamburger to open the Sheet sidebar
+    await toggleButton.click();
+
+    // Sheet overlay and content should now be visible
+    await expect(sheetContent).toBeVisible({ timeout: 5_000 });
+    expect(await sheetContent.getAttribute("data-side")).toBe("left");
+
+    // Verify the Sheet rendered with sidebar structure
+    const sidebarContent = sheetContent.locator("div").first();
+    await expect(sidebarContent).toBeVisible();
+  });
+
+  test("desktop: sidebar is visible as a persistent aside", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+
+    // Wait for the app to settle after viewport change
+    await page.waitForTimeout(500);
+
+    // Desktop aside should be visible
+    const aside = page.locator("aside");
+    await expect(aside).toBeVisible({ timeout: 5_000 });
+
+    // Aside should have non-zero width (open state = 240px)
+    const box = await aside.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThan(0);
+
+    // The mobile hamburger toggle should NOT be visible on desktop
+    const toggleButton = page.getByRole("button", { name: "Toggle sidebar" });
+    await expect(toggleButton).toBeHidden();
+
+    // Sheet overlay should not be present
+    const sheetContent = page.locator('[data-slot="sheet-content"]');
+    await expect(sheetContent).toBeHidden();
+  });
+
+  test("keyboard shortcut Ctrl+\\ toggles sidebar visibility on desktop", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.setViewportSize(DESKTOP_VIEWPORT);
+    await page.waitForTimeout(500);
+
+    // Sidebar should be open initially
+    const aside = page.locator("aside");
+    await expect(aside).toBeVisible({ timeout: 5_000 });
+
+    const initialBox = await aside.boundingBox();
+    expect(initialBox).not.toBeNull();
+    expect(initialBox!.width).toBeGreaterThan(0);
+
+    // Press Ctrl+\ to close the sidebar
+    await page.keyboard.press("Control+\\");
+
+    // Wait for the CSS transition (duration-200) to complete
+    await expect(async () => {
+      const box = await aside.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeLessThanOrEqual(1);
+    }).toPass({ timeout: 3_000 });
+
+    // Press Ctrl+\ again to reopen
+    await page.keyboard.press("Control+\\");
+
+    // Wait for the sidebar to expand back
+    await expect(async () => {
+      const box = await aside.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThan(100);
+    }).toPass({ timeout: 3_000 });
+  });
+});


### PR DESCRIPTION
Closes #226

## What

Adds Playwright E2E tests covering the responsive sidebar behavior: mobile Sheet overlay, desktop persistent aside, and `Ctrl+\` keyboard shortcut toggle.

## How

Three tests in `e2e/sidebar-responsive.spec.ts`:

1. **Mobile viewport (375×667)**: Verifies the sidebar is hidden by default (no `<aside>` element), the hamburger toggle button is visible, and clicking it opens a Sheet overlay (`data-slot="sheet-content"` with `data-side="left"`).

2. **Desktop viewport (1280×720)**: Verifies the sidebar renders as a persistent `<aside>` with non-zero width, the hamburger toggle is hidden, and no Sheet overlay is present.

3. **Keyboard shortcut**: Verifies `Ctrl+\` collapses the desktop sidebar (width → 0) and a second press reopens it (width > 100). Uses `expect.toPass()` to wait for the CSS transition to complete.

## Testing

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 252 tests pass
- `npx playwright test e2e/sidebar-responsive.spec.ts` — 3/3 pass