### PR TITLE
fix: add idempotent repair migration for favorites table (#315)

### DIFF
--- a/supabase/migrations/20260421072646_repair_favorites_table.sql
+++ b/supabase/migrations/20260421072646_repair_favorites_table.sql
@@ -1,0 +1,63 @@
+-- Repair: the original migration (20260421062334_add_favorites_table.sql) was
+-- deployed empty before being populated. Any database that applied the empty
+-- version has it marked as "applied" but the table does not exist. This
+-- idempotent migration creates the table only if it is missing.
+
+create table if not exists favorites (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  user_id uuid not null references profiles(id) on delete cascade,
+  page_id uuid not null references pages(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique (workspace_id, user_id, page_id)
+);
+
+-- Index (IF NOT EXISTS requires PG 9.5+, which Supabase satisfies)
+create index if not exists favorites_workspace_user
+  on favorites (workspace_id, user_id, created_at);
+
+-- Enable RLS (idempotent — no-op if already enabled)
+alter table favorites enable row level security;
+
+-- Policies: use DO blocks to skip creation if they already exist.
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'favorites'
+      and policyname = 'users can read own favorites in their workspaces'
+  ) then
+    create policy "users can read own favorites in their workspaces"
+      on favorites for select
+      using (
+        user_id = auth.uid()
+        and is_workspace_member(workspace_id)
+      );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'favorites'
+      and policyname = 'users can insert own favorites in their workspaces'
+  ) then
+    create policy "users can insert own favorites in their workspaces"
+      on favorites for insert
+      with check (
+        user_id = auth.uid()
+        and is_workspace_member(workspace_id)
+      );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'favorites'
+      and policyname = 'users can delete own favorites'
+  ) then
+    create policy "users can delete own favorites"
+      on favorites for delete
+      using (user_id = auth.uid());
+  end if;
+end $$;

--- a/supabase/migrations/migrations.test.ts
+++ b/supabase/migrations/migrations.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "fs";
+import { resolve, join } from "path";
+
+/**
+ * Regression test for issue #315: an empty migration file was committed,
+ * causing PGRST205 errors because the table was never created.
+ *
+ * Every .sql migration file must contain at least one SQL statement.
+ */
+
+const migrationsDir = resolve(__dirname);
+
+function getMigrationFiles(): string[] {
+  return readdirSync(migrationsDir).filter((f) => f.endsWith(".sql"));
+}
+
+function stripComments(sql: string): string {
+  return sql
+    .replace(/--[^\n]*/g, "") // single-line comments
+    .replace(/\/\*[\s\S]*?\*\//g, "") // block comments
+    .trim();
+}
+
+describe("database migrations", () => {
+  const files = getMigrationFiles();
+
+  it("has at least one migration file", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)("%s contains SQL statements", (filename) => {
+    const content = readFileSync(join(migrationsDir, filename), "utf-8");
+    const sql = stripComments(content);
+    expect(sql.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #315

## What

The original migration (`20260421062334_add_favorites_table.sql`) was deployed empty before being populated in PR #314. Any Supabase database that applied the empty version has it recorded in `supabase_migrations` as "applied" but the `favorites` table does not exist, causing PGRST205 errors (`Could not find the table 'public.favorites' in the schema cache`).

## How

Adds a new idempotent repair migration (`20260421072646_repair_favorites_table.sql`) that uses `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, and conditional `DO` blocks for RLS policies. This is safe on both:
- **Fresh databases** where the original migration now has content (all statements are no-ops)
- **Affected databases** where the empty migration was already applied (creates the missing table, index, and policies)

## Testing

Added `supabase/migrations/migrations.test.ts` — a regression test that reads all `.sql` migration files and verifies each contains at least one SQL statement (after stripping comments). This would have caught the original empty-file bug at CI time.