### PR TITLE
feat: add user_feedback and usage_events database tables with RLS (#392)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -89,6 +89,30 @@ page_versions (snapshots of page content for version history and restore)
   `prune_excess_page_versions(page_id)` keeps only the latest 50 per page.
   Created every 5 minutes during auto-save (deduplicated — skipped if content unchanged).
 
+user_feedback (user-submitted feedback: bugs, features, general)
+  ├── user_id → auth.users.id (ON DELETE CASCADE)
+  ├── type: text (check: bug | feature | general)
+  ├── message: text (not null)
+  ├── page_path: text (nullable — URL path where feedback was submitted)
+  ├── page_title: text (nullable)
+  ├── screenshot_url: text (nullable — public URL in feedback-screenshots bucket)
+  ├── metadata: jsonb (nullable)
+  ├── status: text (check: new | reviewed | actioned | dismissed, default 'new')
+  └── created_at: timestamptz
+  RLS: authenticated users can INSERT where user_id = auth.uid(). No SELECT/UPDATE/DELETE for regular users.
+
+usage_events (server-side product analytics)
+  ├── event_name: text (not null)
+  ├── user_id → auth.users.id (ON DELETE CASCADE)
+  ├── workspace_id: uuid (nullable)
+  ├── page_path: text (nullable)
+  ├── metadata: jsonb (nullable)
+  ├── created_at: timestamptz
+  └── Index: (event_name, created_at) for efficient digest queries
+  RLS: authenticated users can INSERT where user_id = auth.uid(). No SELECT/UPDATE/DELETE for regular users.
+
+Storage bucket: feedback-screenshots (public, 5 MB limit, png/jpeg/webp)
+
 Sign-up flow (atomic, via DB trigger):
   1. auth.users row created by Supabase Auth
   2. handle_new_user trigger fires → creates:

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,3 +117,29 @@ export interface PageLink {
 export interface BacklinkWithPage extends PageLink {
   source_page: Pick<Page, "id" | "title" | "icon">;
 }
+
+export type FeedbackType = "bug" | "feature" | "general";
+export type FeedbackStatus = "new" | "reviewed" | "actioned" | "dismissed";
+
+export interface UserFeedback {
+  id: string;
+  user_id: string;
+  type: FeedbackType;
+  message: string;
+  page_path: string | null;
+  page_title: string | null;
+  screenshot_url: string | null;
+  metadata: Record<string, unknown> | null;
+  status: FeedbackStatus;
+  created_at: string;
+}
+
+export interface UsageEvent {
+  id: string;
+  event_name: string;
+  user_id: string;
+  workspace_id: string | null;
+  page_path: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
+}

--- a/supabase/migrations/20260421140300_add_feedback_and_usage_tables.sql
+++ b/supabase/migrations/20260421140300_add_feedback_and_usage_tables.sql
@@ -1,0 +1,96 @@
+-- User feedback and usage events tables for the feedback tool.
+-- Includes RLS policies and a storage bucket for screenshot attachments.
+
+-- =============================================================================
+-- 1. Tables
+-- =============================================================================
+
+-- user_feedback: stores user-submitted feedback (bugs, features, general)
+create table user_feedback (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  type text not null check (type in ('bug', 'feature', 'general')),
+  message text not null,
+  page_path text,
+  page_title text,
+  screenshot_url text,
+  metadata jsonb,
+  status text not null default 'new' check (status in ('new', 'reviewed', 'actioned', 'dismissed')),
+  created_at timestamptz not null default now()
+);
+
+-- usage_events: server-side product analytics
+create table usage_events (
+  id uuid primary key default gen_random_uuid(),
+  event_name text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  workspace_id uuid,
+  page_path text,
+  metadata jsonb,
+  created_at timestamptz not null default now()
+);
+
+-- Index for efficient digest queries on usage_events
+create index usage_events_name_created on usage_events (event_name, created_at);
+
+-- =============================================================================
+-- 2. Row Level Security
+-- =============================================================================
+
+alter table user_feedback enable row level security;
+alter table usage_events enable row level security;
+
+-- user_feedback: authenticated users can INSERT their own feedback only
+create policy "users can insert own feedback"
+  on user_feedback for insert
+  to authenticated
+  with check (user_id = auth.uid());
+
+-- usage_events: authenticated users can INSERT their own events only
+create policy "users can insert own usage events"
+  on usage_events for insert
+  to authenticated
+  with check (user_id = auth.uid());
+
+-- =============================================================================
+-- 3. Storage bucket for feedback screenshots
+-- =============================================================================
+
+DO $$ BEGIN
+  INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  VALUES (
+    'feedback-screenshots',
+    'feedback-screenshots',
+    true,
+    5242880, -- 5 MB
+    ARRAY['image/png', 'image/jpeg', 'image/webp']
+  );
+EXCEPTION WHEN unique_violation THEN NULL;
+END $$;
+
+-- Authenticated users can upload screenshots
+DO $$ BEGIN
+  CREATE POLICY "Authenticated users can upload feedback screenshots"
+    ON storage.objects FOR INSERT
+    TO authenticated
+    WITH CHECK (bucket_id = 'feedback-screenshots');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Anyone can view uploaded screenshots (public bucket)
+DO $$ BEGIN
+  CREATE POLICY "Public read access for feedback screenshots"
+    ON storage.objects FOR SELECT
+    TO public
+    USING (bucket_id = 'feedback-screenshots');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Users can delete their own screenshots
+DO $$ BEGIN
+  CREATE POLICY "Users can delete own feedback screenshots"
+    ON storage.objects FOR DELETE
+    TO authenticated
+    USING (bucket_id = 'feedback-screenshots' AND auth.uid() = owner);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
Closes #392

## What

Adds the foundational database tables for the User Feedback Tool:

- **`user_feedback`** — stores user-submitted feedback (bug reports, feature requests, general feedback) with type/status check constraints, optional screenshot URL, and JSONB metadata
- **`usage_events`** — server-side product analytics with an index on `(event_name, created_at)` for efficient digest queries
- **`feedback-screenshots`** storage bucket — public bucket for optional screenshot attachments (5 MB limit, png/jpeg/webp)

## How

- Single migration file: `20260421140300_add_feedback_and_usage_tables.sql`
- Both tables FK to `auth.users(id)` with `ON DELETE CASCADE` (matches existing patterns)
- RLS: authenticated users can INSERT where `user_id = auth.uid()`. No SELECT/UPDATE/DELETE for regular users — service role handles reads for automation.
- Storage bucket uses `DO $$ ... EXCEPTION` pattern for idempotent creation (matches `page-images` bucket pattern)
- TypeScript types added: `UserFeedback`, `UsageEvent`, `FeedbackType`, `FeedbackStatus`
- Updated `.agents/architecture.md` data model section with new tables

## Testing

- `pnpm lint` — 0 errors (7 pre-existing warnings)
- `pnpm typecheck` — passes
- `pnpm test` — 467/467 tests pass (including migration regression test for the new file)
- No UI components added — this is a schema-only change, no stories or E2E tests needed