### PR TITLE
fix: enable table cell content persistence test (#402)

### DIFF
--- a/e2e/editor-table.spec.ts
+++ b/e2e/editor-table.spec.ts
@@ -154,11 +154,40 @@ test.describe("Editor table blocks", () => {
     // Blocked by: Tab inside table cell deletes the table
   });
 
-  // Bug: Table cell content is lost after page reload. The table structure
-  // (rows/columns) is preserved but all cell text content is empty after
-  // deserialization.
-  test.skip("table cell content persists after reload", async () => {
-    // Blocked by: table cell content not serialized/deserialized correctly
+  test("table cell content persists after reload", async ({
+    authenticatedPage: page,
+  }) => {
+    // Insert a table and wait for the insertion to be saved
+    const insertSave = waitForContentSave(page);
+    await insertTable(page);
+    await insertSave;
+
+    // Focus the first header cell and type text
+    await focusFirstCell(page);
+    const cellSave = waitForContentSave(page);
+    await page.keyboard.type("Hello");
+    await cellSave;
+
+    // Extra wait to ensure save is fully committed to the database
+    await page.waitForTimeout(500);
+
+    // Reload the page
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // The table should be visible with the cell content preserved
+    const reloadedTable = editor.locator("table");
+    await expect(reloadedTable).toBeVisible({ timeout: 10_000 });
+    await expect(reloadedTable.locator("th").first()).toContainText("Hello", {
+      timeout: 5_000,
+    });
+
+    // Table structure should also be intact
+    await expect(reloadedTable.locator("th")).toHaveCount(3);
+    await expect(reloadedTable.locator("td")).toHaveCount(6);
+    await expect(reloadedTable.locator("tr")).toHaveCount(3);
   });
 
   // Bug: The TableActionMenuPlugin uses createPortal to render a trigger

--- a/src/components/editor/table-serialization.test.ts
+++ b/src/components/editor/table-serialization.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import {
+  createEditor,
+  $getRoot,
+  $createTextNode,
+  $isElementNode,
+  type ElementNode,
+} from "lexical";
+import {
+  TableNode,
+  TableRowNode,
+  TableCellNode,
+  $createTableNodeWithDimensions,
+  $isTableNode,
+  registerTablePlugin,
+} from "@lexical/table";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { ListNode, ListItemNode } from "@lexical/list";
+import { CodeNode, CodeHighlightNode } from "@lexical/code";
+import { AutoLinkNode, LinkNode } from "@lexical/link";
+
+const editorNodes = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  CodeNode,
+  CodeHighlightNode,
+  AutoLinkNode,
+  LinkNode,
+  TableNode,
+  TableRowNode,
+  TableCellNode,
+];
+
+function createTestEditor() {
+  const editor = createEditor({ nodes: editorNodes });
+  registerTablePlugin(editor);
+  return editor;
+}
+
+/** Navigate table → row → cell → paragraph, all with type guards. */
+function $getTableCellParagraph(
+  table: ElementNode,
+  rowIndex: number,
+  cellIndex: number,
+): ElementNode {
+  const row = table.getChildren()[rowIndex];
+  if (!$isElementNode(row)) throw new Error("Expected row to be ElementNode");
+  const cell = row.getChildren()[cellIndex];
+  if (!$isElementNode(cell)) throw new Error("Expected cell to be ElementNode");
+  const paragraph = cell.getFirstChild();
+  if (!$isElementNode(paragraph))
+    throw new Error("Expected paragraph to be ElementNode");
+  return paragraph;
+}
+
+describe("Table cell content serialization roundtrip", () => {
+  it("preserves text typed into a header cell", () => {
+    const editor = createTestEditor();
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const table = $createTableNodeWithDimensions(3, 3, {
+          rows: true,
+          columns: false,
+        });
+        root.append(table);
+        $getTableCellParagraph(table, 0, 0).append($createTextNode("Hello"));
+      },
+      { discrete: true },
+    );
+
+    const json = editor.getEditorState().toJSON();
+    const serialized = JSON.stringify(json);
+
+    const editor2 = createTestEditor();
+    const restored = editor2.parseEditorState(serialized);
+    const json2 = restored.toJSON();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const table = json2.root.children.find((c: any) => c.type === "table") as any;
+    expect(table).toBeDefined();
+
+    const firstCellParagraph = table.children[0].children[0].children[0];
+    expect(firstCellParagraph.children).toHaveLength(1);
+    expect(firstCellParagraph.children[0].text).toBe("Hello");
+  });
+
+  it("preserves text added in a separate update (simulates user typing)", () => {
+    const editor = createTestEditor();
+
+    // Create table in first update
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const table = $createTableNodeWithDimensions(3, 3, {
+          rows: true,
+          columns: false,
+        });
+        root.append(table);
+      },
+      { discrete: true },
+    );
+
+    // Add text in a separate update (like user typing after table creation)
+    editor.update(
+      () => {
+        const root = $getRoot();
+        for (const child of root.getChildren()) {
+          if ($isTableNode(child)) {
+            $getTableCellParagraph(child, 0, 0).append(
+              $createTextNode("World"),
+            );
+            break;
+          }
+        }
+      },
+      { discrete: true },
+    );
+
+    const json = editor.getEditorState().toJSON();
+    const serialized = JSON.stringify(json);
+
+    const editor2 = createTestEditor();
+    const restored = editor2.parseEditorState(serialized);
+    const json2 = restored.toJSON();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const table = json2.root.children.find((c: any) => c.type === "table") as any;
+    const firstCellParagraph = table.children[0].children[0].children[0];
+    expect(firstCellParagraph.children).toHaveLength(1);
+    expect(firstCellParagraph.children[0].text).toBe("World");
+  });
+
+  it("preserves content in multiple cells across rows", () => {
+    const editor = createTestEditor();
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const table = $createTableNodeWithDimensions(3, 3, {
+          rows: true,
+          columns: false,
+        });
+        root.append(table);
+
+        $getTableCellParagraph(table, 0, 0).append(
+          $createTextNode("Header 1"),
+        );
+        $getTableCellParagraph(table, 1, 1).append(
+          $createTextNode("Body 1-2"),
+        );
+        $getTableCellParagraph(table, 2, 2).append(
+          $createTextNode("Body 2-3"),
+        );
+      },
+      { discrete: true },
+    );
+
+    const json = editor.getEditorState().toJSON();
+    const serialized = JSON.stringify(json);
+
+    const editor2 = createTestEditor();
+    const restored = editor2.parseEditorState(serialized);
+    const json2 = restored.toJSON();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const table = json2.root.children.find((c: any) => c.type === "table") as any;
+
+    expect(table.children[0].children[0].children[0].children[0].text).toBe(
+      "Header 1",
+    );
+    expect(table.children[1].children[1].children[0].children[0].text).toBe(
+      "Body 1-2",
+    );
+    expect(table.children[2].children[2].children[0].children[0].text).toBe(
+      "Body 2-3",
+    );
+  });
+
+  it("onChange listener receives state with table cell content", () => {
+    const editor = createTestEditor();
+    let capturedState: string | null = null;
+
+    editor.registerUpdateListener(
+      ({ editorState, dirtyElements, dirtyLeaves, prevEditorState }) => {
+        // Mirror OnChangePlugin's ignoreSelectionChange behavior
+        if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
+        if (prevEditorState.isEmpty()) return;
+        capturedState = JSON.stringify(editorState.toJSON());
+      },
+    );
+
+    // Initial table creation (prevEditorState.isEmpty() → skipped)
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const table = $createTableNodeWithDimensions(3, 3, {
+          rows: true,
+          columns: false,
+        });
+        root.append(table);
+      },
+      { discrete: true },
+    );
+
+    // Type into cell (this should trigger the listener)
+    editor.update(
+      () => {
+        const root = $getRoot();
+        for (const child of root.getChildren()) {
+          if ($isTableNode(child)) {
+            $getTableCellParagraph(child, 0, 0).append(
+              $createTextNode("Captured"),
+            );
+            break;
+          }
+        }
+      },
+      { discrete: true },
+    );
+
+    expect(capturedState).not.toBeNull();
+    expect(capturedState).toContain("Captured");
+  });
+});


### PR DESCRIPTION
Closes #402

## What

The bug reported that table cell text content was lost after saving and reloading a page. Investigation confirmed that the underlying Lexical serialization/deserialization works correctly with Lexical 0.31.0 — the E2E test was skipped with an empty body and was never actually implemented to verify the behavior.

## How

- Implemented the skipped E2E test `table cell content persists after reload` in `e2e/editor-table.spec.ts` — it inserts a table, types "Hello" into the first header cell, waits for auto-save, reloads the page, and verifies the text and table structure are preserved.
- Added a Vitest unit test suite (`table-serialization.test.ts`) covering four scenarios: single-cell roundtrip, separate-update roundtrip (simulating user typing), multi-cell content across rows, and onChange listener integration with table cell edits.

## Testing

- E2E: `pnpm test:e2e -- e2e/editor-table.spec.ts` — 4 passed, 4 skipped (unrelated table bugs)
- Unit: `pnpm test -- src/components/editor/table-serialization.test.ts` — 4 passed
- Full suite: `pnpm lint && pnpm typecheck && pnpm test` — 471 tests passed, 0 errors