### PR TITLE
chore: schedule trash auto-purge for pages deleted over 30 days (#351)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -113,7 +113,7 @@ Sign-up flow (atomic, via DB trigger):
 | Image storage | Supabase Storage | Bucket for uploaded images, public URL stored in ImageNode |
 | Full-text search | PostgreSQL `tsvector` + `tsquery` | Generated column on pages combining title (weight A) + extracted content text (weight B), GIN index, `search_pages` RPC |
 | Page ancestors | PostgreSQL recursive CTE | `get_page_ancestors` RPC walks `parent_id` chain to build breadcrumb path. Returns ancestors root-first. `security invoker` respects RLS. |
-| Soft delete | `deleted_at` column + RPCs | Pages are soft-deleted (moved to trash) instead of hard-deleted. `soft_delete_page` and `restore_page` RPCs use recursive CTEs to handle sub-pages. RLS policies split into active/trashed. `purge_old_trash` function for 30-day auto-purge. |
+| Soft delete | `deleted_at` column + RPCs | Pages are soft-deleted (moved to trash) instead of hard-deleted. `soft_delete_page` and `restore_page` RPCs use recursive CTEs to handle sub-pages. RLS policies split into active/trashed. `purge_old_trash` function for 30-day auto-purge, scheduled via Vercel Cron (`GET /api/cron/purge-trash` at 3 AM UTC daily) with pg_cron as a secondary mechanism when available. |
 
 ## Lexical Editor — Implementation Plan
 
@@ -233,7 +233,8 @@ src/
 │       ├── health/route.ts  # Health check endpoint (DB connectivity)
 │       ├── pages/[pageId]/versions/route.ts       # GET: list versions, POST: create version snapshot
 │       ├── pages/[pageId]/versions/[versionId]/route.ts # GET: single version content, POST: restore version
-│       └── search/route.ts  # Full-text search (GET ?q=&workspace_id=) → calls search_pages RPC
+│       ├── search/route.ts  # Full-text search (GET ?q=&workspace_id=) → calls search_pages RPC
+│       └── cron/purge-trash/route.ts # Vercel Cron: purges pages trashed >30 days (CRON_SECRET auth)
 ├── components/
 │   ├── auth/
 │   │   ├── oauth-buttons.tsx    # GitHub + Google OAuth sign-in buttons (signInWithOAuth)

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -86,6 +86,19 @@ export function PageList() {
 }
 ```
 
+### Admin client (service-role, no user session)
+
+For server-only operations without a user session (cron jobs, webhooks), use the
+admin client. It uses `SUPABASE_SECRET_KEY` (service role) and must never be
+imported from client code.
+
+```typescript
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const supabase = createAdminClient();
+const { data, error } = await supabase.rpc("purge_old_trash");
+```
+
 ### Proxy (session refresh)
 
 Next.js 16 uses `src/proxy.ts` instead of `src/middleware.ts`. The proxy refreshes

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ SENTRY_AUTH_TOKEN=your-sentry-auth-token
 SENTRY_ORG=your-sentry-org
 SENTRY_PROJECT=your-sentry-project
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+CRON_SECRET=your-cron-secret
 
 # Test user credentials for automated smoke tests and UI verification
 TEST_USER_EMAIL=your-test-user-email

--- a/src/app/api/cron/purge-trash/route.test.ts
+++ b/src/app/api/cron/purge-trash/route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+const mockedCreateAdminClient = vi.mocked(createAdminClient);
+
+function makeRequest(authHeader?: string): Request {
+  const headers = new Headers();
+  if (authHeader) {
+    headers.set("authorization", authHeader);
+  }
+  return new Request("http://localhost:3000/api/cron/purge-trash", {
+    headers,
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  process.env.CRON_SECRET = "test-cron-secret";
+});
+
+describe("GET /api/cron/purge-trash", () => {
+  it("returns 503 when CRON_SECRET is not configured", async () => {
+    delete process.env.CRON_SECRET;
+
+    const response = await GET(makeRequest("Bearer anything"));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe("CRON_SECRET not configured");
+  });
+
+  it("returns 401 when authorization header is missing", async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 when authorization header is wrong", async () => {
+    const response = await GET(makeRequest("Bearer wrong-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 200 with deleted count on success", async () => {
+    const mockRpc = vi.fn().mockResolvedValue({ data: 5, error: null });
+    mockedCreateAdminClient.mockReturnValue({
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof createAdminClient>);
+
+    const response = await GET(makeRequest("Bearer test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.deleted).toBe(5);
+    expect(mockRpc).toHaveBeenCalledWith("purge_old_trash");
+  });
+
+  it("returns 200 with deleted 0 when no pages purged", async () => {
+    const mockRpc = vi.fn().mockResolvedValue({ data: 0, error: null });
+    mockedCreateAdminClient.mockReturnValue({
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof createAdminClient>);
+
+    const response = await GET(makeRequest("Bearer test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.deleted).toBe(0);
+  });
+
+  it("returns 500 when RPC fails", async () => {
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "DB error", code: "PGRST" },
+    });
+    mockedCreateAdminClient.mockReturnValue({
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof createAdminClient>);
+
+    const response = await GET(makeRequest("Bearer test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Purge failed");
+  });
+
+  it("returns 500 when admin client throws", async () => {
+    mockedCreateAdminClient.mockImplementation(() => {
+      throw new Error("Missing env vars");
+    });
+
+    const response = await GET(makeRequest("Bearer test-cron-secret"));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Internal server error");
+  });
+});

--- a/src/app/api/cron/purge-trash/route.ts
+++ b/src/app/api/cron/purge-trash/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET not configured" },
+      { status: 503 },
+    );
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const supabase = createAdminClient();
+    const { data, error } = await supabase.rpc("purge_old_trash");
+
+    if (error) {
+      Sentry.captureException(error);
+      return NextResponse.json(
+        { error: "Purge failed" },
+        { status: 500 },
+      );
+    }
+
+    const deletedCount = typeof data === "number" ? data : 0;
+    return NextResponse.json({ ok: true, deleted: deletedCount });
+  } catch (error) {
+    Sentry.captureException(error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,23 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Service-role Supabase client for server-only operations that run without
+ * a user session (e.g. cron jobs). Never import this from client code.
+ */
+export function createAdminClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SECRET_KEY;
+
+  if (!url || !key) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SECRET_KEY for admin client",
+    );
+  }
+
+  return createSupabaseClient(url, key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}

--- a/supabase/migrations/20260421131320_schedule_trash_purge.sql
+++ b/supabase/migrations/20260421131320_schedule_trash_purge.sql
@@ -1,0 +1,20 @@
+-- Schedule daily purge of pages trashed for more than 30 days.
+--
+-- Attempts to use pg_cron (available on Supabase Pro+). If pg_cron is not
+-- available, the migration succeeds silently — the Vercel Cron job at
+-- GET /api/cron/purge-trash serves as the guaranteed fallback.
+
+do $outer$
+begin
+  create extension if not exists pg_cron;
+
+  perform cron.schedule(
+    'purge-old-trash',
+    '0 3 * * *',
+    $$select public.purge_old_trash()$$
+  );
+exception
+  when others then
+    raise notice 'pg_cron not available (%), trash purge will run via Vercel Cron', sqlerrm;
+end;
+$outer$;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/purge-trash",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #351

## What

Schedules the existing `purge_old_trash()` PostgreSQL function to run daily, permanently deleting pages that have been in the trash for more than 30 days.

## How

**Dual scheduling approach** for reliability across Supabase plans:

1. **Vercel Cron** (primary) — `GET /api/cron/purge-trash` runs daily at 3:00 AM UTC via `vercel.json`. Secured with `CRON_SECRET` Bearer token (Vercel sends this automatically). Uses a new service-role admin client (`src/lib/supabase/admin.ts`) since there's no user session in cron context.

2. **pg_cron** (secondary) — Migration attempts to enable `pg_cron` and schedule the job. If the extension isn't available (free-tier Supabase), the migration succeeds silently via exception handler.

**New files:**
- `src/app/api/cron/purge-trash/route.ts` — Cron endpoint with CRON_SECRET auth
- `src/app/api/cron/purge-trash/route.test.ts` — 7 tests covering auth, success, and error paths
- `src/lib/supabase/admin.ts` — Service-role Supabase client for sessionless operations
- `supabase/migrations/20260421131320_schedule_trash_purge.sql` — pg_cron setup (graceful fallback)
- `vercel.json` — Vercel Cron configuration

**Updated:**
- `.env.example` — added `CRON_SECRET`
- `.agents/architecture.md` — documented cron route and scheduling mechanism
- `.agents/conventions.md` — documented admin client pattern

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 53 files, 445 tests pass (including 7 new cron route tests)
- Sub-page cascade verified: `parent_id` has `ON DELETE CASCADE` in the schema

## Setup required

Add `CRON_SECRET` environment variable in Vercel project settings (random string, 16+ characters).