### PR TITLE
feat: reduce app-shell pages below 300kB first-load JS (#271)

### DIFF
--- a/src/components/auth/sign-out-button.tsx
+++ b/src/components/auth/sign-out-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { Button } from "@/components/ui/button";
 import { LogOut } from "lucide-react";
 
@@ -9,7 +9,7 @@ export function SignOutButton() {
   const router = useRouter();
 
   async function handleSignOut() {
-    const supabase = createClient();
+    const supabase = await getClient();
     await supabase.auth.signOut();
     router.push("/sign-in");
   }

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -44,7 +44,7 @@ import {
   CollapsibleContentNode,
 } from "@/components/editor/collapsible-node";
 import { CollapsiblePlugin } from "@/components/editor/collapsible-plugin";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 
 const SAVE_DEBOUNCE_MS = 500;
 
@@ -112,7 +112,7 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
       }
 
       saveTimerRef.current = setTimeout(async () => {
-        const supabase = createClient();
+        const supabase = await getClient();
         const { error } = await supabase
           .from("pages")
           .update({ content: json })

--- a/src/components/editor/image-crop-dialog.tsx
+++ b/src/components/editor/image-crop-dialog.tsx
@@ -3,7 +3,7 @@
 import type { JSX } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { lazyCaptureException } from "@/lib/capture";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   Dialog,
   DialogContent,

--- a/src/components/editor/image-plugin.tsx
+++ b/src/components/editor/image-plugin.tsx
@@ -13,9 +13,9 @@ import {
   type LexicalCommand,
 } from "lexical";
 import { lazyCaptureException } from "@/lib/capture";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { $createImageNode, type ImagePayload } from "@/components/editor/image-node";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
 
 export const INSERT_IMAGE_COMMAND: LexicalCommand<ImagePayload> =
@@ -43,7 +43,7 @@ export async function uploadImage(file: File): Promise<UploadResult> {
     return { url: null, error: "Image is too large. Maximum size is 5 MB." };
   }
 
-  const supabase = createClient();
+  const supabase = await getClient();
   const ext = file.name.split(".").pop() ?? "png";
   const fileName = `${crypto.randomUUID()}.${ext}`;
   const filePath = `uploads/${fileName}`;

--- a/src/components/members/invite-accept.tsx
+++ b/src/components/members/invite-accept.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { Button } from "@/components/ui/button";
 
 interface InviteAcceptProps {
@@ -68,7 +68,7 @@ export function InviteAccept({
     setAccepting(true);
     setError(null);
 
-    const supabase = createClient();
+    const supabase = await getClient();
 
     // Use the security definer RPC which atomically marks the invite as
     // accepted and inserts the member with the correct role from the invite.

--- a/src/components/members/invite-form.tsx
+++ b/src/components/members/invite-form.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, Copy, Send } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -68,7 +68,7 @@ export function InviteForm({
 
     setSending(true);
 
-    const supabase = createClient();
+    const supabase = await getClient();
 
     // Check if user is already a member.
     // Disambiguate: members has two FKs to profiles (user_id, invited_by).

--- a/src/components/members/members-page.tsx
+++ b/src/components/members/members-page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { Separator } from "@/components/ui/separator";
 import { MemberList } from "@/components/members/member-list";
 import { InviteForm } from "@/components/members/invite-form";
@@ -43,7 +43,7 @@ export function MembersPage({
 
   async function handleRoleChange(memberId: string, newRole: MemberRole) {
     setError(null);
-    const supabase = createClient();
+    const supabase = await getClient();
 
     const { error: updateError } = await supabase
       .from("members")
@@ -60,7 +60,7 @@ export function MembersPage({
 
   async function handleRemoveMember(memberId: string) {
     setError(null);
-    const supabase = createClient();
+    const supabase = await getClient();
 
     const { error: deleteError } = await supabase
       .from("members")
@@ -77,7 +77,7 @@ export function MembersPage({
 
   async function handleRevokeInvite(inviteId: string) {
     setError(null);
-    const supabase = createClient();
+    const supabase = await getClient();
 
     // Optimistically remove the invite so the UI updates immediately
     setInvites((prev) => prev.filter((i) => i.id !== inviteId));

--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { SmilePlus } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
 import { EmojiPicker } from "@/components/emoji-picker";
 
@@ -18,7 +18,7 @@ export function PageIcon({ pageId, initialIcon }: PageIconProps) {
   const saveIcon = useCallback(
     async (value: string | null) => {
       setIcon(value);
-      const supabase = createClient();
+      const supabase = await getClient();
       const { error } = await supabase
         .from("pages")
         .update({ icon: value })

--- a/src/components/page-menu.tsx
+++ b/src/components/page-menu.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Download, MoreHorizontal, Upload } from "lucide-react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import type { LexicalEditor } from "lexical";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,7 +19,7 @@ import {
   parseMarkdownToEditorState,
 } from "@/components/editor/markdown-utils";
 import { lazyCaptureException } from "@/lib/capture";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
 
 interface PageMenuProps {
@@ -88,7 +88,7 @@ export function PageMenu({
         // Derive page title from filename (strip extension)
         const importedTitle = file.name.replace(/\.(md|markdown)$/, "");
 
-        const supabase = createClient();
+        const supabase = await getClient();
 
         // Count existing pages to determine position
         const { count } = await supabase

--- a/src/components/page-title.tsx
+++ b/src/components/page-title.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
 
 interface PageTitleProps {
@@ -30,7 +30,7 @@ export function PageTitle({ pageId, initialTitle }: PageTitleProps) {
       const trimmed = value.trim();
       if (trimmed === lastSavedRef.current) return;
 
-      const supabase = createClient();
+      const supabase = await getClient();
       const { error } = await supabase
         .from("pages")
         .update({ title: trimmed })

--- a/src/components/page-view-client.tsx
+++ b/src/components/page-view-client.tsx
@@ -1,11 +1,32 @@
 "use client";
 
 import { useRef } from "react";
+import dynamic from "next/dynamic";
 import type { LexicalEditor, SerializedEditorState } from "lexical";
 import { PageTitle } from "@/components/page-title";
 import { PageIcon } from "@/components/page-icon";
-import { Editor } from "@/components/editor/editor";
-import { PageMenu } from "@/components/page-menu";
+
+const Editor = dynamic(
+  () => import("@/components/editor/editor").then((mod) => mod.Editor),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-3">
+        <div className="h-4 w-full animate-pulse bg-muted" />
+        <div className="h-4 w-5/6 animate-pulse bg-muted" />
+        <div className="h-4 w-4/6 animate-pulse bg-muted" />
+      </div>
+    ),
+  },
+);
+
+const PageMenu = dynamic(
+  () => import("@/components/page-menu").then((mod) => mod.PageMenu),
+  {
+    ssr: false,
+    loading: () => <div className="h-8 w-8" />,
+  },
+);
 
 interface PageViewClientProps {
   pageId: string;

--- a/src/components/sidebar/create-workspace-dialog.tsx
+++ b/src/components/sidebar/create-workspace-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { generateSlug, WORKSPACE_LIMIT } from "@/lib/workspace";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -43,7 +43,7 @@ export function CreateWorkspaceDialog({
     setError(null);
     setLoading(true);
 
-    const supabase = createClient();
+    const supabase = await getClient();
     const slug = generateSlug(name.trim());
 
     const { data: workspace, error: createError } = await supabase

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { FileText, Search, X } from "lucide-react";
 import { lazyCaptureException } from "@/lib/capture";
 import { Input } from "@/components/ui/input";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import { useSidebar } from "@/components/sidebar/sidebar-context";
@@ -70,8 +70,8 @@ export function PageSearch() {
     setWorkspaceResolved(false);
     let cancelled = false;
 
-    retryOnNetworkError(() => {
-      const supabase = createClient();
+    retryOnNetworkError(async () => {
+      const supabase = await getClient();
       return supabase
         .from("workspaces")
         .select("id")

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -10,8 +10,8 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
-import { toast } from "sonner";
-import { createClient } from "@/lib/supabase/client";
+import { toast } from "@/lib/toast";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import { Button } from "@/components/ui/button";
@@ -72,8 +72,8 @@ export function PageTree({ userId }: PageTreeProps) {
 
     let cancelled = false;
 
-    retryOnNetworkError(() => {
-      const supabase = createClient();
+    retryOnNetworkError(async () => {
+      const supabase = await getClient();
       return supabase
         .from("workspaces")
         .select("id")
@@ -99,8 +99,8 @@ export function PageTree({ userId }: PageTreeProps) {
     let cancelled = false;
 
     async function fetchPages() {
-      const { data, error } = await retryOnNetworkError(() => {
-        const supabase = createClient();
+      const { data, error } = await retryOnNetworkError(async () => {
+        const supabase = await getClient();
         return supabase
           .from("pages")
           .select("*")
@@ -148,7 +148,7 @@ export function PageTree({ userId }: PageTreeProps) {
 
       const nextPosition = getNextSiblingPosition(pages, parentId);
 
-      const supabase = createClient();
+      const supabase = await getClient();
       const { data: newPage, error } = await supabase
         .from("pages")
         .insert({
@@ -195,7 +195,7 @@ export function PageTree({ userId }: PageTreeProps) {
     if (!deleteTarget) return;
     setDeleting(true);
 
-    const supabase = createClient();
+    const supabase = await getClient();
     const { error } = await supabase
       .from("pages")
       .delete()
@@ -235,7 +235,7 @@ export function PageTree({ userId }: PageTreeProps) {
   async function applySwap(
     updates: Array<{ id: string; position: number }>,
   ) {
-    const supabase = createClient();
+    const supabase = await getClient();
 
     setPages((prev) =>
       prev.map((p) => {
@@ -264,7 +264,7 @@ export function PageTree({ userId }: PageTreeProps) {
     if (!result) return;
 
     const { parentId, position } = result;
-    const supabase = createClient();
+    const supabase = await getClient();
 
     setPages((prev) =>
       prev.map((p) =>
@@ -292,7 +292,7 @@ export function PageTree({ userId }: PageTreeProps) {
     if (!result) return;
 
     const { pageUpdate, shiftUpdates } = result;
-    const supabase = createClient();
+    const supabase = await getClient();
 
     setPages((prev) =>
       prev.map((p) => {
@@ -383,7 +383,7 @@ export function PageTree({ userId }: PageTreeProps) {
       return;
     }
 
-    const supabase = createClient();
+    const supabase = await getClient();
 
     // Optimistic UI update
     setPages((prev) => {

--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from "next/navigation";
 import { LogOut, Settings, User, Users } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -22,7 +22,7 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
   const params = useParams<{ workspaceSlug?: string }>();
 
   async function handleSignOut() {
-    const supabase = createClient();
+    const supabase = await getClient();
     await supabase.auth.signOut();
     router.push("/sign-in");
   }

--- a/src/components/sidebar/workspace-switcher.tsx
+++ b/src/components/sidebar/workspace-switcher.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ChevronsUpDown, Plus, Check } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -28,9 +28,8 @@ export function WorkspaceSwitcher({ userId }: WorkspaceSwitcherProps) {
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   useEffect(() => {
-    const supabase = createClient();
-
     async function fetchWorkspaces() {
+      const supabase = await getClient();
       const { data: memberships } = await supabase
         .from("members")
         .select("workspace_id, workspaces(*)")

--- a/src/components/toast-error-duration.test.ts
+++ b/src/components/toast-error-duration.test.ts
@@ -27,7 +27,10 @@ function collectFiles(dir: string, ext: string[]): string[] {
 describe("toast.error() duration matches design spec", () => {
   const srcDir = join(__dirname, "..");
   const files = collectFiles(srcDir, [".ts", ".tsx"]).filter(
-    (f) => !f.endsWith(".test.ts") && !f.endsWith(".test.tsx")
+    (f) =>
+      !f.endsWith(".test.ts") &&
+      !f.endsWith(".test.tsx") &&
+      !f.endsWith("lib/toast.ts") // lazy wrapper — forwards caller's data as-is
   );
 
   it("every toast.error() call includes { duration: 8000 }", () => {

--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { FileText, Plus } from "lucide-react";
-import { toast } from "sonner";
-import { createClient } from "@/lib/supabase/client";
+import { toast } from "@/lib/toast";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 import { RelativeTime } from "@/components/relative-time";
@@ -27,7 +27,7 @@ export function WorkspaceHome({
   const router = useRouter();
 
   async function handleCreatePage() {
-    const supabase = createClient();
+    const supabase = await getClient();
     const { data: newPage, error } = await supabase
       .from("pages")
       .insert({

--- a/src/components/workspace-settings-form.tsx
+++ b/src/components/workspace-settings-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
-import { createClient } from "@/lib/supabase/client";
+import { getClient } from "@/lib/supabase/lazy-client";
 import { isValidSlug } from "@/lib/workspace";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -60,7 +60,7 @@ export function WorkspaceSettingsForm({
 
     setSaving(true);
 
-    const supabase = createClient();
+    const supabase = await getClient();
     const slugChanged = slug !== workspace.slug;
 
     const { error: updateError } = await supabase
@@ -91,7 +91,7 @@ export function WorkspaceSettingsForm({
 
   async function handleDelete() {
     setDeleting(true);
-    const supabase = createClient();
+    const supabase = await getClient();
 
     const { error: deleteError } = await supabase
       .from("workspaces")

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,9 +1,24 @@
 import type { ErrorEvent } from "@sentry/nextjs";
-import { PostgrestError } from "@supabase/supabase-js";
 import { lazyCaptureException } from "@/lib/capture";
 
 // Re-export so existing imports keep working
 export { lazyCaptureException } from "@/lib/capture";
+
+/**
+ * Duck-type check for Supabase PostgrestError. Avoids importing the class
+ * from `@supabase/supabase-js` which would pull the entire SDK (~59 kB)
+ * into every page bundle.
+ */
+function isPostgrestError(
+  error: unknown,
+): error is { message: string; code: string; details: string; hint: string } {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    "details" in error &&
+    "hint" in error
+  );
+}
 
 /**
  * Error messages from Next.js internals that are caused by clients sending
@@ -35,10 +50,9 @@ export function isNextjsInternalNoise(event: ErrorEvent): boolean {
  * timeout, connection reset). These are not application bugs and should be
  * reported at warning level so they don't trigger error-level alerts.
  */
-export function isTransientNetworkError(error: PostgrestError | Error): boolean {
+export function isTransientNetworkError(error: Error): boolean {
   const msg = error.message;
-  const details =
-    error instanceof PostgrestError ? error.details : "";
+  const details = isPostgrestError(error) ? error.details : "";
 
   return (
     msg === "TypeError: Failed to fetch" ||
@@ -62,7 +76,7 @@ export function isTransientNetworkError(error: PostgrestError | Error): boolean 
  * `warning` level to reduce noise — they are not application bugs.
  */
 export function captureSupabaseError(
-  error: PostgrestError | Error,
+  error: Error,
   operation: string,
 ): void {
   const extra: Record<string, string> = {
@@ -70,7 +84,7 @@ export function captureSupabaseError(
     message: error.message,
   };
 
-  if (error instanceof PostgrestError) {
+  if (isPostgrestError(error)) {
     extra.code = error.code;
     extra.details = error.details;
     extra.hint = error.hint;

--- a/src/lib/supabase/lazy-client.ts
+++ b/src/lib/supabase/lazy-client.ts
@@ -1,0 +1,18 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+let clientPromise: Promise<() => SupabaseClient> | null = null;
+
+/**
+ * Lazily import and create a Supabase browser client. The full SDK
+ * (~59 kB gzipped) is loaded on first call instead of at module
+ * evaluation time, keeping it out of the initial page JS.
+ */
+export async function getClient(): Promise<SupabaseClient> {
+  if (!clientPromise) {
+    clientPromise = import("@/lib/supabase/client").then(
+      (mod) => mod.createClient,
+    );
+  }
+  const createClient = await clientPromise;
+  return createClient();
+}

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,29 @@
+interface ToastData {
+  description?: string;
+  duration?: number;
+}
+
+type ToastFn = (message: string, data?: ToastData) => void;
+
+/**
+ * Lazy wrapper around sonner's `toast`. The sonner module (~15 kB gzipped)
+ * is loaded on first invocation instead of at import time, keeping it out
+ * of the initial page JS. Safe because toast is only called from event
+ * handlers, never during render.
+ */
+export const toast: ToastFn & {
+  success: ToastFn;
+  error: ToastFn;
+} = Object.assign(
+  (message: string, data?: ToastData) => {
+    import("sonner").then((mod) => mod.toast(message, data));
+  },
+  {
+    success: (message: string, data?: ToastData) => {
+      import("sonner").then((mod) => mod.toast.success(message, data));
+    },
+    error: (message: string, data?: ToastData) => {
+      import("sonner").then((mod) => mod.toast.error(message, data));
+    },
+  },
+);


### PR DESCRIPTION
Closes #271

## What

All authenticated `(app)` pages now load under 300 kB gzipped first-load JS, down from 315–452 kB.

| Page | Before | After |
|---|---|---|
| `/[workspace]/[pageId]` | 452 kB | 234 kB |
| `/[workspace]/settings` | 316 kB | 257 kB |
| `/[workspace]/settings/members` | 356 kB | 299 kB |
| `/[workspace]` | 289 kB | 221 kB |

## How

Three independent optimizations, each targeting a different heavy dependency:

### 1. Lazy Supabase browser client (`src/lib/supabase/lazy-client.ts`)

The full `@supabase/supabase-js` SDK (~59 kB gzipped) was statically imported by every client component that calls `createClient()`. Since all call sites invoke it inside event handlers or `useEffect` callbacks (never during render), the import is deferred to first use via `import()`.

All 16 component files updated from `import { createClient }` → `import { getClient }` with `await`.

### 2. Duck-type PostgrestError in `sentry.ts`

`captureSupabaseError` imported `PostgrestError` from `@supabase/supabase-js` for an `instanceof` check, creating a second import path that pulled the full SDK into every page. Replaced with a duck-type check (`"code" in error && "details" in error && "hint" in error`) — same runtime behavior, zero bundle cost.

### 3. Lazy toast + SSR-false editor

- **`src/lib/toast.ts`**: Wraps sonner's `toast` in a lazy proxy that loads the module (~15 kB) on first invocation. The `Toaster` component was already dynamically imported in `providers.tsx`.
- **`src/components/page-view-client.tsx`**: The `Editor` and `PageMenu` components (which pull in Lexical ~95 kB, floating-ui ~38 kB, and markdown-utils) are now loaded with `next/dynamic` + `ssr: false`. This removes them from the page's client-reference manifest entirely.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 310/310 passed ✅
- `pnpm test:e2e` — requires running dev server + Supabase; not available in build environment
- Production build confirms all pages under 300 kB target ✅