### PR TITLE
fix: detect RLS violations from generic Error in catch blocks (#381)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -243,14 +243,21 @@ Check `supabase/migrations/` for constraint names. The naming convention is
 
 ### API route catch blocks
 
-All catch blocks in API routes must call `Sentry.captureException`:
+All catch blocks in API routes must call `Sentry.captureException`, but filter
+out expected authorization errors first. Supabase may throw RLS violations as
+generic `Error` instances (without PostgrestError shape) in catch blocks, so
+always check with `isInsufficientPrivilegeError` before reporting to Sentry:
 
 ```typescript
 import * as Sentry from "@sentry/nextjs";
+import { isInsufficientPrivilegeError } from "@/lib/sentry";
 
 try {
   // ... route logic
 } catch (error) {
+  if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
   Sentry.captureException(error);
   return NextResponse.json({ error: "Internal server error" }, { status: 500 });
 }

--- a/src/app/api/pages/[pageId]/versions/[versionId]/route.test.ts
+++ b/src/app/api/pages/[pageId]/versions/[versionId]/route.test.ts
@@ -51,7 +51,9 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/lib/sentry", () => ({
   captureSupabaseError: vi.fn(),
-  isInsufficientPrivilegeError: (err: { code: string }) => err.code === "42501",
+  isInsufficientPrivilegeError: (err: Error & { code?: string }) =>
+    err.code === "42501" ||
+    err.message?.includes("violates row-level security policy"),
 }));
 
 const { GET, POST } = await import("./route");

--- a/src/app/api/pages/[pageId]/versions/route.test.ts
+++ b/src/app/api/pages/[pageId]/versions/route.test.ts
@@ -66,7 +66,9 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/lib/sentry", () => ({
   captureSupabaseError: vi.fn(),
-  isInsufficientPrivilegeError: (err: { code: string }) => err.code === "42501",
+  isInsufficientPrivilegeError: (err: Error & { code?: string }) =>
+    err.code === "42501" ||
+    err.message?.includes("violates row-level security policy"),
 }));
 
 const { GET, POST } = await import("./route");
@@ -208,6 +210,29 @@ describe("POST /api/pages/[pageId]/versions", () => {
     const body = await res.json();
     expect(body.error).toBe("Forbidden");
     // Must NOT report to Sentry at error level
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when RLS violation is thrown without PostgrestError shape (MEMO-W regression)", async () => {
+    // Simulate Supabase throwing a plain Error without code/details/hint.
+    // This is the exact scenario from MEMO-W: the error has the RLS message
+    // but lacks PostgrestError properties, so the duck-type check fails.
+    const rlsError = new Error(
+      'new row violates row-level security policy for table "page_versions"',
+    );
+    throwOnInsert = rlsError;
+    listResult = { data: null, error: null };
+
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions", {
+        method: "POST",
+        body: JSON.stringify({ content: { root: { children: [] } } }),
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Forbidden");
     expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -110,9 +110,17 @@ export function isSchemaNotFoundError(error: Error): boolean {
  * when an RPC uses `RAISE EXCEPTION` to reject callers who lack access
  * (e.g. non-members calling workspace-scoped functions). It is an expected
  * authorization check, not an application bug — API routes should return 403.
+ *
+ * Matches both PostgrestError objects (with `code` property) and generic
+ * Error instances whose message contains the RLS violation pattern. Supabase
+ * may surface 42501 errors as thrown exceptions without PostgrestError shape
+ * when the query builder promise rejects instead of returning `{ error }`.
  */
 export function isInsufficientPrivilegeError(error: Error): boolean {
-  return isPostgrestError(error) && error.code === "42501";
+  if (isPostgrestError(error)) {
+    return error.code === "42501";
+  }
+  return error.message.includes("violates row-level security policy");
 }
 
 /**

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -135,9 +135,23 @@ describe("isInsufficientPrivilegeError", () => {
     expect(isInsufficientPrivilegeError(error)).toBe(false);
   });
 
-  it("returns false for generic errors", () => {
+  it("returns false for generic errors without RLS message", () => {
     const error = new Error("Something went wrong");
     expect(isInsufficientPrivilegeError(error)).toBe(false);
+  });
+
+  it("detects RLS violation from generic Error message (MEMO-W regression)", () => {
+    const error = new Error(
+      'new row violates row-level security policy for table "page_versions"',
+    );
+    expect(isInsufficientPrivilegeError(error)).toBe(true);
+  });
+
+  it("detects RLS violation from generic Error with different table name", () => {
+    const error = new Error(
+      'new row violates row-level security policy for table "pages"',
+    );
+    expect(isInsufficientPrivilegeError(error)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #381

## What

RLS violation errors (PostgreSQL 42501) on `page_versions` insert were being reported to Sentry at error level despite the route handler having `isInsufficientPrivilegeError` checks in both the Supabase error path and the catch block. The catch block check failed because `isInsufficientPrivilegeError` relied on `isPostgrestError`, which duck-type checks for `code`, `details`, and `hint` properties. When Supabase throws the error as a generic `Error` (not a `PostgrestError` object), the duck-type check fails and the error falls through to `Sentry.captureException`.

## How

Extended `isInsufficientPrivilegeError` in `src/lib/sentry.ts` to also match by error message pattern (`"violates row-level security policy"`) when the error isn't a proper `PostgrestError`. This fixes the detection at the source for all callers — the same pattern exists in multiple route handlers (`versions`, `[versionId]`, `search`, `account`). Updated the API route catch block convention in `.agents/conventions.md` to document the pattern.

## Testing

- Added regression test in `sentry.unit.test.ts`: generic `Error` with RLS violation message is detected by `isInsufficientPrivilegeError` (MEMO-W scenario)
- Added regression test in `versions/route.test.ts`: POST handler returns 403 (not 500) and does not call `Sentry.captureException` when a plain `Error` with RLS message is thrown (no `code`/`details`/`hint` properties)
- Updated test mocks in both `versions/route.test.ts` and `[versionId]/route.test.ts` to match the new detection logic
- All 459 unit tests pass: `pnpm lint && pnpm typecheck && pnpm test`