### PR TITLE
fix: remove rounded corners from dialog component (#266)

### DIFF
--- a/src/components/ui/dialog-design-spec.test.ts
+++ b/src/components/ui/dialog-design-spec.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression tests for issue #266: dialog component uses rounded corners
+ * instead of sharp corners required by the design spec.
+ *
+ * Design spec (Corners section):
+ * "Everything else — buttons, inputs, cards, sidebar items, dialogs, sheets —
+ *  uses sharp corners."
+ *
+ * Only dropdown menus, popovers, toast notifications, and code blocks may use
+ * rounded-sm. Dialogs must have sharp corners (no border-radius).
+ */
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+describe("dialog design spec compliance", () => {
+  const source = readSource("./dialog.tsx");
+
+  it("DialogContent does not use rounded corners", () => {
+    // Extract the className string for DialogContent (data-slot="dialog-content")
+    const contentMatch = source.match(
+      /data-slot="dialog-content"[\s\S]*?className=\{cn\(\s*"([^"]+)"/
+    );
+    expect(contentMatch).not.toBeNull();
+    const classes = contentMatch![1];
+    expect(classes).not.toMatch(/rounded/);
+  });
+
+  it("DialogFooter does not use rounded corners", () => {
+    // Extract the className string for DialogFooter (data-slot="dialog-footer")
+    const footerMatch = source.match(
+      /data-slot="dialog-footer"[\s\S]*?className=\{cn\(\s*"([^"]+)"/
+    );
+    expect(footerMatch).not.toBeNull();
+    const classes = footerMatch![1];
+    expect(classes).not.toMatch(/rounded/);
+  });
+
+  it("DialogOverlay does not use rounded corners", () => {
+    const overlayMatch = source.match(
+      /data-slot="dialog-overlay"[\s\S]*?className=\{cn\(\s*"([^"]+)"/
+    );
+    expect(overlayMatch).not.toBeNull();
+    const classes = overlayMatch![1];
+    expect(classes).not.toMatch(/rounded/);
+  });
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -102,7 +102,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}


### PR DESCRIPTION
Closes #266

## What
The dialog component (`src/components/ui/dialog.tsx`) introduced in PR #265 used `rounded-xl` on `DialogContent` and `rounded-b-xl` on `DialogFooter`. The design spec explicitly requires sharp corners for dialogs — only dropdown menus, popovers, toast notifications, and code blocks may use `rounded-sm`.

## How
Removed `rounded-xl` from the `DialogContent` className and `rounded-b-xl` from the `DialogFooter` className. No other changes needed — the component now inherits the default sharp corners.

## Testing
Added a static analysis test (`src/components/ui/dialog-design-spec.test.ts`) that verifies `DialogContent`, `DialogFooter`, and `DialogOverlay` do not contain any `rounded` classes. This follows the same pattern as existing design spec compliance tests (e.g., `design-spec-compliance.test.ts`). All 310 tests pass.