### PR TITLE
fix: silence version save Sentry noise by dropping non-critical errors (#384)

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -32,7 +32,6 @@ import type {
   SerializedEditorState,
 } from "lexical";
 import { lazyCaptureException } from "@/lib/capture";
-import { isTransientNetworkError } from "@/lib/sentry";
 import { editorTheme } from "@/components/editor/theme";
 import { SlashCommandPlugin } from "@/components/editor/slash-command-plugin";
 import { FloatingToolbarPlugin } from "@/components/editor/floating-toolbar-plugin";
@@ -218,7 +217,10 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
             lazyCaptureException(err),
           );
 
-          // Save a version snapshot at intervals (every 5 minutes)
+          // Save a version snapshot at intervals (every 5 minutes).
+          // Failures are silently dropped — the page content is already
+          // saved and the next interval will retry. Reporting these to
+          // Sentry is pure noise (see #384).
           const now = Date.now();
           if (now - lastVersionSavedAtRef.current >= VERSION_SAVE_INTERVAL_MS) {
             lastVersionSavedAtRef.current = now;
@@ -226,12 +228,10 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ content: json }),
-            }).catch((err) => {
-              if (err instanceof Error && isTransientNetworkError(err)) {
-                lazyCaptureException(err, { level: "warning" });
-              } else {
-                lazyCaptureException(err);
-              }
+            }).catch(() => {
+              // Reset so the next content save retries immediately
+              // instead of waiting another full interval.
+              lastVersionSavedAtRef.current = 0;
             });
           }
         } else {

--- a/src/components/editor/version-save-error-handling.test.ts
+++ b/src/components/editor/version-save-error-handling.test.ts
@@ -3,11 +3,11 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 /**
- * Regression test for #364: version save fetch must downgrade transient
- * network errors to warning level instead of reporting at error level.
+ * Regression test for #384: version save fetch failures must be silently
+ * dropped — no Sentry reporting at all. The page content is already saved
+ * via PATCH and the next 5-minute interval will retry the version snapshot.
  *
- * This is a static analysis test that verifies the editor source code
- * contains the correct error handling pattern for the version save fetch.
+ * Supersedes the #364 test which only downgraded to warning level.
  */
 describe("version save error handling", () => {
   const editorSource = readFileSync(
@@ -15,22 +15,25 @@ describe("version save error handling", () => {
     "utf-8",
   );
 
-  it("imports isTransientNetworkError", () => {
-    expect(editorSource).toContain("isTransientNetworkError");
+  it("does not import isTransientNetworkError (no longer needed for version saves)", () => {
+    // The version save catch no longer distinguishes transient vs other errors —
+    // all failures are silently dropped. The import should be removed.
+    expect(editorSource).not.toContain("isTransientNetworkError");
   });
 
-  it("does not call lazyCaptureException directly in version save catch without checking for transient errors", () => {
-    // The old buggy pattern: .catch((err) => lazyCaptureException(err))
-    // on the version save fetch. Verify this single-expression catch
-    // pattern is NOT used for the /versions endpoint fetch.
-    const versionFetchRegex =
-      /fetch\([^)]*\/versions[^)]*\)[\s\S]*?\.catch\(\(err\)\s*=>\s*lazyCaptureException\(err\)\s*\)/;
-    expect(editorSource).not.toMatch(versionFetchRegex);
+  it("does not call lazyCaptureException in the version save catch", () => {
+    // Extract the version save fetch block and verify it contains no
+    // lazyCaptureException call. The catch handler should only reset
+    // the timer so the next save retries immediately.
+    const versionFetchBlock = editorSource.match(
+      /fetch\([^)]*\/versions[\s\S]*?\.catch\([\s\S]*?\)/,
+    );
+    expect(versionFetchBlock).not.toBeNull();
+    expect(versionFetchBlock![0]).not.toContain("lazyCaptureException");
+    expect(versionFetchBlock![0]).not.toContain("captureException");
   });
 
-  it("downgrades transient network errors to warning level in version save catch", () => {
-    // Verify the catch handler checks isTransientNetworkError and passes
-    // level: "warning" for transient errors.
-    expect(editorSource).toContain('lazyCaptureException(err, { level: "warning" })');
+  it("resets lastVersionSavedAtRef on failure so the next save retries immediately", () => {
+    expect(editorSource).toContain("lastVersionSavedAtRef.current = 0");
   });
 });


### PR DESCRIPTION
Closes #384

## What

`TypeError: Failed to fetch` on `POST /api/pages/{pageId}/versions` during the editor's auto-save version snapshot was flooding Sentry with 10+ warning-level events. The page content itself saves successfully via PATCH — only the periodic version snapshot (every 5 minutes) was failing on transient network errors. No data loss, no user-visible error.

## How

Removed all Sentry reporting from the version save `.catch()` handler. Version saves are non-critical and self-healing — the next interval will retry. On failure, the `lastVersionSavedAtRef` is reset to 0 so the next content save retries the version immediately instead of waiting another full 5-minute interval. Also removed the now-unused `isTransientNetworkError` import from `editor.tsx`.

## Testing

Updated the static analysis regression test (`version-save-error-handling.test.ts`) to verify:
- `isTransientNetworkError` is no longer imported in editor.tsx
- The version save `.catch()` contains no `lazyCaptureException` or `captureException` calls
- `lastVersionSavedAtRef.current = 0` is set on failure for immediate retry

All 456 unit tests pass. Lint and typecheck clean.