### PR TITLE
fix: backfill metrics snapshots and restructure daily-metrics prompt

### DIFF
--- a/.ona/automations/daily-metrics.yaml
+++ b/.ona/automations/daily-metrics.yaml
@@ -14,33 +14,17 @@ action:
     steps:
         - agent:
             prompt: |
-                You are the Metrics Collector. Gather daily project stats, commit them, and open a PR.
+                You are the Metrics Collector. Your output is a single JSON file that MUST match the schema below exactly. No extra fields, no missing fields, no renamed fields.
 
-                ## Data Collection (on latest main)
+                ## 1. Required Output Schema
 
-                1. Lines of code: run `npx cloc src/ supabase/migrations/ --json`. Extract total and by-language.
-                2. File count: count files in src/ excluding node_modules, .next, test files.
-                3. PRs today: use gh pr list to count opened and merged today, and currently open.
-                4. Test coverage: run `pnpm test:coverage` then read `coverage/coverage-summary.json`.
-                   Extract the value at `total.statements.pct` (a number like 72.5).
-                   If the command fails or the file is missing, set to null.
-                5. CI pass rate: use `gh run list --limit 20 --json conclusion` and calculate success %.
-                6. GitHub Issues: use gh issue list with label filters to count issues per status.
-                7. Commits today: `git log --oneline --since="today" | wc -l`
-                8. Autonomous PR ratio:
-                   - Total merged PRs: `gh pr list --state merged --limit 500 --json number --jq 'length'`
-                   - User-prompted PRs: `gh pr list --state merged --label "ona-user" --limit 500 --json number --jq 'length'`
-                   - Calculate: `autonomous_pct = round(((total - ona_user) / total) * 100)`
+                The file MUST be `metrics/daily/YYYY-MM-DD.json` with this EXACT structure:
 
-                ## Output
-
-                Create a branch: `chore/metrics-YYYY-MM-DD`
-
-                Create `metrics/daily/YYYY-MM-DD.json`:
+                ```json
                 {
                   "date": "YYYY-MM-DD",
                   "day_number": N,
-                  "loc": { "total": N, "delta": N, "by_language": { "TypeScript": N } },
+                  "loc": { "total": N, "delta": N, "by_language": { "TypeScript": N, "CSS": N } },
                   "files": { "total": N, "delta": N },
                   "prs": { "total": N, "delta": N, "currently_open": N },
                   "commits": { "total": N, "delta": N },
@@ -51,29 +35,112 @@ action:
                   "human_minutes": null,
                   "agent_minutes": null
                 }
+                ```
 
-                Day 1 was 2026-04-13. Calculate day_number from that.
+                Field definitions (read these carefully):
+                - `day_number`: Days since project start. Day 1 = 2026-04-13.
+                - `prs.total`: Cumulative PRs merged since project start (all time).
+                - `prs.delta`: PRs merged TODAY only (since midnight UTC).
+                - `prs.currently_open`: PRs in open state right now.
+                - `commits.total`: Cumulative commits on main (all time).
+                - `commits.delta`: Commits made TODAY only (since midnight UTC).
+                - `loc.total` / `files.total`: Current totals in the codebase right now.
+                - `loc.delta` / `files.delta`: Difference from yesterday's snapshot.
+                - `autonomous_pct`: Percentage of merged PRs that were NOT labeled `ona-user`.
+                - `test_coverage_pct`: Statement coverage from Vitest, or null if unavailable.
+                - `human_minutes` / `agent_minutes`: Always null (filled manually).
 
-                All top-level numeric fields are CUMULATIVE TOTALS, not daily counts:
-                - loc.total: total lines of code in src/ right now
-                - files.total: total files in src/ right now
-                - prs.total: total PRs merged since project start (gh pr list --state merged --json mergedAt | count all)
-                - commits.total: total commits on main (git rev-list --count HEAD)
+                ## 2. Data Collection Commands
 
-                The "delta" field is today's change vs yesterday's total:
-                - loc.delta = loc.total - yesterday's loc.total
-                - files.delta = files.total - yesterday's files.total
-                - prs.delta = PRs merged today only
-                - commits.delta = commits made today only
+                Run these on latest main. Use the EXACT commands — do not improvise alternatives.
 
-                For delta fields, read yesterday's file from metrics/daily/. If none exists, delta = total.
-                human_minutes and agent_minutes are null — filled manually.
+                **Lines of code:**
+                ```
+                npx cloc src/ supabase/migrations/ --json
+                ```
+                Extract `SUM.code` for total, and per-language `.code` values.
 
-                ## Commit and PR
+                **File count:**
+                ```
+                find src/ -type f ! -path '*/node_modules/*' ! -path '*/.next/*' ! -name '*.test.*' ! -name '*.spec.*' ! -name '*.stories.*' | wc -l
+                ```
+
+                **PRs — cumulative merged (all time):**
+                ```
+                gh pr list --state merged --limit 500 --json number --jq 'length'
+                ```
+
+                **PRs — merged today (UTC):**
+                ```
+                gh pr list --state merged --limit 500 --json mergedAt --jq '[.[] | select(.mergedAt >= "YYYY-MM-DDT00:00:00Z")] | length'
+                ```
+                Replace YYYY-MM-DD with today's date.
+
+                **PRs — currently open:**
+                ```
+                gh pr list --state open --json number --jq 'length'
+                ```
+
+                **Commits — cumulative:**
+                ```
+                git rev-list --count HEAD
+                ```
+
+                **Commits — today (UTC):**
+                ```
+                git log --oneline --since="YYYY-MM-DDT00:00:00Z" --format="%H" | wc -l
+                ```
+                Replace YYYY-MM-DD with today's date.
+
+                **Autonomous PR ratio:**
+                ```
+                TOTAL=$(gh pr list --state merged --limit 500 --json number --jq 'length')
+                ONA_USER=$(gh pr list --state merged --label "ona-user" --limit 500 --json number --jq 'length')
+                ```
+                Calculate: `autonomous_pct = round(((TOTAL - ONA_USER) / TOTAL) * 100)`. If TOTAL is 0, set to 0.
+
+                **Test coverage:**
+                ```
+                pnpm test:coverage
+                ```
+                Then read `coverage/coverage-summary.json` → `total.statements.pct`. If the command fails or the file is missing, set to null.
+
+                **CI pass rate:**
+                ```
+                gh run list --limit 20 --json conclusion
+                ```
+                Calculate: `round((success_count / total_count) * 100)`.
+
+                **GitHub Issues:**
+                ```
+                gh issue list --label "status:backlog" --state open --json number --jq 'length'
+                gh issue list --label "status:in-progress" --state open --json number --jq 'length'
+                gh issue list --label "status:in-review" --state open --json number --jq 'length'
+                gh issue list --label "status:done" --state closed --json number --jq 'length'
+                ```
+
+                **Delta fields (loc, files):**
+                Read yesterday's snapshot from `metrics/daily/`. If no previous file exists, delta = total.
+                - `loc.delta = loc.total - yesterday.loc.total`
+                - `files.delta = files.total - yesterday.files.total`
+
+                ## 3. Validation
+
+                After generating the JSON, verify it before committing:
+                1. Confirm ALL of these fields exist: `date`, `day_number`, `loc.total`, `loc.delta`, `loc.by_language`, `files.total`, `files.delta`, `prs.total`, `prs.delta`, `prs.currently_open`, `commits.total`, `commits.delta`, `test_coverage_pct`, `ci_pass_rate_pct`, `autonomous_pct`, `issues.backlog`, `issues.in_progress`, `issues.in_review`, `issues.done`, `human_minutes`, `agent_minutes`.
+                2. Confirm `prs.total >= prs.delta` (cumulative must be >= daily).
+                3. Confirm `commits.total >= commits.delta`.
+                4. Confirm `prs.total` is >= yesterday's `prs.total` (cumulative never decreases).
+                5. Confirm `commits.total` is >= yesterday's `commits.total`.
+                6. If any check fails, re-collect the data for that field.
+
+                ## 4. Commit and PR
+
+                Create branch: `chore/metrics-YYYY-MM-DD`
 
                 1. Commit: `chore: daily metrics snapshot YYYY-MM-DD`
                 2. Push the branch.
                 3. Open a PR:
                    - Title: `chore: daily metrics snapshot YYYY-MM-DD`
-                   - Body: summary of today's stats
+                   - Body: summary table of today's stats
                 4. The PR Reviewer will auto-merge chore PRs.

--- a/metrics/daily/2026-04-14.json
+++ b/metrics/daily/2026-04-14.json
@@ -3,10 +3,11 @@
   "day_number": 2,
   "loc": { "total": 217, "delta": 217, "by_language": { "TypeScript": 212, "CSS": 5 } },
   "files": { "total": 15, "delta": 15 },
-  "prs": { "total": 14, "delta": 14, "currently_open": 0 },
-  "commits": { "total": 37, "delta": 37 },
+  "prs": { "total": 17, "delta": 17, "currently_open": 0 },
+  "commits": { "total": 40, "delta": 40 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
+  "autonomous_pct": 100,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 0 },
   "human_minutes": null,
   "agent_minutes": null

--- a/metrics/daily/2026-04-15.json
+++ b/metrics/daily/2026-04-15.json
@@ -1,11 +1,13 @@
 {
   "date": "2026-04-15",
+  "day_number": 3,
   "loc": { "total": 217, "delta": 0, "by_language": { "TypeScript": 212, "CSS": 5 } },
   "files": { "total": 15, "delta": 0 },
-  "prs": { "opened_today": 2, "merged_today": 1, "currently_open": 1 },
-  "commits_today": 1,
+  "prs": { "total": 54, "delta": 37, "currently_open": 0 },
+  "commits": { "total": 77, "delta": 37 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
+  "autonomous_pct": 100,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 0 },
   "human_minutes": null,
   "agent_minutes": null

--- a/metrics/daily/2026-04-16.json
+++ b/metrics/daily/2026-04-16.json
@@ -1,11 +1,13 @@
 {
   "date": "2026-04-16",
+  "day_number": 4,
   "loc": { "total": 7848, "delta": 7631, "by_language": { "TypeScript": 7708, "CSS": 140 } },
   "files": { "total": 76, "delta": 61 },
-  "prs": { "opened_today": 0, "merged_today": 0, "currently_open": 0 },
-  "commits_today": 0,
+  "prs": { "total": 89, "delta": 35, "currently_open": 1 },
+  "commits": { "total": 112, "delta": 35 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
+  "autonomous_pct": 87,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 0 },
   "human_minutes": null,
   "agent_minutes": null

--- a/metrics/daily/2026-04-17.json
+++ b/metrics/daily/2026-04-17.json
@@ -1,11 +1,13 @@
 {
   "date": "2026-04-17",
+  "day_number": 5,
   "loc": { "total": 10410, "delta": 2562, "by_language": { "TypeScript": 10224, "CSS": 186 } },
   "files": { "total": 76, "delta": 0 },
-  "prs": { "opened_today": 9, "merged_today": 10, "currently_open": 0 },
-  "commits_today": 10,
+  "prs": { "total": 132, "delta": 43, "currently_open": 0 },
+  "commits": { "total": 155, "delta": 43 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
+  "autonomous_pct": 86,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 30 },
   "human_minutes": null,
   "agent_minutes": null

--- a/metrics/daily/2026-04-18.json
+++ b/metrics/daily/2026-04-18.json
@@ -1,11 +1,13 @@
 {
   "date": "2026-04-18",
+  "day_number": 6,
   "loc": { "total": 12202, "delta": 1792, "by_language": { "TypeScript": 12013, "CSS": 189 } },
   "files": { "total": 87, "delta": 11 },
-  "prs": { "opened_today": 7, "merged_today": 7, "currently_open": 0 },
-  "commits_today": 7,
+  "prs": { "total": 143, "delta": 11, "currently_open": 0 },
+  "commits": { "total": 166, "delta": 11 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
+  "autonomous_pct": 86,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 88 },
   "human_minutes": null,
   "agent_minutes": null

--- a/metrics/daily/2026-04-19.json
+++ b/metrics/daily/2026-04-19.json
@@ -1,11 +1,13 @@
 {
   "date": "2026-04-19",
+  "day_number": 7,
   "loc": { "total": 12331, "delta": 129, "by_language": { "TypeScript": 12142, "CSS": 189 } },
   "files": { "total": 87, "delta": 0 },
-  "prs": { "opened_today": 4, "merged_today": 4, "currently_open": 0 },
-  "commits_today": 4,
+  "prs": { "total": 155, "delta": 12, "currently_open": 0 },
+  "commits": { "total": 178, "delta": 12 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
+  "autonomous_pct": 85,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 92 },
   "human_minutes": null,
   "agent_minutes": null

--- a/metrics/daily/2026-04-20.json
+++ b/metrics/daily/2026-04-20.json
@@ -1,11 +1,13 @@
 {
   "date": "2026-04-20",
+  "day_number": 8,
   "loc": { "total": 12592, "delta": 261, "by_language": { "TypeScript": 12403, "CSS": 189 } },
   "files": { "total": 90, "delta": 3 },
-  "prs": { "opened_today": 2, "merged_today": 1, "currently_open": 2 },
-  "commits_today": 1,
+  "prs": { "total": 182, "delta": 27, "currently_open": 0 },
+  "commits": { "total": 205, "delta": 27 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 100,
+  "autonomous_pct": 82,
   "issues": { "backlog": 1, "in_progress": 0, "in_review": 0, "done": 95 },
   "human_minutes": null,
   "agent_minutes": null

--- a/metrics/daily/2026-04-21.json
+++ b/metrics/daily/2026-04-21.json
@@ -1,11 +1,13 @@
 {
   "date": "2026-04-21",
+  "day_number": 9,
   "loc": { "total": 18581, "delta": 5989, "by_language": { "TypeScript": 18392, "CSS": 189 } },
   "files": { "total": 108, "delta": 18 },
-  "prs": { "opened_today": 0, "merged_today": 0, "currently_open": 0 },
-  "commits_today": 12,
+  "prs": { "total": 210, "delta": 28, "currently_open": 3 },
+  "commits": { "total": 231, "delta": 26 },
   "test_coverage_pct": null,
   "ci_pass_rate_pct": 90,
+  "autonomous_pct": 83,
   "issues": { "backlog": 0, "in_progress": 0, "in_review": 0, "done": 30 },
   "human_minutes": null,
   "agent_minutes": null


### PR DESCRIPTION
Closes #371

## What changed

**Backfilled all 8 daily snapshots (Apr 14–21)** with correct values computed from the GitHub API and git history:
- Added missing fields: `day_number`, `autonomous_pct`
- Fixed schema: `prs.total`/`prs.delta` and `commits.total`/`commits.delta` (was `opened_today`/`merged_today`/`commits_today`)
- Corrected undercounted PR and commit numbers on every day

**Restructured the daily-metrics automation prompt** to prevent future drift:
- Schema definition moved to top of prompt (was buried after collection steps, causing the agent to infer a simpler schema)
- Explicit `gh` and `git` commands for cumulative vs daily counts — no room for improvisation
- Added validation step: field presence check, cumulative >= delta invariant, monotonic totals check

**Synced updated automation to live Ona registry.**

## Corrected values

| Date | Day | prs.total | prs.delta | commits.total | commits.delta | autonomous_pct |
|---|---|---|---|---|---|---|
| Apr 14 | 2 | 17 | 17 | 40 | 40 | 100% |
| Apr 15 | 3 | 54 | 37 | 77 | 37 | 100% |
| Apr 16 | 4 | 89 | 35 | 112 | 35 | 87% |
| Apr 17 | 5 | 132 | 43 | 155 | 43 | 86% |
| Apr 18 | 6 | 143 | 11 | 166 | 11 | 86% |
| Apr 19 | 7 | 155 | 12 | 178 | 12 | 85% |
| Apr 20 | 8 | 182 | 27 | 205 | 27 | 82% |
| Apr 21 | 9 | 210 | 28 | 231 | 26 | 83% |