### PR TITLE
chore: performance report 2026-W17

### DIFF
--- a/metrics/weekly/2026-W17-perf.md
+++ b/metrics/weekly/2026-W17-perf.md
@@ -1,0 +1,43 @@
+# Performance Report — Week 17
+
+## Health Endpoint
+
+- Status: ok
+- DB latency: 201ms
+- DB connected: yes
+
+## Error Trend
+
+- This week: 42 errors
+- Last week: 42 errors
+- Trend: → (flat)
+
+## Build Size
+
+Shared framework baseline: 362kB gzipped (rootMainFiles + common page chunks). This alone exceeds the 200kB threshold — all pages inherit this cost.
+
+| Page | First Load JS (gz) | Page-Specific (gz) | Status |
+|---|---|---|---|
+| / | 364kB | 2kB | ❌ |
+| /sign-in | 433kB | 71kB | ❌ |
+| /sign-up | 433kB | 71kB | ❌ |
+| /invite/[token] | 425kB | 63kB | ❌ |
+| /[workspace] | 474kB | 112kB | ❌ |
+| /[workspace]/[pageId] | 567kB | 205kB | ❌ |
+| /[workspace]/settings | 476kB | 114kB | ❌ |
+| /[workspace]/settings/members | 488kB | 126kB | ❌ |
+
+### Analysis
+
+The root page (`/`) loads only 2kB of page-specific JS, yet its first-load is 364kB because the shared framework bundle (`0ud5x5v-.y-uv.js`) alone is 165kB gzipped. This chunk contains React, Next.js runtime, and likely Sentry SDK.
+
+The heaviest page is `/[workspace]/[pageId]` at 567kB — the 205kB page-specific portion is the Lexical editor and its plugins.
+
+Note: Next.js 16 with Turbopack does not output per-page first-load sizes in the build summary. These figures were computed by summing gzipped sizes of rootMainFiles + page client-reference chunks.
+
+## Action Items
+
+- Investigate the 165kB shared framework chunk — determine if Sentry SDK or other dependencies can be lazy-loaded to reduce the baseline below 200kB.
+- Consider dynamic imports for the Lexical editor on `/[workspace]/[pageId]` to reduce its 205kB page-specific bundle.
+- All pages exceed the 200kB first-load threshold. This is a week-1 baseline — no regression, but bundle optimization should be prioritized.
+- Health endpoint and error trends are healthy. No immediate action needed on those fronts.


### PR DESCRIPTION
Weekly performance report for Week 17 (Apr 14–20, 2026).

## Summary

- **Health endpoint**: ✅ ok — DB latency 201ms, connected
- **Error trend**: → flat (42 errors both weeks)
- **Build size**: ❌ All pages exceed 200kB first-load JS threshold

The shared framework baseline is 362kB gzipped. The heaviest page (`/[workspace]/[pageId]`) is 567kB. Created #268 to track bundle optimization.

## Changes

- `metrics/weekly/2026-W17-perf.md` — full performance report