### PR TITLE
fix: prevent table cell content loss on save race condition (#402)

### DIFF
--- a/e2e/editor-table.spec.ts
+++ b/e2e/editor-table.spec.ts
@@ -154,11 +154,44 @@ test.describe("Editor table blocks", () => {
     // Blocked by: Tab inside table cell deletes the table
   });
 
-  // Bug: Table cell content is lost after page reload. The table structure
-  // (rows/columns) is preserved but all cell text content is empty after
-  // deserialization.
-  test.skip("table cell content persists after reload", async () => {
-    // Blocked by: table cell content not serialized/deserialized correctly
+  test("table cell content persists after reload", async ({
+    authenticatedPage: page,
+  }) => {
+    await insertTable(page);
+
+    // Type text into the first header cell
+    await focusFirstCell(page);
+    await page.keyboard.type("Hello Table");
+
+    // Verify text is in the cell before saving
+    const editor = page.locator('[contenteditable="true"]');
+    const table = editor.locator("table");
+    await expect(table.locator("th").first()).toContainText("Hello Table", {
+      timeout: 3_000,
+    });
+
+    // Wait for auto-save to persist the cell content. The save debounce
+    // fires after the last keystroke, so we wait for the PATCH response.
+    const saveResponse = waitForContentSave(page);
+    await saveResponse;
+
+    // Wait briefly for any follow-up saves (the fix in #402 re-schedules
+    // saves when new changes arrive while a save is in-flight).
+    await page.waitForTimeout(1_500);
+
+    // Reload the page
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    // The table structure AND cell content should be preserved
+    const reloadedTable = editor.locator("table");
+    await expect(reloadedTable).toBeVisible({ timeout: 10_000 });
+    await expect(reloadedTable.locator("th")).toHaveCount(3);
+    await expect(reloadedTable.locator("th").first()).toContainText(
+      "Hello Table",
+      { timeout: 5_000 },
+    );
   });
 
   // Bug: The TableActionMenuPlugin uses createPortal to render a trigger

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@lexical/headless": "0.31.0",
     "@playwright/test": "^1.59.1",
     "@storybook/addon-essentials": "^8.6.14",
     "@storybook/addon-interactions": "^8.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
     devDependencies:
+      '@lexical/headless':
+        specifier: 0.31.0
+        version: 0.31.0
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -170,7 +173,7 @@ importers:
         version: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
 
 packages:
 
@@ -918,6 +921,9 @@ packages:
 
   '@lexical/hashtag@0.31.0':
     resolution: {integrity: sha512-7dX0muZQjMLcRlXTh7Fx+FiGpcIQfANDfyAFYNaJrY+WUpZpTQ8L9w0EZ284G/aDNd5tQLdRgkd651A7D0VxFA==}
+
+  '@lexical/headless@0.31.0':
+    resolution: {integrity: sha512-sNp5yD0P7u0G7TElsSsxDiP+bTV3Wpdruy5cpx7tdXuDO6CMrlIgdN9fdEkOC8Rca6OfYx20/0MUCeaqRYHJuw==}
 
   '@lexical/history@0.31.0':
     resolution: {integrity: sha512-GqMrooznsR108GfqohtXroLGWzYRVYh6pbCYAgocq/LJPKet+kbbDT/AAEqvqGn/ohke0wama0qmjDITx30IcA==}
@@ -2072,6 +2078,9 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2897,6 +2906,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -3335,6 +3348,10 @@ packages:
   graphql@16.13.2:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -5098,6 +5115,10 @@ packages:
       webpack-cli:
         optional: true
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -5937,6 +5958,10 @@ snapshots:
   '@lexical/hashtag@0.31.0':
     dependencies:
       '@lexical/utils': 0.31.0
+      lexical: 0.31.0
+
+  '@lexical/headless@0.31.0':
+    dependencies:
       lexical: 0.31.0
 
   '@lexical/history@0.31.0':
@@ -7251,6 +7276,9 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
+  '@types/whatwg-mimetype@3.0.2':
+    optional: true
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 20.19.39
@@ -7429,7 +7457,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
 
   '@vitest/expect@2.0.5':
     dependencies:
@@ -8089,6 +8117,9 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1:
+    optional: true
+
   env-paths@2.2.1: {}
 
   error-ex@1.3.4:
@@ -8739,6 +8770,19 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 20.19.39
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+    optional: true
 
   has-bigints@1.1.0: {}
 
@@ -10499,7 +10543,7 @@ snapshots:
       lightningcss: 1.32.0
       terser: 5.46.1
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.3(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.13.3(@types/node@20.19.39)(typescript@5.9.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
@@ -10525,6 +10569,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.39
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      happy-dom: 20.9.0
       jsdom: 29.0.2(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
@@ -10579,6 +10624,9 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-mimetype@3.0.0:
+    optional: true
 
   whatwg-mimetype@5.0.0: {}
 

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -178,6 +178,11 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
     initialContent ? JSON.stringify(initialContent) : ""
   );
   const lastVersionSavedAtRef = useRef<number>(0);
+  // Track the latest pending state so we always save the most recent content
+  // and only show "Saved" when the persisted state matches the latest state.
+  const pendingJsonRef = useRef<SerializedEditorState | null>(null);
+  const pendingSerializedRef = useRef<string | null>(null);
+  const isSavingRef = useRef(false);
   const [floatingAnchorElem, setFloatingAnchorElem] =
     useState<HTMLDivElement | null>(null);
 
@@ -187,6 +192,11 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
     }
   }, []);
 
+  // Persist the latest pending content to Supabase. Serialises one save at
+  // a time: if new changes arrive while a PATCH is in-flight, another save
+  // is scheduled automatically once the current one completes. This prevents
+  // an earlier save (e.g. empty table) from overwriting a later one (table
+  // with cell text) — the root cause of #402.
   const handleChange = useCallback(
     (editorState: EditorState) => {
       const json = editorState.toJSON();
@@ -194,25 +204,52 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
 
       if (serialized === lastSavedRef.current) return;
 
+      // Always store the latest state so the save sends the newest content
+      pendingJsonRef.current = json;
+      pendingSerializedRef.current = serialized;
+
       setSaveStatus("saving");
 
       if (saveTimerRef.current) {
         clearTimeout(saveTimerRef.current);
       }
 
-      saveTimerRef.current = setTimeout(async () => {
+      // If a save is already in-flight, don't start a new timer — the
+      // in-flight save will re-schedule when it completes.
+      if (isSavingRef.current) return;
+
+      const doSave = async () => {
+        const pendingJson = pendingJsonRef.current;
+        const pendingSerialized = pendingSerializedRef.current;
+        if (!pendingJson || !pendingSerialized) return;
+
+        // Snapshot and clear so concurrent changes accumulate in a new pending slot
+        pendingJsonRef.current = null;
+        pendingSerializedRef.current = null;
+        isSavingRef.current = true;
+
         const supabase = await getClient();
         const { error } = await supabase
           .from("pages")
-          .update({ content: json })
+          .update({ content: pendingJson })
           .eq("id", pageId);
 
+        isSavingRef.current = false;
+
         if (!error) {
-          lastSavedRef.current = serialized;
-          setSaveStatus("saved");
+          lastSavedRef.current = pendingSerialized;
+
+          // If new changes arrived while this save was in-flight, re-save
+          // instead of showing "Saved".
+          if (pendingSerializedRef.current !== null) {
+            if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+            saveTimerRef.current = setTimeout(doSave, SAVE_DEBOUNCE_MS);
+          } else {
+            setSaveStatus("saved");
+          }
 
           // Sync page_links in the background after successful save
-          const linkedPageIds = extractPageLinkIds(json);
+          const linkedPageIds = extractPageLinkIds(pendingJson);
           syncPageLinks(pageId, workspaceId, linkedPageIds).catch((err) =>
             lazyCaptureException(err),
           );
@@ -227,7 +264,7 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
             fetch(`/api/pages/${pageId}/versions`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ content: json }),
+              body: JSON.stringify({ content: pendingJson }),
             }).catch(() => {
               // Reset so the next content save retries immediately
               // instead of waiting another full interval.
@@ -238,9 +275,11 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
           lazyCaptureException(error);
           setSaveStatus("error");
         }
-      }, SAVE_DEBOUNCE_MS);
+      };
+
+      saveTimerRef.current = setTimeout(doSave, SAVE_DEBOUNCE_MS);
     },
-    [pageId, workspaceId]
+    [pageId, workspaceId],
   );
 
   useEffect(() => {

--- a/src/components/editor/table-serialization.test.ts
+++ b/src/components/editor/table-serialization.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Test table cell content serialization round-trip.
+ *
+ * Reproduces the bug from #402: table cell text content is lost after
+ * save and reload. The table structure (rows, columns, header/body
+ * distinction) is preserved, but all cell text content is empty after
+ * deserialization.
+ */
+import { describe, it, expect } from "vitest";
+import { createHeadlessEditor } from "@lexical/headless";
+import {
+  TableNode,
+  TableRowNode,
+  TableCellNode,
+  $createTableNodeWithDimensions,
+  registerTablePlugin,
+} from "@lexical/table";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { ListNode, ListItemNode } from "@lexical/list";
+import { CodeNode, CodeHighlightNode } from "@lexical/code";
+import { AutoLinkNode, LinkNode } from "@lexical/link";
+import {
+  $getRoot,
+  $createTextNode,
+  $isTextNode,
+  $isElementNode,
+  type SerializedEditorState,
+} from "lexical";
+
+const EDITOR_NODES = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  CodeNode,
+  CodeHighlightNode,
+  AutoLinkNode,
+  LinkNode,
+  TableNode,
+  TableRowNode,
+  TableCellNode,
+];
+
+/**
+ * Create a headless editor with the same node set as the real editor,
+ * insert a 3×3 table, type text into the first header cell, and return
+ * the serialized editor state (what `editorState.toJSON()` produces).
+ */
+function createTableWithContent(cellText: string): SerializedEditorState {
+  const editor = createHeadlessEditor({ nodes: EDITOR_NODES });
+  registerTablePlugin(editor);
+
+  editor.update(
+    () => {
+      const root = $getRoot();
+      root.clear();
+      const table = $createTableNodeWithDimensions(3, 3, {
+        rows: true,
+        columns: false,
+      });
+      root.append(table);
+
+      // Type text into the first header cell's text node
+      const firstTextNode = table.getFirstDescendant();
+      if ($isTextNode(firstTextNode)) {
+        firstTextNode.setTextContent(cellText);
+      }
+    },
+    { discrete: true },
+  );
+
+  return editor.getEditorState().toJSON();
+}
+
+/**
+ * Simulate the exact load path used by the Editor component:
+ *
+ * 1. `initialContent` comes from Supabase as a parsed JSON object
+ * 2. Editor component does `JSON.stringify(initialContent)` for `editorState`
+ * 3. LexicalComposer calls `editor.parseEditorState(string)`
+ * 4. Then `editor.setEditorState(parsed)`
+ * 5. TablePlugin mounts and registers transforms
+ *
+ * Returns the final serialized state after all transforms have run.
+ */
+function loadEditorState(
+  savedContent: SerializedEditorState,
+): SerializedEditorState {
+  // Simulate Supabase round-trip: jsonb stores parsed JSON
+  const fromSupabase = JSON.parse(
+    JSON.stringify(savedContent),
+  ) as SerializedEditorState;
+
+  // Simulate Editor component: JSON.stringify(initialContent)
+  const editorStateString = JSON.stringify(fromSupabase);
+
+  // Create a fresh editor (simulating page reload)
+  const editor = createHeadlessEditor({ nodes: EDITOR_NODES });
+
+  // Simulate LexicalComposer's initializeEditor for string type
+  const parsedState = editor.parseEditorState(editorStateString);
+  editor.setEditorState(parsedState, { tag: "history-merge" });
+
+  // Simulate TablePlugin mounting after setEditorState
+  registerTablePlugin(editor);
+
+  return editor.getEditorState().toJSON();
+}
+
+/** Walk the serialized state tree and extract text from the first table cell. */
+function getFirstCellText(state: SerializedEditorState): string {
+  const root = state.root;
+  // root > table > row > cell > paragraph > text
+  const table = root.children[0] as Record<string, unknown>;
+  const row = (table.children as Record<string, unknown>[])[0];
+  const cell = (row.children as Record<string, unknown>[])[0];
+  const paragraph = (cell.children as Record<string, unknown>[])[0];
+  const children = paragraph.children as Record<string, unknown>[];
+  if (children.length === 0) return "";
+  return (children[0].text as string) ?? "";
+}
+
+describe("Table cell content serialization (#402)", () => {
+  it("serializes table cell text content", () => {
+    const saved = createTableWithContent("Hello");
+    expect(getFirstCellText(saved)).toBe("Hello");
+  });
+
+  it("preserves table cell text after JSON round-trip", () => {
+    const saved = createTableWithContent("Hello");
+    const stringified = JSON.stringify(saved);
+    const parsed = JSON.parse(stringified) as SerializedEditorState;
+    expect(getFirstCellText(parsed)).toBe("Hello");
+  });
+
+  it("preserves table cell text after full save/load cycle", () => {
+    const saved = createTableWithContent("Hello");
+    const loaded = loadEditorState(saved);
+    expect(getFirstCellText(loaded)).toBe("Hello");
+  });
+
+  it("preserves table cell text with special characters", () => {
+    const saved = createTableWithContent('Hello "World" & <Friends>');
+    const loaded = loadEditorState(saved);
+    expect(getFirstCellText(loaded)).toBe('Hello "World" & <Friends>');
+  });
+
+  it("preserves table structure after save/load cycle", () => {
+    const saved = createTableWithContent("Hello");
+    const loaded = loadEditorState(saved);
+
+    const table = loaded.root.children[0] as Record<string, unknown>;
+    expect(table.type).toBe("table");
+
+    const rows = table.children as Record<string, unknown>[];
+    expect(rows).toHaveLength(3);
+
+    const firstRow = rows[0];
+    const cells = firstRow.children as Record<string, unknown>[];
+    expect(cells).toHaveLength(3);
+    expect(cells[0].type).toBe("tablecell");
+    expect((cells[0] as { headerState: number }).headerState).toBe(1);
+  });
+
+  it("preserves multiple cells with content", () => {
+    const editor = createHeadlessEditor({ nodes: EDITOR_NODES });
+    registerTablePlugin(editor);
+
+    editor.update(
+      () => {
+        const root = $getRoot();
+        root.clear();
+        const table = $createTableNodeWithDimensions(3, 3, {
+          rows: true,
+          columns: false,
+        });
+        root.append(table);
+
+        // Fill multiple cells
+        const rows = table.getChildren();
+        for (let r = 0; r < rows.length; r++) {
+          const row = rows[r];
+          if (!$isElementNode(row)) continue;
+          const cells = row.getChildren();
+          for (let c = 0; c < cells.length; c++) {
+            const cell = cells[c];
+            if (!$isElementNode(cell)) continue;
+            const paragraph = cell.getFirstChild();
+            if ($isElementNode(paragraph)) {
+              const textNode = paragraph.getFirstChild();
+              if ($isTextNode(textNode)) {
+                textNode.setTextContent(`R${r}C${c}`);
+              } else {
+                paragraph.append($createTextNode(`R${r}C${c}`));
+              }
+            }
+          }
+        }
+      },
+      { discrete: true },
+    );
+
+    const saved = editor.getEditorState().toJSON();
+    const loaded = loadEditorState(saved);
+
+    // Verify all cells have content
+    const table = loaded.root.children[0] as Record<string, unknown>;
+    const rows = table.children as Record<string, unknown>[];
+    for (let r = 0; r < 3; r++) {
+      const cells = rows[r].children as Record<string, unknown>[];
+      for (let c = 0; c < 3; c++) {
+        const paragraph = (cells[c].children as Record<string, unknown>[])[0];
+        const textNodes = paragraph.children as Record<string, unknown>[];
+        expect(textNodes.length).toBeGreaterThan(0);
+        expect(textNodes[0].text).toBe(`R${r}C${c}`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #402

## What
Table cell text content was lost after saving and reloading a page. The table structure (rows, columns, header/body distinction) was preserved, but all cell text was empty after reload.

The root cause was a race condition in the editor's debounced auto-save mechanism. When a table was inserted, the `OnChangePlugin` fired immediately with the empty table state and started a 500ms debounce timer. If the timer fired before the user typed into a cell, the empty table was saved. When the user then typed text, a second save was scheduled — but the first save's completion set the status to "Saved", misleading the user into thinking their text was persisted. If they reloaded at that point, the database still had the empty table.

Additionally, two PATCH requests could be in-flight simultaneously with no coordination, allowing an older save to overwrite a newer one.

## How
Rewrote the save mechanism to serialise saves one at a time:

- **Pending state refs**: `pendingJsonRef` and `pendingSerializedRef` always hold the latest editor state. The `handleChange` callback updates these on every change, ensuring the save always sends the most recent content.
- **In-flight guard**: `isSavingRef` prevents starting a new debounce timer while a PATCH is in-flight. When the in-flight save completes, it checks if new changes arrived and re-schedules automatically.
- **Accurate status**: The "Saved" indicator only appears when the persisted state matches the latest pending state. If changes arrived during a save, the status stays at "Saving..." until the follow-up save completes.

## Testing
- Added `table-serialization.test.ts` (6 Vitest tests) verifying the Lexical serialization round-trip for table cell content through the exact same code path as the editor (create → toJSON → JSON.stringify → parseEditorState → setEditorState → registerTablePlugin → toJSON).
- Enabled the previously-skipped E2E test `"table cell content persists after reload"` in `e2e/editor-table.spec.ts` — inserts a table, types text into a header cell, waits for auto-save, reloads, and verifies the text is preserved.
- All 473 existing tests continue to pass.