### PR TITLE
fix(ci): add --include-all to production migration deploy

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -84,7 +84,7 @@ jobs:
         run: supabase link --project-ref $SUPABASE_PROJECT_ID
 
       - name: Deploy migrations
-        run: supabase db push --yes
+        run: supabase db push --yes --include-all
 
       - name: Verify critical tables exist
         env:


### PR DESCRIPTION
## Problem

The [Deploy Migrations](https://github.com/gitpod-io/memo/actions/runs/24711608963/job/72277411116) workflow fails when parallel automation PRs merge in a different order than their migration timestamps.

**What happened:**
1. PR #313 (page_visits) merged first, deploying migration `20260421064250`
2. PR #314 (favorites) merged second, with migration `20260421062334` — an earlier timestamp
3. `supabase db push` rejected the favorites migration because it has a timestamp before the last applied migration on the remote DB

**Error:**
```
Found local migration files to be inserted before the last migration on remote database.
Rerun the command with --include-all flag to apply these migrations:
supabase/migrations/20260421062334_add_favorites_table.sql
```

## Fix

Add `--include-all` to the production `supabase db push` command. This allows out-of-order migrations to be applied safely.

This is safe because:
- The staging job already validates all migrations apply cleanly from scratch via `db reset --linked`
- The migrations are independent (favorites doesn't depend on page_visits or vice versa)
- This is the expected pattern when multiple branches create migrations concurrently