### PR TITLE
feat: add route-level error boundaries for app routes (#252)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/[pageId]/error.test.ts
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/error.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("[pageId] route error boundary", () => {
+  it("error.tsx exists for the page editor route segment", () => {
+    expect(existsSync(resolve(DIR, "error.tsx"))).toBe(true);
+  });
+
+  it("is a client component (required by Next.js error boundaries)", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toMatch(/^"use client"/);
+  });
+
+  it("uses the shared RouteError component", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("RouteError");
+  });
+
+  it("passes error and reset props through", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("error={error}");
+    expect(source).toContain("reset={reset}");
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/[pageId]/error.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/route-error";
+
+export default function PageError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <RouteError error={error} reset={reset} />;
+}

--- a/src/app/(app)/[workspaceSlug]/error.test.ts
+++ b/src/app/(app)/[workspaceSlug]/error.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("[workspaceSlug] route error boundary", () => {
+  it("error.tsx exists for the workspace route segment", () => {
+    expect(existsSync(resolve(DIR, "error.tsx"))).toBe(true);
+  });
+
+  it("is a client component (required by Next.js error boundaries)", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toMatch(/^"use client"/);
+  });
+
+  it("uses the shared RouteError component", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("RouteError");
+  });
+
+  it("passes error and reset props through", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("error={error}");
+    expect(source).toContain("reset={reset}");
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/error.tsx
+++ b/src/app/(app)/[workspaceSlug]/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/route-error";
+
+export default function WorkspaceError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <RouteError error={error} reset={reset} />;
+}

--- a/src/components/route-error.test.ts
+++ b/src/components/route-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const COMPONENT_PATH = resolve(__dirname, "route-error.tsx");
+
+describe("RouteError component", () => {
+  const source = readFileSync(COMPONENT_PATH, "utf-8");
+
+  it("is a client component", () => {
+    expect(source).toMatch(/^"use client"/);
+  });
+
+  it("reports errors to Sentry via captureException in useEffect", () => {
+    expect(source).toContain("Sentry.captureException(error)");
+    expect(source).toContain("useEffect");
+  });
+
+  it("renders a Try again button that calls reset()", () => {
+    expect(source).toContain("reset()");
+    expect(source).toContain("Try again");
+  });
+
+  it("uses design tokens: destructive icon, muted-foreground description", () => {
+    expect(source).toContain("text-destructive");
+    expect(source).toContain("text-muted-foreground");
+  });
+
+  it("follows empty state pattern: icon + heading + description + CTA", () => {
+    expect(source).toContain("Something went wrong");
+    expect(source).toContain("<Button");
+  });
+
+  it("uses named export (not default)", () => {
+    expect(source).toContain("export function RouteError");
+  });
+});

--- a/src/components/route-error.tsx
+++ b/src/components/route-error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { AlertCircle } from "lucide-react";
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export function RouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center p-6">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <AlertCircle className="h-12 w-12 text-destructive" />
+        <h2 className="text-lg font-medium">Something went wrong</h2>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          An unexpected error occurred. You can try again, and the rest of the
+          app should still work.
+        </p>
+        <Button onClick={() => reset()}>Try again</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #252

## What

Adds `error.tsx` files to the `[workspaceSlug]` and `[pageId]` route segments so that server component failures (e.g. Supabase down, RLS denial) are contained to the affected route instead of crashing the entire app to `global-error.tsx`.

## How

- **`src/components/route-error.tsx`** — shared client component that renders the error UI and reports to Sentry via `captureException` in a `useEffect`. Follows the same empty-state pattern as the existing `not-found.tsx` pages (icon + heading + description + CTA).
- **`src/app/(app)/[workspaceSlug]/error.tsx`** — workspace-level error boundary, delegates to `RouteError`.
- **`src/app/(app)/[workspaceSlug]/[pageId]/error.tsx`** — page editor error boundary, delegates to `RouteError`.

Because both `error.tsx` files are inside `[workspaceSlug]` (a child of `(app)/layout.tsx` which renders `AppShell`), the sidebar remains functional when an error boundary catches.

## Testing

- Static analysis tests for all three files (existence, client directive, Sentry integration, design tokens, prop forwarding)
- `pnpm lint && pnpm typecheck && pnpm test` — all 270 tests pass