### PR TITLE
fix: downgrade transient network errors in version save to warning level (#364)

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -32,6 +32,7 @@ import type {
   SerializedEditorState,
 } from "lexical";
 import { lazyCaptureException } from "@/lib/capture";
+import { isTransientNetworkError } from "@/lib/sentry";
 import { editorTheme } from "@/components/editor/theme";
 import { SlashCommandPlugin } from "@/components/editor/slash-command-plugin";
 import { FloatingToolbarPlugin } from "@/components/editor/floating-toolbar-plugin";
@@ -223,7 +224,13 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ content: json }),
-            }).catch((err) => lazyCaptureException(err));
+            }).catch((err) => {
+              if (err instanceof Error && isTransientNetworkError(err)) {
+                lazyCaptureException(err, { level: "warning" });
+              } else {
+                lazyCaptureException(err);
+              }
+            });
           }
         } else {
           lazyCaptureException(error);

--- a/src/components/editor/version-save-error-handling.test.ts
+++ b/src/components/editor/version-save-error-handling.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for #364: version save fetch must downgrade transient
+ * network errors to warning level instead of reporting at error level.
+ *
+ * This is a static analysis test that verifies the editor source code
+ * contains the correct error handling pattern for the version save fetch.
+ */
+describe("version save error handling", () => {
+  const editorSource = readFileSync(
+    join(__dirname, "editor.tsx"),
+    "utf-8",
+  );
+
+  it("imports isTransientNetworkError", () => {
+    expect(editorSource).toContain("isTransientNetworkError");
+  });
+
+  it("does not call lazyCaptureException directly in version save catch without checking for transient errors", () => {
+    // The old buggy pattern: .catch((err) => lazyCaptureException(err))
+    // on the version save fetch. Verify this single-expression catch
+    // pattern is NOT used for the /versions endpoint fetch.
+    const versionFetchRegex =
+      /fetch\([^)]*\/versions[^)]*\)[\s\S]*?\.catch\(\(err\)\s*=>\s*lazyCaptureException\(err\)\s*\)/;
+    expect(editorSource).not.toMatch(versionFetchRegex);
+  });
+
+  it("downgrades transient network errors to warning level in version save catch", () => {
+    // Verify the catch handler checks isTransientNetworkError and passes
+    // level: "warning" for transient errors.
+    expect(editorSource).toContain('lazyCaptureException(err, { level: "warning" })');
+  });
+});


### PR DESCRIPTION
Closes #364

## What

The version save fetch (`POST /api/pages/:id/versions`) reported transient network errors (`TypeError: Failed to fetch`) to Sentry at error level. This is a fire-and-forget background operation that runs every 5 minutes — the primary page save via Supabase PATCH succeeds before the version snapshot is attempted. Transient network failures here are not application bugs and should not trigger error-level alerts.

## How

Added `isTransientNetworkError` check to the version save fetch's `.catch()` handler. When the error is a transient network failure, it is now reported at `warning` level instead of the default `error` level. This matches the existing convention used by `captureSupabaseError` and documented in `.agents/conventions.md`.

## Testing

Added a static analysis regression test (`version-save-error-handling.test.ts`) that verifies:
- The editor imports `isTransientNetworkError`
- The version save fetch catch handler does not use the old single-expression pattern (`lazyCaptureException(err)`) without checking for transient errors
- The catch handler includes `lazyCaptureException(err, { level: "warning" })` for transient errors

All checks pass: `pnpm lint && pnpm typecheck && pnpm test` (409 tests, 0 failures).