### PR TITLE
feat: persist sidebar page tree expand/collapse state (#329)

### DIFF
--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -17,6 +17,7 @@ import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError, isSchemaNotFoundError } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
+import { usePersistedExpanded } from "@/lib/use-persisted-expanded";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -57,7 +58,6 @@ export function PageTree({ userId }: PageTreeProps) {
   const params = useParams<{ workspaceSlug?: string; pageId?: string }>();
   const [pages, setPages] = useState<Page[]>([]);
   const [loading, setLoading] = useState(true);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [deleteTarget, setDeleteTarget] = useState<TreeNode | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [draggedId, setDraggedId] = useState<string | null>(null);
@@ -73,6 +73,8 @@ export function PageTree({ userId }: PageTreeProps) {
   const workspaceSlug = params.workspaceSlug;
 
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const { expanded, setExpanded, removeFromPersisted } =
+    usePersistedExpanded(workspaceId);
 
   useEffect(() => {
     if (!workspaceSlug) return;
@@ -252,7 +254,7 @@ export function PageTree({ userId }: PageTreeProps) {
       }
       return next;
     });
-  }, []);
+  }, [setExpanded]);
 
   const handleCreate = useCallback(
     async (parentId: string | null) => {
@@ -288,7 +290,7 @@ export function PageTree({ userId }: PageTreeProps) {
 
       router.push(`/${workspaceSlug}/${newPage.id}`);
     },
-    [workspaceId, workspaceSlug, pages, userId, router],
+    [workspaceId, workspaceSlug, pages, userId, router, setExpanded],
   );
 
   const handleDuplicate = useCallback(
@@ -358,6 +360,7 @@ export function PageTree({ userId }: PageTreeProps) {
         ...getDescendantIds(deleteTarget),
       ]);
       setPages((prev) => prev.filter((p) => !removedIds.has(p.id)));
+      removeFromPersisted(removedIds);
 
       if (params.pageId && removedIds.has(params.pageId)) {
         router.push(`/${workspaceSlug}`);

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -19,6 +19,7 @@ const BARE_CATCH_PERMANENT_ALLOWLIST = new Set([
   "src/app/api/health/route.ts", // intentionally silent, monitored externally
   "src/components/members/invite-form.tsx", // clipboard writeText — intentionally silent on permission denied
   "src/components/members/pending-invite-list.tsx", // clipboard writeText — intentionally silent on permission denied
+  "src/lib/use-persisted-expanded.ts", // localStorage read/write — intentionally silent in private browsing / SSR
 ]);
 
 /**

--- a/src/lib/use-persisted-expanded.test.ts
+++ b/src/lib/use-persisted-expanded.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePersistedExpanded } from "./use-persisted-expanded";
+
+const STORAGE_KEY = "memo:tree-expanded:ws-1";
+
+describe("usePersistedExpanded", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns empty set when workspaceId is null", () => {
+    const { result } = renderHook(() => usePersistedExpanded(null));
+    expect(result.current.expanded.size).toBe(0);
+  });
+
+  it("initializes from localStorage on mount", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["a", "b"]));
+    const { result } = renderHook(() => usePersistedExpanded("ws-1"));
+    expect(result.current.expanded).toEqual(new Set(["a", "b"]));
+  });
+
+  it("persists expanded state to localStorage after debounce", async () => {
+    const { result } = renderHook(() => usePersistedExpanded("ws-1"));
+
+    act(() => {
+      result.current.setExpanded(new Set(["x", "y"]));
+    });
+
+    // Not yet persisted (debounce)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    // Advance past debounce
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(new Set(stored)).toEqual(new Set(["x", "y"]));
+  });
+
+  it("supports updater function for setExpanded", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["a"]));
+    const { result } = renderHook(() => usePersistedExpanded("ws-1"));
+
+    act(() => {
+      result.current.setExpanded((prev) => {
+        const next = new Set(prev);
+        next.add("b");
+        return next;
+      });
+    });
+
+    expect(result.current.expanded).toEqual(new Set(["a", "b"]));
+  });
+
+  it("removeFromPersisted removes deleted IDs", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["a", "b", "c"]));
+    const { result } = renderHook(() => usePersistedExpanded("ws-1"));
+
+    act(() => {
+      result.current.removeFromPersisted(new Set(["a", "c"]));
+    });
+
+    expect(result.current.expanded).toEqual(new Set(["b"]));
+
+    // Flush debounce
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toEqual(["b"]);
+  });
+
+  it("reloads state when workspaceId changes", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["a"]));
+    localStorage.setItem(
+      "memo:tree-expanded:ws-2",
+      JSON.stringify(["x", "y"]),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ wsId }: { wsId: string | null }) => usePersistedExpanded(wsId),
+      { initialProps: { wsId: "ws-1" as string | null } },
+    );
+
+    expect(result.current.expanded).toEqual(new Set(["a"]));
+
+    rerender({ wsId: "ws-2" });
+    expect(result.current.expanded).toEqual(new Set(["x", "y"]));
+  });
+
+  it("handles corrupted localStorage gracefully", () => {
+    localStorage.setItem(STORAGE_KEY, "not-json{{{");
+    const { result } = renderHook(() => usePersistedExpanded("ws-1"));
+    expect(result.current.expanded.size).toBe(0);
+  });
+
+  it("filters non-string values from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["a", 123, null, "b"]));
+    const { result } = renderHook(() => usePersistedExpanded("ws-1"));
+    expect(result.current.expanded).toEqual(new Set(["a", "b"]));
+  });
+
+  it("removeFromPersisted is a no-op when IDs are not present", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(["a"]));
+    const { result } = renderHook(() => usePersistedExpanded("ws-1"));
+
+    const before = result.current.expanded;
+    act(() => {
+      result.current.removeFromPersisted(new Set(["z"]));
+    });
+
+    // Same reference — no unnecessary re-render
+    expect(result.current.expanded).toBe(before);
+  });
+});

--- a/src/lib/use-persisted-expanded.ts
+++ b/src/lib/use-persisted-expanded.ts
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY_PREFIX = "memo:tree-expanded:";
+const DEBOUNCE_MS = 300;
+
+function readFromStorage(workspaceId: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_PREFIX + workspaceId);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((v): v is string => typeof v === "string"));
+    }
+    return new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeToStorage(workspaceId: string, ids: Set<string>): void {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY_PREFIX + workspaceId,
+      JSON.stringify([...ids]),
+    );
+  } catch {
+    // Private browsing or quota exceeded — silently ignore
+  }
+}
+
+/**
+ * Manages expand/collapse state for a page tree, persisted to localStorage
+ * per workspace. Returns the same API shape as useState<Set<string>>.
+ *
+ * - Initializes from localStorage when workspaceId becomes available (no flicker).
+ * - Debounces writes to localStorage on state changes.
+ * - Provides a helper to remove deleted page IDs from persisted state.
+ */
+export function usePersistedExpanded(workspaceId: string | null) {
+  const [expanded, setExpandedRaw] = useState<Set<string>>(() => {
+    if (!workspaceId) return new Set<string>();
+    return readFromStorage(workspaceId);
+  });
+
+  // Track previous workspaceId to detect workspace switches during render.
+  const [prevWorkspaceId, setPrevWorkspaceId] = useState(workspaceId);
+
+  // When workspaceId changes, reload from storage. Uses the "setState during
+  // render" pattern recommended by React to avoid cascading effects.
+  if (workspaceId !== prevWorkspaceId) {
+    setPrevWorkspaceId(workspaceId);
+    const restored = workspaceId
+      ? readFromStorage(workspaceId)
+      : new Set<string>();
+    setExpandedRaw(restored);
+  }
+
+  // Debounced persist whenever expanded changes.
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    const timer = setTimeout(() => {
+      writeToStorage(workspaceId, expanded);
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [expanded, workspaceId]);
+
+  // Stable setter that accepts a value or updater function.
+  const setExpanded = useCallback(
+    (updater: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+      setExpandedRaw((prev) =>
+        typeof updater === "function" ? updater(prev) : updater,
+      );
+    },
+    [],
+  );
+
+  // Remove a set of page IDs from persisted state (call after delete).
+  const removeFromPersisted = useCallback(
+    (idsToRemove: Set<string>) => {
+      setExpandedRaw((prev) => {
+        let changed = false;
+        const next = new Set(prev);
+        for (const id of idsToRemove) {
+          if (next.delete(id)) changed = true;
+        }
+        return changed ? next : prev;
+      });
+    },
+    [],
+  );
+
+  return { expanded, setExpanded, removeFromPersisted };
+}


### PR DESCRIPTION
Closes #329

## What

Persists the sidebar page tree expand/collapse state to `localStorage` per workspace, so users don't lose their working context on navigation or page refresh.

## How

- New `usePersistedExpanded` hook (`src/lib/use-persisted-expanded.ts`) manages a `Set<string>` of expanded node IDs backed by `localStorage` with key `memo:tree-expanded:{workspaceId}`.
- Initializes synchronously from `localStorage` in the `useState` initializer to avoid flicker on first paint.
- Debounces writes (300ms) to avoid excessive storage calls during rapid expand/collapse.
- Reloads state when workspace changes (render-phase setState pattern).
- Provides `removeFromPersisted` to clean up deleted page IDs.
- Integrated into `PageTree` component, replacing the plain `useState<Set<string>>(new Set())`.
- Added to the bare-catch allowlist in `sentry.test.ts` (localStorage access can throw in private browsing).

## Testing

- 9 unit tests for the hook covering: initialization from storage, debounced persistence, workspace switching, corrupted data handling, non-string filtering, delete cleanup, and no-op stability.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (382/382 tests).
- No visual changes — this is a behavioral enhancement only.