### PR TITLE
fix: return 400 for malformed JSON in versions API routes (#380)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -243,6 +243,29 @@ try {
 }
 ```
 
+### Safe `request.json()` parsing in API routes
+
+`request.json()` throws a `SyntaxError` when the body is empty or malformed JSON.
+This is a client error, not an application bug — it must return 400 without reaching
+the generic catch block (which would report it to Sentry at error level).
+
+Wrap `request.json()` in its own try-catch before the main route logic:
+
+```typescript
+let body: { content: Record<string, unknown> | null };
+try {
+  body = await request.json() as typeof body;
+} catch (_e) {
+  // Malformed/empty body is a client error — return 400 without Sentry capture
+  return NextResponse.json(
+    { error: "Invalid JSON in request body" },
+    { status: 400 },
+  );
+}
+```
+
+Use `catch (_e)` (not bare `catch {}`) to satisfy the static analysis convention.
+
 ### Client-side mutations
 
 Client-side mutations must show `toast.error()` on failure in addition to Sentry

--- a/src/app/api/pages/[pageId]/versions/[versionId]/route.test.ts
+++ b/src/app/api/pages/[pageId]/versions/[versionId]/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 
 vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
@@ -208,5 +209,33 @@ describe("POST /api/pages/[pageId]/versions/[versionId] (restore)", () => {
       { params: mockParams },
     );
     expect(res.status).toBe(403);
+  });
+
+  it("returns 400 on empty request body (#380)", async () => {
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions/version-456", {
+        method: "POST",
+        body: "",
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on malformed JSON body (#380)", async () => {
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions/version-456", {
+        method: "POST",
+        body: "{not valid json",
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/pages/[pageId]/versions/[versionId]/route.ts
+++ b/src/app/api/pages/[pageId]/versions/[versionId]/route.ts
@@ -69,7 +69,17 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json() as { action: string };
+    let body: { action: string };
+    try {
+      body = await request.json() as typeof body;
+    } catch (_e) {
+      // Malformed/empty body is a client error, not an application bug — return 400 without Sentry capture
+      return NextResponse.json(
+        { error: "Invalid JSON in request body" },
+        { status: 400 },
+      );
+    }
+
     if (body.action !== "restore") {
       return NextResponse.json({ error: "Invalid action" }, { status: 400 });
     }

--- a/src/app/api/pages/[pageId]/versions/route.test.ts
+++ b/src/app/api/pages/[pageId]/versions/route.test.ts
@@ -152,6 +152,34 @@ describe("POST /api/pages/[pageId]/versions", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 on empty request body (#380)", async () => {
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions", {
+        method: "POST",
+        body: "",
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on malformed JSON body (#380)", async () => {
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions", {
+        method: "POST",
+        body: "{invalid json",
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid JSON in request body");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
   it("creates a version on success", async () => {
     // First select = dedup check (no existing version)
     listResult = { data: null, error: null };

--- a/src/app/api/pages/[pageId]/versions/route.ts
+++ b/src/app/api/pages/[pageId]/versions/route.ts
@@ -65,7 +65,17 @@ export async function POST(
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json() as { content: Record<string, unknown> | null };
+    let body: { content: Record<string, unknown> | null };
+    try {
+      body = await request.json() as typeof body;
+    } catch (_e) {
+      // Malformed/empty body is a client error, not an application bug — return 400 without Sentry capture
+      return NextResponse.json(
+        { error: "Invalid JSON in request body" },
+        { status: 400 },
+      );
+    }
+
     if (body.content === undefined) {
       return NextResponse.json(
         { error: "Missing required field: content" },


### PR DESCRIPTION
Closes #380

## What

`POST /api/pages/[pageId]/versions` and `POST /api/pages/[pageId]/versions/[versionId]` crash with 500 and report to Sentry when the request body is empty or malformed JSON. The `request.json()` call throws a `SyntaxError` that propagates to the generic catch block, which calls `Sentry.captureException` and returns 500 — treating a client error as an application bug.

## How

Wrapped `request.json()` in its own try-catch that returns 400 with a structured error message before the main route logic. The `SyntaxError` is caught early and never reaches the generic catch block, so it is not reported to Sentry. Applied the same fix to both the versions list route and the version restore route. Added a safe `request.json()` parsing convention to `.agents/conventions.md` to prevent this class of bug in future API routes.

## Testing

Added 4 regression tests (2 per route):
- Empty request body → returns 400 with "Invalid JSON in request body", Sentry.captureException not called
- Malformed JSON body → returns 400 with "Invalid JSON in request body", Sentry.captureException not called

All 441 unit tests pass. Lint and typecheck clean.