### PR TITLE
fix: optimistically add new invite to pending list (#243)

### DIFF
--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -119,10 +119,12 @@ test.describe("Workspace member management", () => {
 
     // The pending invites section should show the invited email
     const pendingSection = page.locator("text=Pending invites").first();
-    await expect(pendingSection).toBeVisible({ timeout: 5_000 });
+    await expect(pendingSection).toBeVisible({ timeout: 10_000 });
 
     // The invited email should appear in the pending invites table
-    await expect(page.locator(`text=${INVITE_EMAIL}`)).toBeVisible();
+    await expect(page.locator(`text=${INVITE_EMAIL}`)).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
   test("owner can revoke a pending invite", async ({

--- a/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
@@ -53,6 +53,13 @@ export default async function WorkspaceMembersPage({
   // Supabase join returns the relation as an opaque type; cast is unavoidable
   const members = (membersRaw ?? []) as unknown as MemberWithProfile[];
 
+  // Extract current user's display name for optimistic invite UI
+  const currentUserProfile = members.find((m) => m.user_id === user.id);
+  const currentUserDisplayName =
+    currentUserProfile?.profiles?.display_name ||
+    user.user_metadata?.display_name ||
+    "";
+
   // Fetch pending invites (only visible to admins/owners)
   const isAdmin = currentMember.role === "owner" || currentMember.role === "admin";
   let pendingInvites: WorkspaceInviteWithInviter[] = [];
@@ -82,6 +89,7 @@ export default async function WorkspaceMembersPage({
           pendingInvites={pendingInvites}
           currentUserId={user.id}
           currentUserRole={currentMember.role}
+          currentUserDisplayName={currentUserDisplayName}
         />
       </div>
     </div>

--- a/src/components/members/invite-form.test.ts
+++ b/src/components/members/invite-form.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Static analysis tests for invite-form.tsx to prevent regressions
+ * where the onInviteSent callback loses its invite data parameter.
+ *
+ * The bug (#243): InviteForm called onInviteSent() with no arguments after
+ * creating an invite. MembersPage used onInviteSent as () => router.refresh(),
+ * which is async and fire-and-forget. The pending invites list didn't update
+ * until the refresh completed (or on the next navigation). The fix passes the
+ * created invite back so MembersPage can optimistically add it to the list.
+ */
+
+const INVITE_FORM_PATH = join(__dirname, "invite-form.tsx");
+const MEMBERS_PAGE_PATH = join(__dirname, "members-page.tsx");
+
+describe("invite-form: onInviteSent passes invite data", () => {
+  const inviteFormSource = readFileSync(INVITE_FORM_PATH, "utf-8");
+  const membersPageSource = readFileSync(MEMBERS_PAGE_PATH, "utf-8");
+
+  it("InviteForm onInviteSent callback accepts WorkspaceInviteWithInviter", () => {
+    // The callback type must accept invite data, not be a void callback
+    expect(inviteFormSource).toContain(
+      "onInviteSent: (invite: WorkspaceInviteWithInviter) => void"
+    );
+  });
+
+  it("InviteForm insert uses .select().single() to return the created row", () => {
+    // The insert must chain .select().single() to get the created invite back
+    expect(inviteFormSource).toMatch(/\.insert\([\s\S]*?\)\s*\.select\(\)\s*\.single\(\)/);
+  });
+
+  it("InviteForm calls onInviteSent with invite data", () => {
+    // onInviteSent must be called with an object spread, not with no arguments
+    expect(inviteFormSource).toMatch(/onInviteSent\(\{/);
+    expect(inviteFormSource).not.toMatch(/onInviteSent\(\)\s*;/);
+  });
+
+  it("MembersPage optimistically adds new invite to local state", () => {
+    // The onInviteSent handler must call setInvites to add the new invite
+    expect(membersPageSource).toMatch(/setInvites\(/);
+    expect(membersPageSource).toContain("onInviteSent");
+  });
+});

--- a/src/components/members/invite-form.tsx
+++ b/src/components/members/invite-form.tsx
@@ -13,12 +13,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { InviteRole } from "@/lib/types";
+import type { InviteRole, WorkspaceInviteWithInviter } from "@/lib/types";
 
 interface InviteFormProps {
   workspaceId: string;
   currentUserId: string;
-  onInviteSent: () => void;
+  currentUserDisplayName: string;
+  onInviteSent: (invite: WorkspaceInviteWithInviter) => void;
   onError: (error: string) => void;
 }
 
@@ -27,6 +28,7 @@ const INVITE_EXPIRY_DAYS = 7;
 export function InviteForm({
   workspaceId,
   currentUserId,
+  currentUserDisplayName,
   onInviteSent,
   onError,
 }: InviteFormProps) {
@@ -116,7 +118,7 @@ export function InviteForm({
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + INVITE_EXPIRY_DAYS);
 
-    const { error: insertError } = await supabase
+    const { data: newInvite, error: insertError } = await supabase
       .from("workspace_invites")
       .insert({
         workspace_id: workspaceId,
@@ -125,10 +127,12 @@ export function InviteForm({
         invited_by: currentUserId,
         token,
         expires_at: expiresAt.toISOString(),
-      });
+      })
+      .select()
+      .single();
 
-    if (insertError) {
-      onError(insertError.message);
+    if (insertError || !newInvite) {
+      onError(insertError?.message ?? "Failed to create invite.");
       setSending(false);
       return;
     }
@@ -138,7 +142,10 @@ export function InviteForm({
     setInviteLink(link);
     setEmail("");
     setRole("member");
-    onInviteSent();
+    onInviteSent({
+      ...newInvite,
+      profiles: { display_name: currentUserDisplayName },
+    });
   }
 
   return (

--- a/src/components/members/members-page.tsx
+++ b/src/components/members/members-page.tsx
@@ -20,6 +20,7 @@ interface MembersPageProps {
   pendingInvites: WorkspaceInviteWithInviter[];
   currentUserId: string;
   currentUserRole: MemberRole;
+  currentUserDisplayName: string;
 }
 
 export function MembersPage({
@@ -28,6 +29,7 @@ export function MembersPage({
   pendingInvites: initialInvites,
   currentUserId,
   currentUserRole,
+  currentUserDisplayName,
 }: MembersPageProps) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
@@ -102,7 +104,11 @@ export function MembersPage({
           <InviteForm
             workspaceId={workspace.id}
             currentUserId={currentUserId}
-            onInviteSent={() => router.refresh()}
+            currentUserDisplayName={currentUserDisplayName}
+            onInviteSent={(newInvite) => {
+              setInvites((prev) => [newInvite, ...prev]);
+              router.refresh();
+            }}
             onError={setError}
           />
           <Separator className="bg-white/[0.06]" />


### PR DESCRIPTION
Closes #243

## What

After creating a workspace invite, the invited email did not appear in the pending invites list. The `InviteForm` called `onInviteSent()` with no arguments, which triggered `router.refresh()` — an async, fire-and-forget operation. The `MembersPage` component relied entirely on the server re-render completing and the `useEffect` sync pattern detecting the prop change to update the local `invites` state. This meant the pending invites section (conditionally rendered with `invites.length > 0`) could remain empty until the refresh completed or the user navigated away and back.

## How

Changed `InviteForm` to return the created invite row via `.select().single()` on the insert, then pass it back through the `onInviteSent` callback. `MembersPage` now optimistically prepends the new invite to the local `invites` state immediately — the same pattern already used for optimistic revoke. The background `router.refresh()` still runs to reconcile with the server, but the UI updates instantly.

Also increased the E2E test timeout for the pending invites assertions from 5s to 10s to match other assertions in the suite.

## Testing

- Added static analysis regression tests in `invite-form.test.ts` that verify:
  - `onInviteSent` callback accepts `WorkspaceInviteWithInviter` (not void)
  - Insert chains `.select().single()` to return the created row
  - `onInviteSent` is called with invite data (not empty)
  - `MembersPage` calls `setInvites` for optimistic update
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 256 tests pass ✅