### PR TITLE
fix: graceful degradation for missing favorites table (PGRST205)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1054,6 +1054,29 @@ Custom `not-found.tsx` files provide contextual 404 messages:
 
 Pattern: `FileQuestion` icon (48px) + heading + description + "Go home" button.
 
+## Graceful Degradation for Optional Features
+
+When a feature depends on a database table that may not exist yet (e.g. migration
+not applied), the code must degrade silently instead of flooding Sentry with errors.
+
+Pattern: check for `PGRST205` (schema-not-found) before calling `captureSupabaseError`:
+
+```typescript
+import { captureSupabaseError, isSchemaNotFoundError } from "@/lib/sentry";
+
+const { data, error } = await supabase.from("optional_table").select("*");
+if (error) {
+  // Table missing — degrade gracefully, don't report to Sentry
+  if (isSchemaNotFoundError(error)) return;
+  captureSupabaseError(error, "feature:operation");
+  return;
+}
+```
+
+Additionally, `captureSupabaseError` automatically downgrades `PGRST205` errors to
+`warning` level as a safety net, but callers should still skip the call entirely for
+read operations on optional tables to avoid unnecessary noise.
+
 ## This file evolves
 
 When you discover a new pattern that should be replicated, or an anti-pattern that

--- a/src/components/sidebar/favorites-section.tsx
+++ b/src/components/sidebar/favorites-section.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { FileText, StarOff } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError } from "@/lib/sentry";
+import { captureSupabaseError, isSchemaNotFoundError } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import type { FavoriteWithPage } from "@/lib/types";
 
@@ -80,6 +80,8 @@ export function FavoritesSection({ userId }: FavoritesSectionProps) {
       if (cancelled) return;
 
       if (error) {
+        // Table missing (migration not applied yet) — degrade gracefully
+        if (isSchemaNotFoundError(error)) return;
         captureSupabaseError(error, "favorites:fetch");
         return;
       }
@@ -108,7 +110,9 @@ export function FavoritesSection({ userId }: FavoritesSectionProps) {
         .eq("id", favoriteId);
 
       if (error) {
-        captureSupabaseError(error, "favorites:remove");
+        if (!isSchemaNotFoundError(error)) {
+          captureSupabaseError(error, "favorites:remove");
+        }
         toast.error("Failed to remove favorite", { duration: 8000 });
         // Revert — trigger re-fetch
         setFavRefetchKey((k) => k + 1);
@@ -211,7 +215,9 @@ export function useFavorite({
       if (cancelled) return;
 
       if (error) {
-        captureSupabaseError(error, "favorites:check");
+        if (!isSchemaNotFoundError(error)) {
+          captureSupabaseError(error, "favorites:check");
+        }
       }
 
       setFavoriteId(data?.id ?? null);
@@ -237,7 +243,9 @@ export function useFavorite({
         .eq("id", favoriteId);
 
       if (error) {
-        captureSupabaseError(error, "favorites:toggle-remove");
+        if (!isSchemaNotFoundError(error)) {
+          captureSupabaseError(error, "favorites:toggle-remove");
+        }
         toast.error("Failed to remove favorite", { duration: 8000 });
         // Revert
         setFavoriteId(favoriteId);
@@ -257,7 +265,9 @@ export function useFavorite({
         .single();
 
       if (error) {
-        captureSupabaseError(error, "favorites:toggle-add");
+        if (!isSchemaNotFoundError(error)) {
+          captureSupabaseError(error, "favorites:toggle-add");
+        }
         toast.error("Failed to add favorite", { duration: 8000 });
         return;
       }

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError } from "@/lib/sentry";
+import { captureSupabaseError, isSchemaNotFoundError } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import { Button } from "@/components/ui/button";
 import {
@@ -163,6 +163,8 @@ export function PageTree({ userId }: PageTreeProps) {
       if (cancelled) return;
 
       if (error) {
+        // Table missing (migration not applied yet) — degrade gracefully
+        if (isSchemaNotFoundError(error)) return;
         captureSupabaseError(error, "page-tree:fetch-favorites");
         return;
       }
@@ -200,7 +202,9 @@ export function PageTree({ userId }: PageTreeProps) {
           .eq("id", existingFavId);
 
         if (error) {
-          captureSupabaseError(error, "page-tree:remove-favorite");
+          if (!isSchemaNotFoundError(error)) {
+            captureSupabaseError(error, "page-tree:remove-favorite");
+          }
           toast.error("Failed to remove favorite", { duration: 8000 });
           // Revert
           setFavoriteMap((prev) => new Map(prev).set(pageId, existingFavId));
@@ -220,7 +224,9 @@ export function PageTree({ userId }: PageTreeProps) {
           .single();
 
         if (error) {
-          captureSupabaseError(error, "page-tree:add-favorite");
+          if (!isSchemaNotFoundError(error)) {
+            captureSupabaseError(error, "page-tree:add-favorite");
+          }
           toast.error("Failed to add favorite", { duration: 8000 });
           return;
         }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -46,6 +46,16 @@ export function isNextjsInternalNoise(event: ErrorEvent): boolean {
 }
 
 /**
+ * True when PostgREST cannot find a table in its schema cache (PGRST205).
+ * This happens when a migration hasn't been applied or the schema cache is
+ * stale. It's a deployment issue, not an application bug, so it should be
+ * reported at warning level.
+ */
+export function isSchemaNotFoundError(error: Error): boolean {
+  return isPostgrestError(error) && error.code === "PGRST205";
+}
+
+/**
  * True when the error is a transient network failure (e.g. offline, DNS
  * timeout, connection reset). These are not application bugs and should be
  * reported at warning level so they don't trigger error-level alerts.
@@ -90,7 +100,7 @@ export function captureSupabaseError(
     extra.hint = error.hint;
   }
 
-  if (isTransientNetworkError(error)) {
+  if (isTransientNetworkError(error) || isSchemaNotFoundError(error)) {
     lazyCaptureException(error, { extra, level: "warning" });
     return;
   }

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -10,6 +10,7 @@ vi.mock("@sentry/nextjs", () => ({
 
 import {
   isTransientNetworkError,
+  isSchemaNotFoundError,
   captureSupabaseError,
   isNextjsInternalNoise,
 } from "./sentry";
@@ -83,6 +84,30 @@ describe("isTransientNetworkError", () => {
   });
 });
 
+describe("isSchemaNotFoundError", () => {
+  it("detects PGRST205 (table not found in schema cache)", () => {
+    const error = makePostgrestError({
+      message: "Could not find the table 'public.favorites' in the schema cache",
+      code: "PGRST205",
+      hint: "Perhaps you meant the table 'public.profiles'",
+    });
+    expect(isSchemaNotFoundError(error)).toBe(true);
+  });
+
+  it("returns false for other PostgrestError codes", () => {
+    const error = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    expect(isSchemaNotFoundError(error)).toBe(false);
+  });
+
+  it("returns false for generic errors", () => {
+    const error = new Error("Something went wrong");
+    expect(isSchemaNotFoundError(error)).toBe(false);
+  });
+});
+
 describe("captureSupabaseError", () => {
   beforeEach(() => {
     captureExceptionMock.mockClear();
@@ -115,6 +140,22 @@ describe("captureSupabaseError", () => {
     expect(captureExceptionMock).toHaveBeenCalledOnce();
     const [, opts] = captureExceptionMock.mock.calls[0];
     expect(opts.level).toBe("warning");
+  });
+
+  it("captures PGRST205 schema-not-found errors at warning level", async () => {
+    const error = makePostgrestError({
+      message: "Could not find the table 'public.favorites' in the schema cache",
+      code: "PGRST205",
+      hint: "Perhaps you meant the table 'public.profiles'",
+    });
+    captureSupabaseError(error, "page-tree:fetch-favorites");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("page-tree:fetch-favorites");
+    expect(opts.extra.code).toBe("PGRST205");
   });
 
   it("captures non-network errors at default (error) level", async () => {


### PR DESCRIPTION
## Summary

Favorites queries now silently degrade when the `favorites` table doesn't exist, instead of flooding Sentry with 1300+ error-level events.

**Sentry issues:** [MEMO-E](https://ona-2j.sentry.io/issues/MEMO-E) (1260 events, 24 users), [MEMO-F](https://ona-2j.sentry.io/issues/MEMO-F) (37 events, 10 users)

## Root Cause

The favorites feature code calls `captureSupabaseError` for all Supabase errors, including `PGRST205` (table not found in PostgREST schema cache). When the repair migration hasn't been applied to the production database or the schema cache is stale, every page load generates error-level Sentry events.

## Changes

- **`src/lib/sentry.ts`**: Add `isSchemaNotFoundError` helper to detect `PGRST205`. Downgrade PGRST205 to warning level in `captureSupabaseError` as a safety net.
- **`src/components/sidebar/page-tree.tsx`**: Skip Sentry reporting entirely for `page-tree:fetch-favorites` when table is missing — return empty map.
- **`src/components/sidebar/favorites-section.tsx`**: Skip Sentry reporting for all favorites operations (`fetch`, `check`, `remove`, `toggle-*`) when table is missing.
- **`src/lib/sentry.unit.test.ts`**: Regression tests for `isSchemaNotFoundError` and the warning-level downgrade behavior.
- **`.agents/conventions.md`**: Document the graceful degradation pattern for optional features.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (361 tests, 44 files)

Closes #321