### PR TITLE
fix: return 403 instead of 500 for workspace authorization errors in search API (#337)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1077,6 +1077,30 @@ Additionally, `captureSupabaseError` automatically downgrades `PGRST205` errors 
 `warning` level as a safety net, but callers should still skip the call entirely for
 read operations on optional tables to avoid unnecessary noise.
 
+## Authorization Errors in API Routes (PostgreSQL 42501)
+
+When an RPC uses `RAISE EXCEPTION` to reject callers who lack access (e.g.
+non-members calling workspace-scoped functions), PostgreSQL returns error code
+`42501` (insufficient_privilege). This is an expected authorization check, not an
+application bug — API routes must return 403 and must NOT report to Sentry.
+
+Pattern: check for `42501` before calling `captureSupabaseError`:
+
+```typescript
+import { captureSupabaseError, isInsufficientPrivilegeError } from "@/lib/sentry";
+
+const { data, error } = await supabase.rpc("workspace_rpc", { ws_id: workspaceId });
+if (error) {
+  if (isInsufficientPrivilegeError(error)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  captureSupabaseError(error, "workspace_rpc");
+  return NextResponse.json({ error: "Operation failed" }, { status: 500 });
+}
+```
+
+Never return 500 for `42501` — it inflates Sentry error counts with non-bugs.
+
 ## This file evolves
 
 When you discover a new pattern that should be replicated, or an anti-pattern that

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -86,6 +86,31 @@ describe("GET /api/search", () => {
     expect(body.error).toBe("Unauthorized");
   });
 
+  it("returns 403 when RPC returns insufficient_privilege (42501)", async () => {
+    const mockGetUser = vi
+      .fn()
+      .mockResolvedValue({ data: { user: { id: "user-1" } } });
+    const insufficientPrivilegeError = Object.assign(
+      new Error("Not a member of this workspace"),
+      { code: "42501", details: null, hint: null },
+    );
+    const mockRpc = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: insufficientPrivilegeError });
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      rpc: mockRpc,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      makeRequest({ q: "test", workspace_id: "ws-1" }) as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+  });
+
   it("returns 500 when RPC call fails", async () => {
     const mockGetUser = vi
       .fn()

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { createClient } from "@/lib/supabase/server";
-import { captureSupabaseError } from "@/lib/sentry";
+import { captureSupabaseError, isInsufficientPrivilegeError } from "@/lib/sentry";
 
 export async function GET(request: NextRequest) {
   if (
@@ -47,6 +47,9 @@ export async function GET(request: NextRequest) {
     });
 
     if (error) {
+      if (isInsufficientPrivilegeError(error)) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
       captureSupabaseError(error, "search_pages");
       return NextResponse.json(
         { error: "Search failed" },

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -56,6 +56,16 @@ export function isSchemaNotFoundError(error: Error): boolean {
 }
 
 /**
+ * True when PostgreSQL raises `insufficient_privilege` (42501). This occurs
+ * when an RPC uses `RAISE EXCEPTION` to reject callers who lack access
+ * (e.g. non-members calling workspace-scoped functions). It is an expected
+ * authorization check, not an application bug — API routes should return 403.
+ */
+export function isInsufficientPrivilegeError(error: Error): boolean {
+  return isPostgrestError(error) && error.code === "42501";
+}
+
+/**
  * True when the error is a transient network failure (e.g. offline, DNS
  * timeout, connection reset). These are not application bugs and should be
  * reported at warning level so they don't trigger error-level alerts.

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -11,6 +11,7 @@ vi.mock("@sentry/nextjs", () => ({
 import {
   isTransientNetworkError,
   isSchemaNotFoundError,
+  isInsufficientPrivilegeError,
   captureSupabaseError,
   isNextjsInternalNoise,
 } from "./sentry";
@@ -105,6 +106,37 @@ describe("isSchemaNotFoundError", () => {
   it("returns false for generic errors", () => {
     const error = new Error("Something went wrong");
     expect(isSchemaNotFoundError(error)).toBe(false);
+  });
+});
+
+describe("isInsufficientPrivilegeError", () => {
+  it("detects PostgreSQL 42501 (insufficient_privilege)", () => {
+    const error = makePostgrestError({
+      message: "Not a member of this workspace",
+      code: "42501",
+    });
+    expect(isInsufficientPrivilegeError(error)).toBe(true);
+  });
+
+  it("returns false for other PostgrestError codes", () => {
+    const error = makePostgrestError({
+      message: "duplicate key",
+      code: "23505",
+    });
+    expect(isInsufficientPrivilegeError(error)).toBe(false);
+  });
+
+  it("returns false for PGRST205 errors", () => {
+    const error = makePostgrestError({
+      message: "Could not find the table",
+      code: "PGRST205",
+    });
+    expect(isInsufficientPrivilegeError(error)).toBe(false);
+  });
+
+  it("returns false for generic errors", () => {
+    const error = new Error("Something went wrong");
+    expect(isInsufficientPrivilegeError(error)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #337

## What

The `GET /api/search` route returned HTTP 500 and reported to Sentry at error level when the `search_pages` RPC raised a PostgreSQL `42501` (insufficient_privilege) error for non-members. This is an expected authorization check from the RPC's `RAISE EXCEPTION`, not an application bug.

## How

Added `isInsufficientPrivilegeError` helper to `src/lib/sentry.ts` that detects PostgreSQL error code `42501`. The search route now checks for this error before falling through to the generic 500 path — returning 403 with `{ error: "Forbidden" }` and skipping the Sentry report entirely. Also added a convention to `.agents/conventions.md` documenting the pattern for handling `42501` in API routes.

## Testing

- Added unit test in `route.test.ts`: verifies that a `42501` error from `search_pages` RPC returns 403 with `"Forbidden"` body
- Added unit tests in `sentry.unit.test.ts`: verifies `isInsufficientPrivilegeError` correctly identifies `42501` errors and rejects other error codes and generic errors
- All 378 existing tests continue to pass
- `pnpm lint && pnpm typecheck && pnpm test` all green