### PR TITLE
fix: update E2E invite test to match copyable link UI (#241)

### DIFF
--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -106,10 +106,10 @@ test.describe("Workspace member management", () => {
     // Submit the invite
     await page.getByRole("button", { name: "Invite", exact: true }).click();
 
-    // Wait for success message
-    await expect(page.locator("text=Invite sent.")).toBeVisible({
-      timeout: 10_000,
-    });
+    // Wait for the invite link to appear (PR #240 replaced "Invite sent." with a copyable link)
+    await expect(
+      page.getByRole("button", { name: "Copy invite link" })
+    ).toBeVisible({ timeout: 10_000 });
   });
 
   test("invited user appears in the pending invites list", async ({
@@ -156,9 +156,9 @@ test.describe("Workspace member management", () => {
     // Re-invite the same email
     await page.fill("#invite-email", INVITE_EMAIL);
     await page.getByRole("button", { name: "Invite", exact: true }).click();
-    await expect(page.locator("text=Invite sent.")).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(
+      page.getByRole("button", { name: "Copy invite link" })
+    ).toBeVisible({ timeout: 10_000 });
 
     // Create the test user via admin API so they can accept the invite
     const testUser = await createTestUser(


### PR DESCRIPTION
Closes #241

## What

PR #240 replaced the "Invite sent." success text in the invite form with an inline copyable invite link. The E2E test `members.spec.ts` still asserted on `text=Invite sent.`, causing the first test in the serial block to fail and blocking all 6 dependent tests.

## How

Updated both invite assertions (initial invite at line 110 and re-invite at line 159) to wait for the "Copy invite link" button instead of the removed "Invite sent." text. The button's `aria-label` is a stable locator that directly corresponds to the new success state in `invite-form.tsx`.

## Testing

- `pnpm lint` — ✅ pass
- `pnpm typecheck` — ✅ pass
- `pnpm test` — ✅ 252 tests pass
- E2E: the two updated assertions now match the actual DOM rendered by `invite-form.tsx` after a successful invite. CI will validate against production.