### PR TITLE
feat: add word count and reading time to page view (#307)

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -44,6 +44,7 @@ import {
   CollapsibleContentNode,
 } from "@/components/editor/collapsible-node";
 import { CollapsiblePlugin } from "@/components/editor/collapsible-plugin";
+import { WordCountPlugin } from "@/components/editor/word-count-plugin";
 import { getClient } from "@/lib/supabase/lazy-client";
 
 const SAVE_DEBOUNCE_MS = 500;
@@ -221,6 +222,7 @@ export function Editor({ pageId, initialContent, editorRef }: EditorProps) {
             <DraggableBlockPlugin anchorElem={floatingAnchorElem} />
           </>
         )}
+        <WordCountPlugin />
       </LexicalComposer>
       <div className="mt-2 h-5 text-xs text-muted-foreground">
         {saveStatus === "saving" && "Saving..."}

--- a/src/components/editor/word-count-plugin.tsx
+++ b/src/components/editor/word-count-plugin.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { JSX } from "react";
+import { useEffect, useState } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getRoot } from "lexical";
+import { $isCodeNode } from "@lexical/code";
+import { getWordCount, formatWordCountDisplay } from "@/lib/word-count";
+
+const DEBOUNCE_MS = 500;
+
+/**
+ * Extract visible text from the editor state, excluding code blocks.
+ * Walks the root's children and collects text content from non-code nodes.
+ */
+function $getVisibleTextContent(): string {
+  const root = $getRoot();
+  const parts: string[] = [];
+
+  for (const child of root.getChildren()) {
+    if ($isCodeNode(child)) continue;
+    parts.push(child.getTextContent());
+  }
+
+  return parts.join(" ");
+}
+
+export function WordCountPlugin(): JSX.Element {
+  const [editor] = useLexicalComposerContext();
+  const [wordCount, setWordCount] = useState(0);
+
+  useEffect(() => {
+    // Compute initial word count from the current editor state
+    editor.getEditorState().read(() => {
+      const text = $getVisibleTextContent();
+      setWordCount(getWordCount(text));
+    });
+
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+
+    const unregister = editor.registerUpdateListener(({ editorState }) => {
+      if (timerId) clearTimeout(timerId);
+
+      timerId = setTimeout(() => {
+        editorState.read(() => {
+          const text = $getVisibleTextContent();
+          setWordCount(getWordCount(text));
+        });
+      }, DEBOUNCE_MS);
+    });
+
+    return () => {
+      if (timerId) clearTimeout(timerId);
+      unregister();
+    };
+  }, [editor]);
+
+  return (
+    <div className="mt-8 text-xs text-muted-foreground">
+      {formatWordCountDisplay(wordCount)}
+    </div>
+  );
+}

--- a/src/lib/word-count.test.ts
+++ b/src/lib/word-count.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  getWordCount,
+  getReadingTime,
+  formatWordCountDisplay,
+} from "./word-count";
+
+describe("getWordCount", () => {
+  it("returns 0 for empty string", () => {
+    expect(getWordCount("")).toBe(0);
+  });
+
+  it("returns 0 for whitespace-only string", () => {
+    expect(getWordCount("   \n\t  ")).toBe(0);
+  });
+
+  it("counts single word", () => {
+    expect(getWordCount("hello")).toBe(1);
+  });
+
+  it("counts multiple words", () => {
+    expect(getWordCount("hello world foo bar")).toBe(4);
+  });
+
+  it("handles multiple spaces between words", () => {
+    expect(getWordCount("hello   world")).toBe(2);
+  });
+
+  it("handles newlines and tabs", () => {
+    expect(getWordCount("hello\nworld\tfoo")).toBe(3);
+  });
+
+  it("handles leading and trailing whitespace", () => {
+    expect(getWordCount("  hello world  ")).toBe(2);
+  });
+
+  it("returns 0 for null-ish input", () => {
+    expect(getWordCount("")).toBe(0);
+  });
+});
+
+describe("getReadingTime", () => {
+  it("returns 0 for 0 words", () => {
+    expect(getReadingTime(0)).toBe(0);
+  });
+
+  it("returns 1 minute for 1 word", () => {
+    expect(getReadingTime(1)).toBe(1);
+  });
+
+  it("returns 1 minute for 200 words", () => {
+    expect(getReadingTime(200)).toBe(1);
+  });
+
+  it("returns 2 minutes for 201 words", () => {
+    expect(getReadingTime(201)).toBe(2);
+  });
+
+  it("returns 5 minutes for 1000 words", () => {
+    expect(getReadingTime(1000)).toBe(5);
+  });
+
+  it("rounds up to next minute", () => {
+    expect(getReadingTime(401)).toBe(3);
+  });
+});
+
+describe("formatWordCountDisplay", () => {
+  it("shows '0 words' for empty content", () => {
+    expect(formatWordCountDisplay(0)).toBe("0 words");
+  });
+
+  it("shows singular 'word' for 1 word", () => {
+    expect(formatWordCountDisplay(1)).toBe("1 word · 1 min read");
+  });
+
+  it("shows plural 'words' for multiple words", () => {
+    expect(formatWordCountDisplay(50)).toBe("50 words · 1 min read");
+  });
+
+  it("shows correct reading time for longer content", () => {
+    expect(formatWordCountDisplay(500)).toBe("500 words · 3 min read");
+  });
+});

--- a/src/lib/word-count.ts
+++ b/src/lib/word-count.ts
@@ -1,0 +1,30 @@
+const WORDS_PER_MINUTE = 200;
+
+/**
+ * Count words in a text string by splitting on whitespace
+ * and filtering empty strings.
+ */
+export function getWordCount(text: string): number {
+  if (!text) return 0;
+  return text.split(/\s+/).filter((word) => word.length > 0).length;
+}
+
+/**
+ * Estimate reading time in minutes based on word count.
+ * Returns at least 1 minute for any non-zero word count.
+ */
+export function getReadingTime(wordCount: number): number {
+  if (wordCount === 0) return 0;
+  return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
+}
+
+/**
+ * Format word count and reading time as a display string.
+ */
+export function formatWordCountDisplay(wordCount: number): string {
+  const readingTime = getReadingTime(wordCount);
+  if (wordCount === 0) return "0 words";
+  const wordLabel = wordCount === 1 ? "word" : "words";
+  const minuteLabel = readingTime === 1 ? "min" : "min";
+  return `${wordCount} ${wordLabel} · ${readingTime} ${minuteLabel} read`;
+}


### PR DESCRIPTION
Closes #307

## What

Adds a word count and estimated reading time indicator below the editor content area. Displays as "X words · Y min read" in subtle secondary text, updating in real-time as the user types.

## How

- **`src/lib/word-count.ts`** — Pure utility functions: `getWordCount`, `getReadingTime` (200 wpm), `formatWordCountDisplay`. Handles edge cases (empty string, single word, zero words).
- **`src/components/editor/word-count-plugin.tsx`** — Lexical plugin that listens to editor updates via `registerUpdateListener`, debounced at 500ms. Extracts visible text by walking root children and skipping `CodeNode` blocks. `ImageNode` (DecoratorNode) text is excluded automatically.
- **`src/components/editor/editor.tsx`** — Registers the `WordCountPlugin` inside the `LexicalComposer`.

## Testing

- 18 unit tests for `getWordCount`, `getReadingTime`, and `formatWordCountDisplay` covering empty input, whitespace, single/multiple words, reading time rounding, and display formatting.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (343 tests).
- No stories required per acceptance criteria (editor integration, not standalone component).