### PR TITLE
feat: add custom not-found pages for workspace and page routes (#251)

### DIFF
--- a/src/app/(app)/not-found.tsx
+++ b/src/app/(app)/not-found.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function AppNotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center p-6">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <FileQuestion className="h-12 w-12 text-muted-foreground" />
+        <h2 className="text-lg font-medium">Page not found</h2>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          The workspace or page you&apos;re looking for doesn&apos;t exist or
+          you don&apos;t have access to it.
+        </p>
+        <Button render={<Link href="/" />}>Go home</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function RootNotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-foreground">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <FileQuestion className="h-12 w-12 text-muted-foreground" />
+        <h2 className="text-lg font-medium">Page not found</h2>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist.
+        </p>
+        <Button render={<Link href="/" />}>Go home</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #251

## What

Adds styled 404 pages that match the app's dark theme, replacing the default Next.js 404.

## How

Two `not-found.tsx` files at different levels of the route hierarchy:

- **`src/app/(app)/not-found.tsx`** — catches `notFound()` calls from `[workspaceSlug]/page.tsx` and `[pageId]/page.tsx`. Renders inside the AppShell (sidebar visible), with a "Go home" link that routes to `/` (which redirects authenticated users to their personal workspace).

- **`src/app/not-found.tsx`** — root-level catch-all for completely unmatched URLs. Renders inside the root layout (no sidebar), with the same "Go home" link.

Both follow the empty state pattern from `workspace-home.tsx`: centered layout with `FileQuestion` icon, heading, description, and CTA button. Server components only — no `"use client"`.

## Testing

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 256 tests pass
- No E2E tests needed (static server-rendered pages with no interactive behavior)