### PR TITLE
fix: update E2E delete test for soft-delete confirmation dialog (#347)

### DIFF
--- a/e2e/page-crud.spec.ts
+++ b/e2e/page-crud.spec.ts
@@ -190,11 +190,16 @@ test.describe("Page CRUD", () => {
 
     await deleteBtn.click();
 
-    // Confirmation dialog should appear
-    const confirmBtn = page.getByRole("button", { name: /delete|confirm/i }).last();
+    // Soft-delete confirmation dialog should appear with "Move to trash" button
+    const confirmBtn = page.getByRole("button", { name: /move to trash/i });
     await expect(confirmBtn).toBeVisible({ timeout: 3_000 });
     await confirmBtn.click();
 
+    // Wait for the soft-delete to complete
     await page.waitForTimeout(1_000);
+
+    // Verify the page was moved to trash — the Trash section should appear in the sidebar
+    const trashSection = sidebar.getByRole("button", { name: /trash/i });
+    await expect(trashSection).toBeVisible({ timeout: 5_000 });
   });
 });


### PR DESCRIPTION
Closes #347

## What

The E2E test `user can delete a page with confirmation` in `page-crud.spec.ts` fails because PR #346 (soft-delete pages with trash bin and restore) changed the delete confirmation dialog. The confirmation button text changed from "Delete"/"Confirm" to "Move to trash", so the test locator `getByRole("button", { name: /delete|confirm/i })` no longer matches any visible button.

## How

Updated the confirmation button locator from `/delete|confirm/i` to `/move to trash/i` to match the new soft-delete dialog. Added a verification step that checks the Trash section appears in the sidebar after the page is moved to trash, confirming the soft-delete flow works end-to-end.

## Testing

- The updated E2E test now targets the correct "Move to trash" button in the confirmation dialog
- After clicking the confirmation, the test verifies the sidebar Trash section becomes visible, confirming the page was soft-deleted
- `pnpm lint && pnpm typecheck && pnpm test` all pass (388 tests)