### PR TITLE
chore: add Storybook as toggleable Ona service on port 6006

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,14 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli": {}
   },
-  "forwardPorts": [3000],
+  "forwardPorts": [3000, 6006],
   "portsAttributes": {
     "3000": {
       "label": "Memo App",
+      "onAutoForward": "notify"
+    },
+    "6006": {
+      "label": "Storybook",
       "onAutoForward": "notify"
     }
   }

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -14,3 +14,9 @@ services:
     commands:
       start: pnpm dev
       ready: curl -sf http://localhost:3000
+  storybook:
+    name: Storybook
+    description: Storybook component browser on port 6006.
+    commands:
+      start: pnpm storybook -p 6006 -h 0.0.0.0 --no-open
+      ready: curl -sf http://localhost:6006


### PR DESCRIPTION
Adds Storybook as a service in `.ona/automations.yaml` so it appears in the Ona UI as a toggleable service alongside the Dev Server. Also forwards port 6006 in the devcontainer config.

- **`.ona/automations.yaml`**: new `storybook` service (`pnpm storybook -p 6006 -h 0.0.0.0 --no-open`)
- **`.devcontainer/devcontainer.json`**: port 6006 forwarding with "Storybook" label

The service does not auto-start — toggle it on when needed.