### PR TITLE
fix: use WORKSPACE_LIMIT constant in AtLimit story (#361)

### DIFF
--- a/src/components/sidebar/create-workspace-dialog.stories.tsx
+++ b/src/components/sidebar/create-workspace-dialog.stories.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { WORKSPACE_LIMIT } from "@/lib/workspace";
 
 const meta: Meta = {
   title: "Sidebar/CreateWorkspaceDialog",
@@ -60,7 +61,7 @@ export const AtLimit: Story = {
         <DialogHeader>
           <DialogTitle>Create workspace</DialogTitle>
           <DialogDescription>
-            You&apos;ve reached the limit of 5 workspaces.
+            You&apos;ve reached the limit of {WORKSPACE_LIMIT} workspaces.
           </DialogDescription>
         </DialogHeader>
         <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Closes #361

## What

The `AtLimit` Storybook story for `CreateWorkspaceDialog` hardcoded "limit of 5 workspaces" but the actual workspace limit is 3 (`WORKSPACE_LIMIT` in `src/lib/workspace.ts`). The story text was inconsistent with the real component, which correctly uses the constant.

## How

Imported `WORKSPACE_LIMIT` from `@/lib/workspace` in the story file and replaced the hardcoded `5` with the constant via JSX interpolation. This keeps the story in sync with any future changes to the limit.

## Testing

- Verified `pnpm lint`, `pnpm typecheck`, and `pnpm test` all pass (48 test files, 406 tests)
- Built Storybook and confirmed the AtLimit story renders correctly with the updated text
- Checked visual regression baselines — the existing baseline only captures the closed dialog (trigger button), so no baseline update was needed