### PR TITLE
fix: image crop applies but image disappears from editor (#279)

### DIFF
--- a/src/components/editor/floating-image-toolbar-plugin.tsx
+++ b/src/components/editor/floating-image-toolbar-plugin.tsx
@@ -164,7 +164,7 @@ export function FloatingImageToolbarPlugin({
         if ($isImageNode(node)) {
           node.setSrc(newSrc);
           // Reset dimensions so the image renders at its new natural size
-          node.setWidthAndHeight(0, 0);
+          node.setWidthAndHeight(undefined, undefined);
         }
       });
       setCropOpen(false);

--- a/src/components/editor/floating-image-toolbar.test.ts
+++ b/src/components/editor/floating-image-toolbar.test.ts
@@ -75,6 +75,15 @@ describe("Floating image toolbar — design spec", () => {
   });
 });
 
+describe("Floating image toolbar — crop dimension reset (#279)", () => {
+  it("resets dimensions with undefined, not 0, after crop", () => {
+    // Setting width/height to 0 makes the image invisible (0x0 pixels).
+    // The crop handler must pass undefined so the <img> renders at natural size.
+    expect(toolbarSource).toContain("setWidthAndHeight(undefined, undefined)");
+    expect(toolbarSource).not.toContain("setWidthAndHeight(0, 0)");
+  });
+});
+
 describe("Image expand dialog", () => {
   it("uses shadcn Dialog component", () => {
     expect(expandSource).toContain("@/components/ui/dialog");

--- a/src/components/editor/image-node.test.ts
+++ b/src/components/editor/image-node.test.ts
@@ -40,10 +40,31 @@ describe("ImageNode — alignment field", () => {
     expect(imageNodeSource).toContain("setSrc(src: string)");
   });
 
-  it("has setWidthAndHeight method for resize persistence", () => {
+  it("has setWidthAndHeight method that accepts undefined for dimension reset", () => {
     expect(imageNodeSource).toContain(
-      "setWidthAndHeight(width: number, height: number)"
+      "setWidthAndHeight("
     );
+    expect(imageNodeSource).toContain("width: number | undefined");
+    expect(imageNodeSource).toContain("height: number | undefined");
+  });
+});
+
+describe("ImageNode — crop dimension reset (#279)", () => {
+  it("setWidthAndHeight accepts undefined to reset to natural size", () => {
+    // Passing 0 instead of undefined causes the image to render at 0x0 (invisible)
+    expect(imageNodeSource).toContain("width: number | undefined");
+    expect(imageNodeSource).toContain("height: number | undefined");
+  });
+
+  it("does not set width/height to 0 in setWidthAndHeight", () => {
+    // The method body should assign the parameter directly, not coerce to 0
+    const methodMatch = imageNodeSource.match(
+      /setWidthAndHeight\([^)]+\)[^{]*\{([\s\S]*?)\n  \}/
+    );
+    expect(methodMatch).not.toBeNull();
+    const methodBody = methodMatch![1];
+    // Ensure the method doesn't hardcode 0
+    expect(methodBody).not.toMatch(/=\s*0/);
   });
 });
 

--- a/src/components/editor/image-node.tsx
+++ b/src/components/editor/image-node.tsx
@@ -427,7 +427,10 @@ export class ImageNode extends DecoratorNode<JSX.Element> {
     writable.__caption = caption;
   }
 
-  setWidthAndHeight(width: number, height: number): void {
+  setWidthAndHeight(
+    width: number | undefined,
+    height: number | undefined,
+  ): void {
     const writable = this.getWritable();
     writable.__width = width;
     writable.__height = height;


### PR DESCRIPTION
Closes #279

## What

After using the image crop feature and clicking "Apply Crop", the image disappeared from the editor. The crop dialog worked correctly (canvas drawing, region selection, upload), but the image became invisible after the node was updated.

## How

The root cause was in `handleCropComplete` which called `node.setWidthAndHeight(0, 0)` to reset dimensions after crop. The literal `0` values were stored on the node and passed as `width={0} height={0}` to the `<img>` element, rendering it at 0×0 pixels (invisible).

The fix:
1. Changed `ImageNode.setWidthAndHeight()` to accept `number | undefined` instead of just `number`
2. Changed the crop handler to pass `undefined` instead of `0`, so the `<img>` renders at its natural size (no width/height attributes)

## Testing

Added regression tests in both `image-node.test.ts` and `floating-image-toolbar.test.ts`:
- Verifies `setWidthAndHeight` accepts `undefined` parameters for dimension reset
- Verifies the crop handler uses `setWidthAndHeight(undefined, undefined)` not `setWidthAndHeight(0, 0)`
- Verifies the method body doesn't hardcode `0`

All checks pass: `pnpm lint && pnpm typecheck && pnpm test` (313 tests passing).