### PR TITLE
fix: replace arbitrary text-[10px] with text-xs in focus mode hint (#376)

### DIFF
--- a/src/components/sidebar/focus-mode-hint-design-spec.test.ts
+++ b/src/components/sidebar/focus-mode-hint-design-spec.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression test for issue #376: arbitrary font size text-[10px] used
+ * instead of the typography scale minimum text-xs.
+ */
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+describe("focus-mode-hint design spec compliance", () => {
+  const source = readSource("./focus-mode-hint.tsx");
+
+  it("does not use arbitrary font sizes", () => {
+    // Design spec: "No font sizes outside the typography scale."
+    // The typography scale is: text-xs, text-sm, text-lg, text-xl, text-2xl, text-3xl.
+    // Arbitrary values like text-[10px] are not allowed.
+    const arbitraryFontSize = /text-\[\d+px\]/;
+    expect(source).not.toMatch(arbitraryFontSize);
+  });
+
+  it("kbd element uses text-xs from the typography scale", () => {
+    // The keyboard shortcut label should use text-xs (12px), the smallest
+    // allowed size in the typography scale.
+    expect(source).toContain("text-xs text-white/30");
+  });
+});
+
+describe("focus-mode-hint story design spec compliance", () => {
+  const source = readSource("./focus-mode-hint.stories.tsx");
+
+  it("does not use arbitrary font sizes", () => {
+    const arbitraryFontSize = /text-\[\d+px\]/;
+    expect(source).not.toMatch(arbitraryFontSize);
+  });
+});

--- a/src/components/sidebar/focus-mode-hint.stories.tsx
+++ b/src/components/sidebar/focus-mode-hint.stories.tsx
@@ -21,7 +21,7 @@ function HintButton({ shortcut }: { shortcut: string }) {
       >
         <Minimize2 className="h-3 w-3" />
         Exit focus mode
-        <kbd className="ml-1 text-[10px] text-white/30">{shortcut}</kbd>
+        <kbd className="ml-1 text-xs text-white/30">{shortcut}</kbd>
       </Button>
     </div>
   );

--- a/src/components/sidebar/focus-mode-hint.tsx
+++ b/src/components/sidebar/focus-mode-hint.tsx
@@ -68,7 +68,7 @@ function FocusModeHintInner() {
       >
         <Minimize2 className="h-3 w-3" />
         Exit focus mode
-        <kbd className="ml-1 text-[10px] text-white/30">{shortcutLabel}</kbd>
+        <kbd className="ml-1 text-xs text-white/30">{shortcutLabel}</kbd>
       </Button>
     </div>
   );


### PR DESCRIPTION
Closes #376

## What

The `<kbd>` element in the focus mode hint button used `text-[10px]`, an arbitrary font size outside the design spec typography scale. The typography scale minimum is `text-xs` (12px), and the design spec explicitly prohibits arbitrary font sizes.

## How

Replaced `text-[10px]` with `text-xs` on the `<kbd>` shortcut label in both `focus-mode-hint.tsx` and `focus-mode-hint.stories.tsx`.

## Testing

Added `focus-mode-hint-design-spec.test.ts` — a static analysis regression test that:
- Verifies no arbitrary font sizes (`text-[Npx]`) appear in the component or story source
- Confirms the `<kbd>` element uses `text-xs` from the typography scale

All 432 Vitest tests pass. Visual regression baselines for the FocusModeHint stories exist but could not be regenerated in this environment (Playwright browser unavailable) — the font size change from 10px to 12px will cause a minor baseline diff that needs updating.