### PR TITLE
fix: downgrade RLS violations to warning and fix removeChild filter (#388)

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -83,16 +83,23 @@ function hasNoFirstPartyFrames(
 ): boolean {
   if (!frames || frames.length === 0) return true;
 
-  return frames.every((frame) => {
-    const filename = frame.filename ?? frame.abs_path ?? "";
-    // First-party frames reference source files under src/ or the app root.
-    // Third-party frames are webpack chunks, node_modules, or anonymous.
-    return (
-      !filename.includes("/src/") &&
-      !filename.includes("src/") &&
-      !filename.startsWith("app://")
-    );
-  });
+  return !frames.some((frame) => isFirstPartyFrame(frame));
+}
+
+/**
+ * A frame is first-party when it references application source code rather
+ * than bundled third-party libraries. In production builds, Sentry prefixes
+ * all client-side frames with `app://` — both first-party and third-party.
+ * Third-party frames land in `_next/static/chunks/` with hash-based filenames
+ * (e.g. `01jr_next_dist_compiled_react-dom_08~fs09._.js`). First-party frames
+ * reference source paths containing `/src/` or `webpack-internal:///`.
+ */
+function isFirstPartyFrame(frame: {
+  filename?: string;
+  abs_path?: string;
+}): boolean {
+  const filename = frame.filename ?? frame.abs_path ?? "";
+  return filename.includes("/src/") || filename.includes("webpack-internal:");
 }
 
 /**
@@ -160,7 +167,11 @@ export function captureSupabaseError(
     extra.hint = error.hint;
   }
 
-  if (isTransientNetworkError(error) || isSchemaNotFoundError(error)) {
+  if (
+    isTransientNetworkError(error) ||
+    isSchemaNotFoundError(error) ||
+    isInsufficientPrivilegeError(error)
+  ) {
     lazyCaptureException(error, { extra, level: "warning" });
     return;
   }

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -191,10 +191,25 @@ describe("captureSupabaseError", () => {
     expect(opts.extra.code).toBe("PGRST205");
   });
 
-  it("captures non-network errors at default (error) level", async () => {
+  it("captures RLS violations (42501) at warning level (MEMO-E)", async () => {
     const error = makePostgrestError({
-      message: "new row violates row-level security policy",
+      message: "new row violates row-level security policy for table \"pages\"",
       code: "42501",
+    });
+    captureSupabaseError(error, "page-tree:create-page");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("page-tree:create-page");
+    expect(opts.extra.code).toBe("42501");
+  });
+
+  it("captures non-network, non-RLS errors at default (error) level", async () => {
+    const error = makePostgrestError({
+      message: "duplicate key value violates unique constraint",
+      code: "23505",
     });
     captureSupabaseError(error, "pages.insert");
     await flush();
@@ -203,7 +218,7 @@ describe("captureSupabaseError", () => {
     const [, opts] = captureExceptionMock.mock.calls[0];
     expect(opts.level).toBeUndefined();
     expect(opts.extra.operation).toBe("pages.insert");
-    expect(opts.extra.code).toBe("42501");
+    expect(opts.extra.code).toBe("23505");
   });
 
   it("includes PostgrestError fields in extra", async () => {
@@ -364,7 +379,7 @@ describe("isReactLexicalDomConflict", () => {
     expect(isReactLexicalDomConflict(event)).toBe(false);
   });
 
-  it("returns false when first-party frames use app:// scheme", () => {
+  it("detects the error with app:// third-party chunk frames (MEMO-11)", () => {
     const event = makeSentryEventWithStack([
       {
         type: "NotFoundError",
@@ -373,6 +388,40 @@ describe("isReactLexicalDomConflict", () => {
         stacktrace: {
           frames: [
             { abs_path: "app:///_next/static/chunks/main.js" },
+            { filename: "app:///_next/static/chunks/01jr_next_dist_compiled_react-dom_08~fs09._.js" },
+          ],
+        },
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(true);
+  });
+
+  it("returns false when first-party frames use app:// with /src/ path", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: {
+          frames: [
+            { abs_path: "app:///_next/static/chunks/main.js" },
+            { filename: "app:///src/components/editor/editor.tsx" },
+          ],
+        },
+      },
+    ]);
+    expect(isReactLexicalDomConflict(event)).toBe(false);
+  });
+
+  it("returns false when first-party frames use webpack-internal:// scheme", () => {
+    const event = makeSentryEventWithStack([
+      {
+        type: "NotFoundError",
+        value:
+          "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+        stacktrace: {
+          frames: [
+            { filename: "webpack-internal:///src/components/editor/editor.tsx" },
           ],
         },
       },


### PR DESCRIPTION
Closes #388

## What

Two Sentry noise fixes in `src/lib/sentry.ts`:

**1. RLS violations (42501) downgraded to warning** — [MEMO-E](https://ona-2j.sentry.io/issues/MEMO-E)

`captureSupabaseError` was reporting RLS violations at error level, generating 1834 events from 24 users. RLS rejections are expected authorization behavior (e.g., E2E tests hitting workspace page limits), not application bugs. Added `isInsufficientPrivilegeError` to the warning-level downgrade check alongside `isTransientNetworkError` and `isSchemaNotFoundError`.

**2. `hasNoFirstPartyFrames` filter fixed** — [MEMO-11](https://ona-2j.sentry.io/issues/MEMO-11)

The `isReactLexicalDomConflict` filter (PR #382) failed to drop `NotFoundError: removeChild` events because `hasNoFirstPartyFrames` treated all `app://` frames as first-party. In production, Sentry prefixes both first-party and third-party client-side frames with `app://`. Replaced the `app://` prefix check with a `/src/` path and `webpack-internal:` scheme check to correctly distinguish application code from bundled library code.

## Testing

- Updated existing test: RLS 42501 now asserts warning level (was error)
- Updated existing test: `app://` third-party chunk frames now correctly detected
- Added regression test: MEMO-11 scenario (React DOM chunks with `app://` prefix)
- Added regression test: `webpack-internal:` frames detected as first-party
- All 459 unit tests pass: `pnpm lint && pnpm typecheck && pnpm test`