### PR TITLE
fix: handle RLS violations in API route outer catch blocks

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1101,6 +1101,26 @@ if (error) {
 
 Never return 500 for `42501` — it inflates Sentry error counts with non-bugs.
 
+### Outer catch blocks must also check for 42501
+
+Supabase can throw RLS violations as exceptions (e.g. via `.single()` or async
+rejection) instead of returning them in `{ data, error }`. The outer `catch`
+block in every API route must check for `isInsufficientPrivilegeError` before
+falling through to `Sentry.captureException`:
+
+```typescript
+} catch (error) {
+  if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  Sentry.captureException(error);
+  return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+}
+```
+
+This prevents 42501 errors from being reported at error level in Sentry and
+ensures the client receives 403 instead of 500.
+
 ## This file evolves
 
 When you discover a new pattern that should be replicated, or an anti-pattern that

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { createClient } from "@/lib/supabase/server";
-import { captureSupabaseError } from "@/lib/sentry";
+import { captureSupabaseError, isInsufficientPrivilegeError } from "@/lib/sentry";
 
 export async function DELETE() {
   if (
@@ -42,6 +42,9 @@ export async function DELETE() {
 
     return NextResponse.json({ ok: true });
   } catch (error) {
+    if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
     Sentry.captureException(error);
     return NextResponse.json(
       { error: "Internal server error" },

--- a/src/app/api/pages/[pageId]/versions/[versionId]/route.ts
+++ b/src/app/api/pages/[pageId]/versions/[versionId]/route.ts
@@ -41,6 +41,9 @@ export async function GET(
 
     return NextResponse.json({ version: data });
   } catch (error) {
+    if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
     Sentry.captureException(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
@@ -132,6 +135,9 @@ export async function POST(
 
     return NextResponse.json({ restored: true, content: version.content });
   } catch (error) {
+    if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
     Sentry.captureException(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/src/app/api/pages/[pageId]/versions/route.test.ts
+++ b/src/app/api/pages/[pageId]/versions/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 
 // Mock Sentry
 vi.mock("@sentry/nextjs", () => ({
@@ -20,12 +21,27 @@ function createChain(result: { data: unknown; error: unknown }) {
   return new Proxy(chain, handler);
 }
 
+// Chainable query builder that throws when awaited
+function createThrowingChain(error: Error) {
+  const chain: Record<string, unknown> = {};
+  const handler: ProxyHandler<Record<string, unknown>> = {
+    get(_target, prop: string) {
+      if (prop === "then") {
+        return (_resolve: unknown, reject: (e: Error) => void) => reject(error);
+      }
+      return () => new Proxy(chain, handler);
+    },
+  };
+  return new Proxy(chain, handler);
+}
+
 let listResult: { data: unknown; error: unknown } = { data: [], error: null };
 let dedupResult: { data: unknown; error: unknown } = { data: null, error: null };
 let insertResult: { data: unknown; error: unknown } = {
   data: { id: "new-version-id", created_at: "2026-04-21T10:00:00Z" },
   error: null,
 };
+let throwOnInsert: Error | null = null;
 
 const mockGetUser = vi.fn();
 let callIndex = 0;
@@ -40,7 +56,10 @@ vi.mock("@/lib/supabase/server", () => ({
         if (idx === 0) return createChain(listResult);
         return createChain(dedupResult);
       },
-      insert: () => createChain(insertResult),
+      insert: () => {
+        if (throwOnInsert) return createThrowingChain(throwOnInsert);
+        return createChain(insertResult);
+      },
     }),
   }),
 }));
@@ -61,6 +80,7 @@ const mockParams = Promise.resolve({ pageId: "page-123" });
 beforeEach(() => {
   vi.clearAllMocks();
   callIndex = 0;
+  throwOnInsert = null;
   mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
   listResult = { data: [], error: null };
   dedupResult = { data: null, error: null };
@@ -164,5 +184,30 @@ describe("POST /api/pages/[pageId]/versions", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.skipped).toBe(true);
+  });
+
+  it("returns 403 when RLS violation is thrown as exception (MEMO-M regression)", async () => {
+    // Simulate Supabase throwing a 42501 error as an exception
+    // instead of returning it in { data, error }
+    const rlsError = Object.assign(
+      new Error("new row violates row-level security policy for table \"page_versions\""),
+      { code: "42501", details: null, hint: null },
+    );
+    throwOnInsert = rlsError;
+    // First select = dedup check (no existing version)
+    listResult = { data: null, error: null };
+
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions", {
+        method: "POST",
+        body: JSON.stringify({ content: { root: { children: [] } } }),
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Forbidden");
+    // Must NOT report to Sentry at error level
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/pages/[pageId]/versions/route.ts
+++ b/src/app/api/pages/[pageId]/versions/route.ts
@@ -38,6 +38,9 @@ export async function GET(
 
     return NextResponse.json({ versions: data ?? [] });
   } catch (error) {
+    if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
     Sentry.captureException(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
@@ -103,6 +106,9 @@ export async function POST(
 
     return NextResponse.json({ version: data });
   } catch (error) {
+    if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
     Sentry.captureException(error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -59,6 +59,9 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ results: data ?? [] });
   } catch (error) {
+    if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
     Sentry.captureException(error);
     return NextResponse.json(
       { error: "Internal server error" },


### PR DESCRIPTION
## Summary

Sentry issue [MEMO-M](https://ona-2j.sentry.io/issues/MEMO-M) reports `42501` (insufficient_privilege) errors at error level from `POST /api/pages/:id/versions`. The route already checks `isInsufficientPrivilegeError` in the `if (error)` block, but Supabase can also throw RLS violations as exceptions (e.g. via `.single()` or async rejection), bypassing that check and hitting the outer `catch` block which calls `Sentry.captureException` at error level and returns 500.

Closes #374

## Root Cause

The outer `catch` blocks in all API routes used `Sentry.captureException(error)` unconditionally. When a `42501` error was thrown as an exception rather than returned in `{ data, error }`, it was:
1. Reported to Sentry at error level (inflating error counts with non-bugs)
2. Returned to the client as 500 instead of 403

## Changes

- **`src/app/api/pages/[pageId]/versions/route.ts`** — Add `isInsufficientPrivilegeError` check to both GET and POST outer catch blocks
- **`src/app/api/pages/[pageId]/versions/[versionId]/route.ts`** — Same fix for GET and POST outer catch blocks
- **`src/app/api/search/route.ts`** — Same fix for GET outer catch block
- **`src/app/api/account/route.ts`** — Same fix for DELETE outer catch block (also added missing `isInsufficientPrivilegeError` import)
- **`src/app/api/pages/[pageId]/versions/route.test.ts`** — Regression test: simulates 42501 thrown as exception, verifies 403 response and no `Sentry.captureException` call
- **`.agents/conventions.md`** — Documents the outer catch block pattern for 42501 handling

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅  
- `pnpm test` ✅ (422 tests pass, including new regression test)