### PR TITLE
fix: ignore FK violation on page_visits upsert when workspace is deleted (#317)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/[pageId]/page-visit.test.ts
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page-visit.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const SOURCE = readFileSync(resolve(__dirname, "page.tsx"), "utf-8");
+
+describe("page visit error handling", () => {
+  it("filters FK violation errors (23503) on page_visits upsert", () => {
+    // Regression test for #317: page_visits upsert must not report FK
+    // violations to Sentry — they occur when a workspace is deleted while
+    // a page visit is in-flight and are expected, non-actionable errors.
+    expect(SOURCE).toContain('error.code !== "23503"');
+  });
+
+  it("still reports non-FK errors to Sentry", () => {
+    expect(SOURCE).toContain("captureSupabaseError(error, \"page-view:record-visit\")");
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -137,7 +137,7 @@ export default async function PageView({
       { onConflict: "workspace_id,user_id,page_id" },
     )
     .then(({ error }) => {
-      if (error) {
+      if (error && error.code !== "23503") {
         captureSupabaseError(error, "page-view:record-visit");
       }
     });


### PR DESCRIPTION
Closes #317

## What

The fire-and-forget `page_visits` upsert reports all errors to Sentry, including FK violations (PostgreSQL code `23503`) that occur when a workspace is deleted while a page visit is in-flight. These are expected, non-actionable errors — the workspace no longer exists, so the visit record is irrelevant.

## How

Added a check for `error.code !== "23503"` before calling `captureSupabaseError` in the page visit handler. FK violations on this best-effort analytics write are silently ignored; all other errors continue to be reported.

## Testing

Added a static analysis regression test (`page-visit.test.ts`) that verifies:
1. The FK violation filter (`error.code !== "23503"`) is present in the page visit handler
2. Non-FK errors are still reported to Sentry via `captureSupabaseError`

All checks pass: `pnpm lint && pnpm typecheck && pnpm test` (345/345 tests).