### PR TITLE
fix: prevent Tab in table cell from crashing editor (#401)

### DIFF
--- a/e2e/editor-table.spec.ts
+++ b/e2e/editor-table.spec.ts
@@ -144,15 +144,80 @@ test.describe("Editor table blocks", () => {
     await expect(reloadedTable.locator("tr")).toHaveCount(3);
   });
 
+  test("Tab navigates to the next cell without deleting the table", async ({
+    authenticatedPage: page,
+  }) => {
+    const table = await insertTable(page);
+
+    // Place cursor inside the first header cell
+    await focusFirstCell(page);
+    await page.keyboard.type("Header 1");
+    await expect(table.locator("th").first()).toContainText("Header 1");
+
+    // Press Tab to move to the next cell
+    await page.keyboard.press("Tab");
+    await page.waitForTimeout(500);
+
+    // The table must still exist (regression for #401)
+    await expect(table).toBeVisible();
+
+    // Type in the second cell to verify the cursor moved
+    await page.keyboard.type("Header 2");
+    const secondHeaderCell = table.locator("th").nth(1);
+    await expect(secondHeaderCell).toContainText("Header 2");
+  });
+
+  test("Shift+Tab navigates to the previous cell", async ({
+    authenticatedPage: page,
+  }) => {
+    const table = await insertTable(page);
+
+    // Place cursor inside the first header cell
+    await focusFirstCell(page);
+    await page.keyboard.type("Cell A");
+    await page.keyboard.press("Tab");
+    await page.waitForTimeout(300);
+    await page.keyboard.type("Cell B");
+
+    // Shift+Tab back to the first cell
+    await page.keyboard.press("Shift+Tab");
+    await page.waitForTimeout(300);
+
+    // The table must still exist
+    await expect(table).toBeVisible();
+
+    // Type additional text — it should appear in the first cell
+    await page.keyboard.type(" updated");
+    await expect(table.locator("th").first()).toContainText("Cell A updated");
+  });
+
+  test("Tab from last cell does not delete the table", async ({
+    authenticatedPage: page,
+  }) => {
+    const table = await insertTable(page);
+
+    // Navigate to the last cell (3×3 table = 9 cells, Tab 8 times)
+    await focusFirstCell(page);
+    for (let i = 0; i < 8; i++) {
+      await page.keyboard.press("Tab");
+      await page.waitForTimeout(100);
+    }
+
+    // Type in the last cell
+    await page.keyboard.type("Last");
+    const lastCell = table.locator("td").last();
+    await expect(lastCell).toContainText("Last");
+
+    // Tab one more time to navigate out of the table
+    await page.keyboard.press("Tab");
+    await page.waitForTimeout(500);
+
+    // The table must still exist
+    await expect(table).toBeVisible();
+  });
+
   // --- Skipped tests: blocked by pre-existing bugs ---
   // These are tracked as separate bug issues.
-
-  // Bug: Tab inside a table cell removes the entire table from the DOM
-  // instead of navigating to the next cell. The TablePlugin has
-  // hasTabHandler={true} but the Tab handler doesn't work correctly.
-  test.skip("user can navigate between cells with Tab", async () => {
-    // Blocked by: Tab inside table cell deletes the table
-  });
 
   // Bug: Table cell content is lost after page reload. The table structure
   // (rows/columns) is preserved but all cell text content is empty after

--- a/src/components/editor/list-tab-indentation-plugin.tsx
+++ b/src/components/editor/list-tab-indentation-plugin.tsx
@@ -3,7 +3,11 @@
 import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $isListItemNode } from "@lexical/list";
-import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils";
+import {
+  $findMatchingParent,
+  $getNearestBlockElementAncestorOrThrow,
+} from "@lexical/utils";
+import { $isTableCellNode } from "@lexical/table";
 import {
   $getSelection,
   $isRangeSelection,
@@ -22,6 +26,12 @@ const MAX_LIST_INDENT = 7;
  * canIndent(), so Tab in the middle/end of a list item inserts a tab
  * character instead of nesting. This plugin intercepts Tab at a higher
  * priority and dispatches INDENT/OUTDENT commands when inside a list item.
+ *
+ * When the selection is inside a table cell, this plugin yields to the
+ * TablePlugin's Tab handler (registered at COMMAND_PRIORITY_CRITICAL).
+ * If the table handler did not handle the event (e.g. non-collapsed
+ * selection), we still preventDefault to stop the browser from moving
+ * focus out of the editor, which can corrupt the table DOM.
  */
 export function ListTabIndentationPlugin(): null {
   const [editor] = useLexicalComposerContext();
@@ -36,6 +46,18 @@ export function ListTabIndentationPlugin(): null {
         }
 
         const anchor = selection.anchor.getNode();
+
+        // If the selection is inside a table cell, prevent the browser
+        // default (which moves focus and can corrupt the table DOM).
+        // The TablePlugin's CRITICAL-priority handler runs first and
+        // handles cell navigation for collapsed selections. This guard
+        // catches the remaining cases (e.g. non-collapsed selection).
+        const tableCell = $findMatchingParent(anchor, $isTableCellNode);
+        if (tableCell !== null) {
+          event.preventDefault();
+          return true;
+        }
+
         const block = $getNearestBlockElementAncestorOrThrow(anchor);
 
         if (!$isListItemNode(block)) {

--- a/src/components/editor/table-action-menu-plugin.tsx
+++ b/src/components/editor/table-action-menu-plugin.tsx
@@ -171,6 +171,13 @@ function TableActionMenu({
   );
 }
 
+/**
+ * Renders a trigger button overlaid on the active table cell. The button
+ * is portalled to document.body and positioned with fixed layout using
+ * the cell's bounding rect. This avoids inserting DOM nodes into
+ * Lexical-managed elements, which causes React/Lexical reconciliation
+ * conflicts (the root cause of the "Tab deletes table" bug — see #401).
+ */
 export function TableActionMenuPlugin(): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [tableCellNode, setTableCellNode] = useState<TableCellNode | null>(
@@ -180,30 +187,61 @@ export function TableActionMenuPlugin(): JSX.Element | null {
     x: number;
     y: number;
   } | null>(null);
+  const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null);
 
   const handleClose = useCallback(() => {
     setTableCellNode(null);
     setMenuPosition(null);
   }, []);
 
+  // Track the active cell and compute the trigger button position from
+  // the cell's bounding rect rather than portalling into the cell DOM.
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState }) => {
       editorState.read(() => {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           setTableCellNode(null);
+          setTriggerRect(null);
           return;
         }
         const anchor = selection.anchor.getNode();
         const cellNode = $getTableCellNodeFromLexicalNode(anchor);
         if (cellNode) {
           setTableCellNode(cellNode);
+          // Defer DOM measurement to after React commit
+          requestAnimationFrame(() => {
+            const cellDom = editor.getElementByKey(cellNode.getKey());
+            if (cellDom) {
+              setTriggerRect(cellDom.getBoundingClientRect());
+            }
+          });
         } else {
           setTableCellNode(null);
+          setTriggerRect(null);
         }
       });
     });
   }, [editor]);
+
+  // Recompute trigger position on scroll/resize so it stays aligned
+  useEffect(() => {
+    if (!tableCellNode) return;
+
+    const updatePosition = () => {
+      const cellDom = editor.getElementByKey(tableCellNode.getKey());
+      if (cellDom) {
+        setTriggerRect(cellDom.getBoundingClientRect());
+      }
+    };
+
+    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener("resize", updatePosition);
+    return () => {
+      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [editor, tableCellNode]);
 
   const handleMenuOpen = useCallback(
     (event: React.MouseEvent) => {
@@ -214,21 +252,18 @@ export function TableActionMenuPlugin(): JSX.Element | null {
     []
   );
 
-  if (!tableCellNode) {
-    return null;
-  }
-
-  // Render a small menu trigger button in the top-right of the active cell
-  const cellDom = editor.getElementByKey(tableCellNode.getKey());
-  if (!cellDom) {
+  if (!tableCellNode || !triggerRect) {
     return null;
   }
 
   return (
     <>
       {createPortal(
-        <TableCellMenuTrigger onMenuOpen={handleMenuOpen} />,
-        cellDom
+        <TableCellMenuTrigger
+          onMenuOpen={handleMenuOpen}
+          cellRect={triggerRect}
+        />,
+        document.body
       )}
       {menuPosition && (
         <TableActionMenu
@@ -244,15 +279,21 @@ export function TableActionMenuPlugin(): JSX.Element | null {
 
 function TableCellMenuTrigger({
   onMenuOpen,
+  cellRect,
 }: {
   onMenuOpen: (event: React.MouseEvent) => void;
+  cellRect: DOMRect;
 }) {
   return (
     <button
-      className="absolute right-0.5 top-0.5 flex h-5 w-5 items-center justify-center text-muted-foreground opacity-0 hover:opacity-100 focus:opacity-100 [td:hover>&]:opacity-60 [th:hover>&]:opacity-60"
+      className="fixed z-40 flex h-5 w-5 items-center justify-center text-muted-foreground opacity-0 hover:opacity-100 focus:opacity-100"
+      style={{
+        top: cellRect.top + 2,
+        left: cellRect.right - 22,
+      }}
       onClick={onMenuOpen}
       aria-label="Table cell actions"
-      contentEditable={false}
+      onMouseDown={(e) => e.preventDefault()}
     >
       <MoreHorizontal className="h-3.5 w-3.5" />
     </button>

--- a/src/components/editor/table-action-menu-plugin.tsx
+++ b/src/components/editor/table-action-menu-plugin.tsx
@@ -188,6 +188,7 @@ export function TableActionMenuPlugin(): JSX.Element | null {
     y: number;
   } | null>(null);
   const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null);
+  const [isCellHovered, setIsCellHovered] = useState(false);
 
   const handleClose = useCallback(() => {
     setTableCellNode(null);
@@ -243,6 +244,26 @@ export function TableActionMenuPlugin(): JSX.Element | null {
     };
   }, [editor, tableCellNode]);
 
+  // Show the trigger button when hovering the active cell. Since the
+  // button is portalled to document.body, CSS parent-hover selectors
+  // can't reach it — use JS listeners on the cell DOM instead.
+  useEffect(() => {
+    if (!tableCellNode) return;
+
+    const cellDom = editor.getElementByKey(tableCellNode.getKey());
+    if (!cellDom) return;
+
+    const onEnter = () => setIsCellHovered(true);
+    const onLeave = () => setIsCellHovered(false);
+    cellDom.addEventListener("mouseenter", onEnter);
+    cellDom.addEventListener("mouseleave", onLeave);
+    return () => {
+      cellDom.removeEventListener("mouseenter", onEnter);
+      cellDom.removeEventListener("mouseleave", onLeave);
+      setIsCellHovered(false);
+    };
+  }, [editor, tableCellNode]);
+
   const handleMenuOpen = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault();
@@ -262,6 +283,7 @@ export function TableActionMenuPlugin(): JSX.Element | null {
         <TableCellMenuTrigger
           onMenuOpen={handleMenuOpen}
           cellRect={triggerRect}
+          isCellHovered={isCellHovered}
         />,
         document.body
       )}
@@ -280,13 +302,15 @@ export function TableActionMenuPlugin(): JSX.Element | null {
 function TableCellMenuTrigger({
   onMenuOpen,
   cellRect,
+  isCellHovered,
 }: {
   onMenuOpen: (event: React.MouseEvent) => void;
   cellRect: DOMRect;
+  isCellHovered: boolean;
 }) {
   return (
     <button
-      className="fixed z-40 flex h-5 w-5 items-center justify-center text-muted-foreground opacity-0 hover:opacity-100 focus:opacity-100"
+      className={`fixed z-40 flex h-5 w-5 items-center justify-center text-muted-foreground hover:opacity-100 focus:opacity-100 ${isCellHovered ? "opacity-60" : "opacity-0"}`}
       style={{
         top: cellRect.top + 2,
         left: cellRect.right - 22,


### PR DESCRIPTION
Closes #401

## What

Pressing Tab while the cursor is inside a table cell crashed the editor with a `NotFoundError: Failed to execute 'removeChild' on 'Node'`, triggering the error boundary and destroying the table.

## How

The `TableActionMenuPlugin` used `createPortal` to render a trigger button directly into Lexical-managed table cell DOM (`<td>`/`<th>` elements). When Tab moved the selection to a new cell, Lexical's DOM reconciliation modified the old cell's children before React could unmount the portal. React then failed trying to `removeChild` a node that was no longer a child of the expected parent.

The fix portals the trigger button to `document.body` instead and positions it with fixed layout using the cell's bounding rect. This avoids inserting any DOM nodes into Lexical-managed elements.

Additionally, `ListTabIndentationPlugin` now includes a defensive guard that prevents the browser's default Tab behavior when the selection is inside a table cell, ensuring Tab never causes focus to leave the editor even if the table plugin's handler doesn't catch it.

## Testing

- Added 3 Playwright E2E tests in `e2e/editor-table.spec.ts`:
  - Tab navigates to the next cell without deleting the table
  - Shift+Tab navigates to the previous cell
  - Tab from last cell does not delete the table
- All 467 unit tests pass
- All E2E tests pass (the only failure is a pre-existing flaky test in `members.spec.ts`)