### PR TITLE
fix: filter React/Lexical removeChild DOM conflict from Sentry (#377)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,7 +4,14 @@
 // first user interaction in practice.
 let captureTransition: ((url: string, type: string) => void) | null = null;
 
-import("@sentry/nextjs").then((Sentry) => {
+import("@sentry/nextjs").then(async (Sentry) => {
+  // Dynamic import keeps sentry.ts out of the shared framework chunk.
+  // The filter functions only inspect the event object — they have no
+  // Sentry runtime dependency.
+  const { isNextjsInternalNoise, isReactLexicalDomConflict } = await import(
+    "@/lib/sentry"
+  );
+
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
@@ -20,6 +27,12 @@ import("@sentry/nextjs").then((Sentry) => {
     enableLogs: true,
 
     integrations: [Sentry.replayIntegration()],
+
+    beforeSend(event) {
+      if (isNextjsInternalNoise(event)) return null;
+      if (isReactLexicalDomConflict(event)) return null;
+      return event;
+    },
   });
 
   captureTransition = Sentry.captureRouterTransitionStart;

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -46,6 +46,56 @@ export function isNextjsInternalNoise(event: ErrorEvent): boolean {
 }
 
 /**
+ * Returns true when the Sentry event is a `NotFoundError` from React's DOM
+ * reconciliation conflicting with Lexical's direct DOM manipulation.
+ *
+ * Lexical manages contentEditable DOM nodes directly for performance. When
+ * React's commit phase runs concurrently, it may try to `removeChild` a node
+ * that Lexical already removed or reparented, producing a `NotFoundError`.
+ * The stack trace contains only React internals — no first-party frames.
+ *
+ * These errors are harmless (the editor continues working) and not actionable,
+ * so they should be dropped from Sentry.
+ *
+ * See: https://github.com/facebook/lexical/issues/4254
+ */
+export function isReactLexicalDomConflict(event: ErrorEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) return false;
+
+  return values.some(
+    (ex) =>
+      ex.type === "NotFoundError" &&
+      typeof ex.value === "string" &&
+      ex.value.includes("removeChild") &&
+      hasNoFirstPartyFrames(ex.stacktrace?.frames),
+  );
+}
+
+/**
+ * Returns true when every frame in the stack trace is from a third-party
+ * bundle (React internals, Webpack runtime, etc.) — i.e. no application code.
+ * An empty or missing frame list also returns true (minified stacks often
+ * lack source info).
+ */
+function hasNoFirstPartyFrames(
+  frames: Array<{ filename?: string; abs_path?: string }> | undefined,
+): boolean {
+  if (!frames || frames.length === 0) return true;
+
+  return frames.every((frame) => {
+    const filename = frame.filename ?? frame.abs_path ?? "";
+    // First-party frames reference source files under src/ or the app root.
+    // Third-party frames are webpack chunks, node_modules, or anonymous.
+    return (
+      !filename.includes("/src/") &&
+      !filename.includes("src/") &&
+      !filename.startsWith("app://")
+    );
+  });
+}
+
+/**
  * True when PostgREST cannot find a table in its schema cache (PGRST205).
  * This happens when a migration hasn't been applied or the schema cache is
  * stale. It's a deployment issue, not an application bug, so it should be

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -14,6 +14,7 @@ import {
   isInsufficientPrivilegeError,
   captureSupabaseError,
   isNextjsInternalNoise,
+  isReactLexicalDomConflict,
 } from "./sentry";
 
 function makePostgrestError(
@@ -283,5 +284,154 @@ describe("isNextjsInternalNoise", () => {
   it("returns false when exception value is undefined", () => {
     const event = makeSentryEvent([{ type: "Error" }]);
     expect(isNextjsInternalNoise(event)).toBe(false);
+  });
+});
+
+/**
+ * Helper that builds a Sentry ErrorEvent with stacktrace support.
+ * Extends the simpler `makeSentryEvent` for tests that need frame data.
+ */
+function makeSentryEventWithStack(
+  exceptionValues: Array<{
+    value?: string;
+    type?: string;
+    stacktrace?: {
+      frames?: Array<{ filename?: string; abs_path?: string }>;
+    };
+  }>,
+): ErrorEvent {
+  return {
+    type: undefined,
+    exception: { values: exceptionValues },
+  } as ErrorEvent;
+}
+
+describe("isReactLexicalDomConflict", () => {
+  it("detects NotFoundError with removeChild and no first-party frames", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: {
+          frames: [
+            { filename: "https://example.com/_next/static/chunks/1431zjw_sha2v.js" },
+            { filename: "https://example.com/_next/static/chunks/1431zjw_sha2v.js" },
+          ],
+        },
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(true);
+  });
+
+  it("detects the error with empty frames (fully minified stack)", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: { frames: [] },
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(true);
+  });
+
+  it("detects the error with no stacktrace at all", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(true);
+  });
+
+  it("returns false when first-party frames are present (src/)", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: {
+          frames: [
+            { filename: "https://example.com/_next/static/chunks/1431zjw_sha2v.js" },
+            { filename: "app:///src/components/editor/editor.tsx" },
+          ],
+        },
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("returns false when first-party frames use app:// scheme", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: {
+          frames: [
+            { abs_path: "app:///_next/static/chunks/main.js" },
+          ],
+        },
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("returns false for NotFoundError without removeChild", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value: "The object can not be found here.",
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("returns false for removeChild error with a different error type", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "DOMException",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("returns false for unrelated errors", () => {
+    const event = makeSentryEvent([
+      { type: "TypeError", value: "Cannot read properties of undefined" },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("returns false when exception values are empty", () => {
+    const event = makeSentryEvent([]);
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("returns false when exception is missing", () => {
+    const event = { type: undefined } as ErrorEvent;
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("detects the error in chained exceptions", () => {
+    const event = makeSentryEventWithStack([
+      { type: "Error", value: "Some wrapper error" },
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: {
+          frames: [
+            { filename: "https://example.com/_next/static/chunks/framework.js" },
+          ],
+        },
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #377

## What

A `NotFoundError: Failed to execute 'removeChild' on 'Node'` was being reported to Sentry from the editor page. This is a known conflict between React's DOM reconciliation and Lexical's direct DOM manipulation for contentEditable — Lexical removes or reparents a DOM node, then React's commit phase tries to remove the same node. The error is harmless (the editor continues working) and the stack trace contains only React internals with no first-party frames.

## How

Added an `isReactLexicalDomConflict` filter function in `src/lib/sentry.ts` that detects `NotFoundError` events with `removeChild` in the message and no first-party frames in the stack trace. Wired this filter into the client-side Sentry `beforeSend` hook in `instrumentation-client.ts` (alongside the existing `isNextjsInternalNoise` filter) so these events are dropped before being sent to Sentry.

## Testing

Added 11 unit tests in `sentry.unit.test.ts` covering:
- Detection of the exact error signature (NotFoundError + removeChild + third-party-only frames)
- Detection with empty frames, missing stacktrace, and chained exceptions
- Rejection when first-party frames are present (ensures real app bugs are not filtered)
- Rejection for wrong error types, unrelated NotFoundErrors, and edge cases (empty/missing exceptions)

All 440 unit tests pass. Lint and typecheck clean.