### PR TITLE
fix: atomic workspace creation RPC + Sentry error reporting

### DIFF
--- a/src/components/members/invite-accept.tsx
+++ b/src/components/members/invite-accept.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { getClient } from "@/lib/supabase/lazy-client";
+import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 
 interface InviteAcceptProps {
@@ -82,7 +83,8 @@ export function InviteAccept({
         router.push(`/${workspaceSlug}`);
         return;
       }
-      setError(acceptError.message);
+      captureSupabaseError(acceptError, "invite-accept:accept");
+      setError("Failed to accept invite. Please try again.");
       setAccepting(false);
       return;
     }

--- a/src/components/members/invite-form.tsx
+++ b/src/components/members/invite-form.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, Copy, Send } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
+import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -132,7 +133,10 @@ export function InviteForm({
       .single();
 
     if (insertError || !newInvite) {
-      onError(insertError?.message ?? "Failed to create invite.");
+      if (insertError) {
+        captureSupabaseError(insertError, "invite-form:create-invite");
+      }
+      onError("Failed to create invite. Please try again.");
       setSending(false);
       return;
     }

--- a/src/components/members/members-page.tsx
+++ b/src/components/members/members-page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getClient } from "@/lib/supabase/lazy-client";
+import { captureSupabaseError } from "@/lib/sentry";
 import { Separator } from "@/components/ui/separator";
 import { MemberList } from "@/components/members/member-list";
 import { InviteForm } from "@/components/members/invite-form";
@@ -51,7 +52,8 @@ export function MembersPage({
       .eq("id", memberId);
 
     if (updateError) {
-      setError(updateError.message);
+      captureSupabaseError(updateError, "members-page:role-change");
+      setError("Failed to update role. Please try again.");
       return;
     }
 
@@ -68,7 +70,8 @@ export function MembersPage({
       .eq("id", memberId);
 
     if (deleteError) {
-      setError(deleteError.message);
+      captureSupabaseError(deleteError, "members-page:remove-member");
+      setError("Failed to remove member. Please try again.");
       return;
     }
 
@@ -90,7 +93,8 @@ export function MembersPage({
     if (deleteError) {
       // Revert optimistic removal on failure
       setInvites(initialInvites);
-      setError(deleteError.message);
+      captureSupabaseError(deleteError, "members-page:revoke-invite");
+      setError("Failed to revoke invite. Please try again.");
       return;
     }
 

--- a/src/components/sidebar/create-workspace-dialog.test.tsx
+++ b/src/components/sidebar/create-workspace-dialog.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+// Mock Sentry
+const mockCaptureSupabaseError = vi.fn();
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: (...args: unknown[]) =>
+    mockCaptureSupabaseError(...args),
+}));
+
+// Mock Supabase client — the lazy-client imports from here
+let rpcResult: {
+  data: { id: string; slug: string } | null;
+  error: { message: string; code: string; details: string; hint: string } | null;
+} = { data: { id: "ws-new", slug: "my-team-abc123" }, error: null };
+
+const mockRpc = vi.fn();
+const mockSingle = vi.fn();
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    rpc: (fn: string, params: Record<string, unknown>) => {
+      mockRpc(fn, params);
+      return {
+        single: () => {
+          mockSingle();
+          return Promise.resolve(rpcResult);
+        },
+      };
+    },
+  }),
+}));
+
+import { CreateWorkspaceDialog } from "./create-workspace-dialog";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rpcResult = {
+    data: { id: "ws-new", slug: "my-team-abc123" },
+    error: null,
+  };
+});
+
+describe("CreateWorkspaceDialog", () => {
+  it("calls create_workspace RPC with name and slug on submit", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateWorkspaceDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        workspaceCount={1}
+      />,
+    );
+
+    const nameInput = screen.getByLabelText("Name");
+    await user.type(nameInput, "My Team");
+
+    const submitButton = screen.getByRole("button", {
+      name: /create workspace/i,
+    });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockRpc).toHaveBeenCalledWith(
+        "create_workspace",
+        expect.objectContaining({
+          workspace_name: "My Team",
+        }),
+      );
+    });
+  });
+
+  it("navigates to new workspace on success", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <CreateWorkspaceDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        workspaceCount={1}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Name"), "My Team");
+    await user.click(
+      screen.getByRole("button", { name: /create workspace/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/my-team-abc123");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("shows user-friendly error and reports to Sentry on RLS/unknown failure", async () => {
+    rpcResult = {
+      data: null,
+      error: {
+        message: "new row violates row-level security policy for table \"workspaces\"",
+        code: "42501",
+        details: "",
+        hint: "",
+      },
+    };
+
+    const user = userEvent.setup();
+    render(
+      <CreateWorkspaceDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        workspaceCount={1}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Name"), "My Team");
+    await user.click(
+      screen.getByRole("button", { name: /create workspace/i }),
+    );
+
+    await waitFor(() => {
+      // User sees a generic message, NOT the raw RLS error
+      expect(
+        screen.getByText("Failed to create workspace. Please try again."),
+      ).toBeInTheDocument();
+
+      // Sentry receives the real error
+      expect(mockCaptureSupabaseError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("row-level security"),
+        }),
+        "create-workspace-dialog:create",
+      );
+    });
+
+    // Raw error message must NOT appear in the DOM
+    expect(
+      screen.queryByText(/row-level security/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows workspace limit message without Sentry report", async () => {
+    rpcResult = {
+      data: null,
+      error: {
+        message: "Workspace limit reached: users can create at most 3 workspaces",
+        code: "P0001",
+        details: "",
+        hint: "",
+      },
+    };
+
+    const user = userEvent.setup();
+    render(
+      <CreateWorkspaceDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        workspaceCount={1}
+      />,
+    );
+
+    await user.type(screen.getByLabelText("Name"), "My Team");
+    await user.click(
+      screen.getByRole("button", { name: /create workspace/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("You can create at most 3 workspaces."),
+      ).toBeInTheDocument();
+    });
+
+    // Workspace limit is expected behavior, not a Sentry error
+    expect(mockCaptureSupabaseError).not.toHaveBeenCalled();
+  });
+
+  it("shows limit-reached UI when workspaceCount >= WORKSPACE_LIMIT", () => {
+    render(
+      <CreateWorkspaceDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        workspaceCount={3}
+      />,
+    );
+
+    expect(
+      screen.getByText("You've reached the limit of 3 workspaces."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Delete an existing workspace to create a new one."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create workspace/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/sidebar/create-workspace-dialog.tsx
+++ b/src/components/sidebar/create-workspace-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { getClient } from "@/lib/supabase/lazy-client";
+import { captureSupabaseError } from "@/lib/sentry";
 import { generateSlug, WORKSPACE_LIMIT } from "@/lib/workspace";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,14 +21,12 @@ interface CreateWorkspaceDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   workspaceCount: number;
-  userId: string;
 }
 
 export function CreateWorkspaceDialog({
   open,
   onOpenChange,
   workspaceCount,
-  userId,
 }: CreateWorkspaceDialogProps) {
   const router = useRouter();
   const [name, setName] = useState("");
@@ -46,37 +45,23 @@ export function CreateWorkspaceDialog({
     const supabase = await getClient();
     const slug = generateSlug(name.trim());
 
-    const { data: workspace, error: createError } = await supabase
-      .from("workspaces")
-      .insert({
-        name: name.trim(),
-        slug,
-        is_personal: false,
-        created_by: userId,
+    // Atomic RPC: creates workspace + owner member in a single transaction.
+    // Avoids the RLS chicken-and-egg where the SELECT policy on workspaces
+    // requires membership that doesn't exist yet during INSERT ... RETURNING.
+    const { data, error: rpcError } = await supabase
+      .rpc("create_workspace", {
+        workspace_name: name.trim(),
+        workspace_slug: slug,
       })
-      .select("id, slug")
-      .single();
+      .single<{ id: string; slug: string }>();
 
-    if (createError) {
-      if (createError.message.includes("Workspace limit reached")) {
+    if (rpcError) {
+      if (rpcError.message.includes("Workspace limit reached")) {
         setError(`You can create at most ${WORKSPACE_LIMIT} workspaces.`);
       } else {
-        setError(createError.message);
+        captureSupabaseError(rpcError, "create-workspace-dialog:create");
+        setError("Failed to create workspace. Please try again.");
       }
-      setLoading(false);
-      return;
-    }
-
-    // Add the creator as owner
-    const { error: memberError } = await supabase.from("members").insert({
-      workspace_id: workspace.id,
-      user_id: userId,
-      role: "owner",
-      joined_at: new Date().toISOString(),
-    });
-
-    if (memberError) {
-      setError(memberError.message);
       setLoading(false);
       return;
     }
@@ -84,7 +69,7 @@ export function CreateWorkspaceDialog({
     onOpenChange(false);
     setName("");
     setLoading(false);
-    router.push(`/${workspace.slug}`);
+    router.push(`/${data!.slug}`);
     router.refresh();
   }
 

--- a/src/components/sidebar/workspace-switcher.tsx
+++ b/src/components/sidebar/workspace-switcher.tsx
@@ -112,7 +112,6 @@ export function WorkspaceSwitcher({ userId }: WorkspaceSwitcherProps) {
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
         workspaceCount={createdCount}
-        userId={userId}
       />
     </DropdownMenu>
   );

--- a/src/components/workspace-settings-form.test.tsx
+++ b/src/components/workspace-settings-form.test.tsx
@@ -333,7 +333,7 @@ describe("WorkspaceSettingsForm", () => {
     });
   });
 
-  it("shows generic error message on non-duplicate update failure", async () => {
+  it("shows user-friendly error on non-duplicate update failure", async () => {
     updateResult = { error: { message: "network timeout" } };
 
     const user = userEvent.setup();
@@ -348,7 +348,9 @@ describe("WorkspaceSettingsForm", () => {
     await user.click(saveButton);
 
     await waitFor(() => {
-      expect(screen.getByText("network timeout")).toBeInTheDocument();
+      expect(
+        screen.getByText("Failed to save settings. Please try again."),
+      ).toBeInTheDocument();
     });
     expect(mockRefresh).not.toHaveBeenCalled();
   });
@@ -392,7 +394,7 @@ describe("WorkspaceSettingsForm", () => {
     });
   });
 
-  it("shows error when delete fails", async () => {
+  it("shows user-friendly error when delete fails", async () => {
     deleteResult = { error: { message: "permission denied" } };
 
     const user = userEvent.setup();
@@ -413,7 +415,9 @@ describe("WorkspaceSettingsForm", () => {
     await user.click(confirmButton);
 
     await waitFor(() => {
-      expect(screen.getByText("permission denied")).toBeInTheDocument();
+      expect(
+        screen.getByText("Failed to delete workspace. Please try again."),
+      ).toBeInTheDocument();
     });
     expect(mockPush).not.toHaveBeenCalled();
   });

--- a/src/components/workspace-settings-form.tsx
+++ b/src/components/workspace-settings-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
+import { captureSupabaseError } from "@/lib/sentry";
 import { isValidSlug } from "@/lib/workspace";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -72,7 +73,8 @@ export function WorkspaceSettingsForm({
       if (updateError.message.includes("duplicate key")) {
         setError("This slug is already taken. Choose a different one.");
       } else {
-        setError(updateError.message);
+        captureSupabaseError(updateError, "workspace-settings:update");
+        setError("Failed to save settings. Please try again.");
       }
       setSaving(false);
       return;
@@ -99,7 +101,8 @@ export function WorkspaceSettingsForm({
       .eq("id", workspace.id);
 
     if (deleteError) {
-      setError(deleteError.message);
+      captureSupabaseError(deleteError, "workspace-settings:delete");
+      setError("Failed to delete workspace. Please try again.");
       setDeleting(false);
       return;
     }

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -119,4 +119,57 @@ describe("error handling conventions", () => {
       `console.error without Sentry capture found outside allowlist. Add Sentry.captureException or captureSupabaseError:\n${violations.join("\n")}`,
     ).toEqual([]);
   });
+
+  it("no Supabase error .message exposed to users without Sentry capture", () => {
+    /**
+     * Detects patterns like `setError(someError.message)` where a Supabase
+     * error message is shown directly to the user. These leak internal
+     * details (e.g. RLS policy names, SQL errors) and bypass Sentry.
+     *
+     * Allowed patterns:
+     * - The file imports and calls captureSupabaseError before setError
+     * - The error message is checked for a known string first (e.g.
+     *   `if (error.message.includes("Workspace limit"))`)
+     *
+     * Auth forms (sign-in, sign-up) are excluded — Supabase Auth error
+     * messages are designed to be user-facing (e.g. "Invalid login credentials").
+     */
+    const AUTH_FORM_ALLOWLIST = new Set([
+      "src/app/(auth)/sign-in/sign-in-form.tsx",
+      "src/app/(auth)/sign-up/sign-up-form.tsx",
+    ]);
+
+    const violations: string[] = [];
+
+    // Matches setError(identifier.message) — the raw error leak pattern
+    const rawErrorPattern = /\bsetError\(\s*\w+(?:Error)?\s*\.\s*message\s*\)/g;
+
+    for (const file of files) {
+      const rel = toRelative(file);
+      if (AUTH_FORM_ALLOWLIST.has(rel)) continue;
+
+      const content = readFileSync(file, "utf-8");
+
+      // Skip files that don't use setError at all
+      if (!content.includes("setError")) continue;
+
+      rawErrorPattern.lastIndex = 0;
+      let match;
+
+      while ((match = rawErrorPattern.exec(content)) !== null) {
+        const lineNum = content.slice(0, match.index).split("\n").length;
+        const hasSentryCapture = content.includes("captureSupabaseError");
+
+        if (!hasSentryCapture) {
+          violations.push(`${rel}:${lineNum}`);
+        }
+      }
+    }
+
+    expect(
+      violations,
+      `Raw Supabase error.message exposed to users without captureSupabaseError. ` +
+        `Use captureSupabaseError() to report to Sentry and show a generic message instead:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
 });

--- a/supabase/migrations/20260420135734_create_workspace_rpc.sql
+++ b/supabase/migrations/20260420135734_create_workspace_rpc.sql
@@ -1,0 +1,50 @@
+-- Atomic workspace creation: inserts workspace + owner member in one call.
+-- Fixes RLS chicken-and-egg: the SELECT policy on workspaces requires
+-- is_workspace_member(id), but the member row doesn't exist yet when
+-- PostgREST tries to return the inserted workspace via RETURNING.
+--
+-- Uses security definer to bypass RLS for the internal inserts while
+-- still enforcing auth, ownership, and the 3-workspace limit.
+
+create or replace function create_workspace(
+  workspace_name text,
+  workspace_slug text
+)
+returns table (id uuid, slug text)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  _user_id uuid;
+  _count   integer;
+  _ws_id   uuid;
+begin
+  _user_id := auth.uid();
+  if _user_id is null then
+    raise exception 'Not authenticated'
+      using errcode = '28000'; -- invalid_authorization_specification
+  end if;
+
+  -- Enforce workspace limit (same as enforce_workspace_limit trigger)
+  select count(*) into _count
+  from public.workspaces w
+  where w.created_by = _user_id;
+
+  if _count >= 3 then
+    raise exception 'Workspace limit reached: users can create at most 3 workspaces'
+      using errcode = 'P0001';
+  end if;
+
+  -- Create workspace
+  insert into public.workspaces (name, slug, is_personal, created_by)
+  values (workspace_name, workspace_slug, false, _user_id)
+  returning public.workspaces.id into _ws_id;
+
+  -- Create owner membership
+  insert into public.members (workspace_id, user_id, role, joined_at)
+  values (_ws_id, _user_id, 'owner', now());
+
+  return query select _ws_id as id, workspace_slug as slug;
+end;
+$$;


### PR DESCRIPTION
## Problem

Creating a new workspace shows the raw PostgreSQL error to the user:

> new row violates row-level security policy for table "workspaces"

Two issues:

1. **RLS chicken-and-egg:** Workspace creation was a non-atomic two-step client-side operation (INSERT workspace, then INSERT member). The SELECT RLS policy on `workspaces` requires `is_workspace_member(id)`, but the member row doesn't exist yet when PostgREST tries to return the inserted row via `RETURNING`.

2. **No Sentry reporting:** The create-workspace dialog (and several other mutation handlers) showed raw Supabase error messages directly to users and never reported to Sentry.

## Changes

**Database migration:**
- New `create_workspace(workspace_name, workspace_slug)` RPC — atomically creates workspace + owner member in a single `security definer` transaction with auth and limit enforcement

**Error handling (5 components):**
- `create-workspace-dialog` — replaced two-step insert with single RPC call
- `workspace-settings-form` — update and delete errors
- `members-page` — role change, remove member, revoke invite errors
- `invite-form` — create invite errors
- `invite-accept` — accept invite errors

All now call `captureSupabaseError()` and show generic user-facing messages instead of raw PostgreSQL internals.

**Tests:**
- New `create-workspace-dialog.test.tsx` — 5 tests covering RPC call, navigation, Sentry capture on failure, limit handling
- New static analysis test in `sentry.test.ts` — catches `setError(error.message)` without `captureSupabaseError` to prevent this pattern from recurring
- Updated `workspace-settings-form.test.tsx` — assertions match new generic error messages

## Deploy note

The migration must be applied to Supabase before the new client code is deployed. The old INSERT policies still exist, so there's no ordering risk.

Closes #284