### PR TITLE
fix: detect pending email confirmation via session instead of identities (#282)

### DIFF
--- a/src/app/(auth)/sign-up/page.test.tsx
+++ b/src/app/(auth)/sign-up/page.test.tsx
@@ -106,7 +106,10 @@ describe("SignUpPage", () => {
 
   it("calls supabase.auth.signUp with correct parameters including emailRedirectTo", async () => {
     mockSignUp.mockResolvedValue({
-      data: { user: { id: "user-1", identities: [{ id: "id-1" }] } },
+      data: {
+        user: { id: "user-1", identities: [{ id: "id-1" }] },
+        session: { access_token: "token" },
+      },
       error: null,
     });
 
@@ -145,7 +148,7 @@ describe("SignUpPage", () => {
 
   it("shows confirmation screen when email confirmation is required", async () => {
     mockSignUp.mockResolvedValue({
-      data: { user: { id: "user-1", identities: [] } },
+      data: { user: { id: "user-1", identities: [] }, session: null },
       error: null,
     });
 
@@ -171,9 +174,44 @@ describe("SignUpPage", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("shows confirmation screen when identities are populated but session is null (#282)", async () => {
+    // Regression: Supabase now returns populated identities even when
+    // email confirmation is still pending. The session being null is the
+    // reliable signal.
+    mockSignUp.mockResolvedValue({
+      data: {
+        user: { id: "user-1", identities: [{ id: "id-1" }] },
+        session: null,
+      },
+      error: null,
+    });
+
+    const user = userEvent.setup();
+    render(<SignUpPage />);
+
+    await user.type(screen.getByLabelText("Display name"), "Jane Doe");
+    await user.type(screen.getByLabelText("Email"), "jane@example.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+
+    const form = screen.getByRole("button", { name: /sign up/i })
+      .closest("form")!;
+    form.requestSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByText("Check your inbox")).toBeInTheDocument();
+      expect(screen.getByText("jane@example.com")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
   it("redirects to workspace after successful sign-up without email confirmation", async () => {
     mockSignUp.mockResolvedValue({
-      data: { user: { id: "user-1", identities: [{ id: "id-1" }] } },
+      data: {
+        user: { id: "user-1", identities: [{ id: "id-1" }] },
+        session: { access_token: "token" },
+      },
       error: null,
     });
 
@@ -203,7 +241,10 @@ describe("SignUpPage", () => {
 
   it("redirects to root when no workspace found after sign-up", async () => {
     mockSignUp.mockResolvedValue({
-      data: { user: { id: "user-1", identities: [{ id: "id-1" }] } },
+      data: {
+        user: { id: "user-1", identities: [{ id: "id-1" }] },
+        session: { access_token: "token" },
+      },
       error: null,
     });
 

--- a/src/app/(auth)/sign-up/sign-up-form.tsx
+++ b/src/app/(auth)/sign-up/sign-up-form.tsx
@@ -50,13 +50,10 @@ export function SignUpForm() {
       return;
     }
 
-    // When email confirmation is required, Supabase returns a user with
-    // an empty identities array. Show the confirmation screen instead of
-    // attempting to redirect.
-    if (
-      data.user &&
-      (!data.user.identities || data.user.identities.length === 0)
-    ) {
+    // When email confirmation is required, Supabase returns a user but no
+    // session. Check for a missing session rather than empty identities —
+    // Supabase populates identities even before confirmation.
+    if (data.user && !data.session) {
       setConfirmationPending(true);
       setLoading(false);
       return;


### PR DESCRIPTION
Closes #282

## What

After sign-up, users were redirected to the landing page instead of seeing the "Check your inbox" email confirmation screen. The `SignUpForm` detected pending confirmation by checking `data.user.identities.length === 0`, but Supabase now populates identities even when email confirmation is still pending, causing the check to fall through to the `router.push("/")` fallback.

## How

Replaced the identities-based detection with a session-based check: `!data.session`. When email confirmation is required, Supabase returns a user object but no session. This is a stable API contract — a null session reliably indicates the user cannot authenticate yet.

## Testing

- Updated existing confirmation test to mock `session: null` alongside empty identities
- Added regression test that specifically covers the bug scenario: identities populated (`[{ id: "id-1" }]`) but session is `null` — verifies the confirmation screen appears and no redirect occurs
- Updated all other sign-up tests to include explicit `session` values in mocks for accuracy
- All 314 tests pass, lint and typecheck clean