### PR TITLE
fix: Tab inside table cell crashes editor (#401)

### DIFF
--- a/e2e/editor-table.spec.ts
+++ b/e2e/editor-table.spec.ts
@@ -147,11 +147,63 @@ test.describe("Editor table blocks", () => {
   // --- Skipped tests: blocked by pre-existing bugs ---
   // These are tracked as separate bug issues.
 
-  // Bug: Tab inside a table cell removes the entire table from the DOM
-  // instead of navigating to the next cell. The TablePlugin has
-  // hasTabHandler={true} but the Tab handler doesn't work correctly.
-  test.skip("user can navigate between cells with Tab", async () => {
-    // Blocked by: Tab inside table cell deletes the table
+  test("user can navigate between cells with Tab", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    const table = await insertTable(page);
+
+    // Focus the first header cell and type text
+    await focusFirstCell(page);
+    await page.keyboard.type("A1");
+    await expect(table.locator("th").first()).toContainText("A1", {
+      timeout: 3_000,
+    });
+
+    // The table must still exist after typing
+    await expect(editor.locator("table")).toBeVisible();
+
+    // Press Tab — cursor should move to the next cell
+    await page.keyboard.press("Tab");
+    await page.waitForTimeout(300);
+
+    // The table must still be in the DOM after pressing Tab
+    await expect(editor.locator("table")).toBeVisible({ timeout: 3_000 });
+
+    // Type in the second cell to prove the cursor moved
+    await page.keyboard.type("B1");
+    await expect(table.locator("th").nth(1)).toContainText("B1", {
+      timeout: 3_000,
+    });
+
+    // Press Tab again to move to the third header cell
+    await page.keyboard.press("Tab");
+    await page.waitForTimeout(300);
+    await page.keyboard.type("C1");
+    await expect(table.locator("th").nth(2)).toContainText("C1", {
+      timeout: 3_000,
+    });
+
+    // Press Tab once more to wrap to the first body row
+    await page.keyboard.press("Tab");
+    await page.waitForTimeout(300);
+    await page.keyboard.type("A2");
+    await expect(table.locator("td").first()).toContainText("A2", {
+      timeout: 3_000,
+    });
+
+    // Shift+Tab should move back to the previous cell (third header)
+    await page.keyboard.press("Shift+Tab");
+    await page.waitForTimeout(300);
+    await page.keyboard.type("-end");
+    await expect(table.locator("th").nth(2)).toContainText("C1-end", {
+      timeout: 3_000,
+    });
+
+    // Table structure should be unchanged throughout
+    await expect(table.locator("th")).toHaveCount(3);
+    await expect(table.locator("td")).toHaveCount(6);
+    await expect(table.locator("tr")).toHaveCount(3);
   });
 
   // Bug: Table cell content is lost after page reload. The table structure

--- a/src/components/editor/list-tab-indentation-plugin.tsx
+++ b/src/components/editor/list-tab-indentation-plugin.tsx
@@ -3,7 +3,11 @@
 import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $isListItemNode } from "@lexical/list";
-import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils";
+import {
+  $findMatchingParent,
+  $getNearestBlockElementAncestorOrThrow,
+} from "@lexical/utils";
+import { $isTableCellNode } from "@lexical/table";
 import {
   $getSelection,
   $isRangeSelection,
@@ -22,6 +26,13 @@ const MAX_LIST_INDENT = 7;
  * canIndent(), so Tab in the middle/end of a list item inserts a tab
  * character instead of nesting. This plugin intercepts Tab at a higher
  * priority and dispatches INDENT/OUTDENT commands when inside a list item.
+ *
+ * Explicitly yields to the TablePlugin's Tab handler (registered at
+ * COMMAND_PRIORITY_CRITICAL) when the selection is inside a table cell.
+ * Without this guard, $getNearestBlockElementAncestorOrThrow can throw
+ * in edge cases within table cells, preventing the event from being
+ * handled and causing the browser's default Tab behaviour to corrupt
+ * the table DOM.
  */
 export function ListTabIndentationPlugin(): null {
   const [editor] = useLexicalComposerContext();
@@ -36,6 +47,12 @@ export function ListTabIndentationPlugin(): null {
         }
 
         const anchor = selection.anchor.getNode();
+
+        // Let the TablePlugin handle Tab inside table cells.
+        if ($findMatchingParent(anchor, $isTableCellNode) !== null) {
+          return false;
+        }
+
         const block = $getNearestBlockElementAncestorOrThrow(anchor);
 
         if (!$isListItemNode(block)) {

--- a/src/components/editor/table-action-menu-plugin.tsx
+++ b/src/components/editor/table-action-menu-plugin.tsx
@@ -171,6 +171,12 @@ function TableActionMenu({
   );
 }
 
+/**
+ * Renders the menu trigger as a fixed-position overlay portaled to
+ * document.body instead of into the Lexical-managed cell DOM.
+ * Portaling React content into Lexical DOM nodes causes removeChild
+ * errors when Lexical reconciles the table (e.g. on Tab cell navigation).
+ */
 export function TableActionMenuPlugin(): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [tableCellNode, setTableCellNode] = useState<TableCellNode | null>(
@@ -218,18 +224,19 @@ export function TableActionMenuPlugin(): JSX.Element | null {
     return null;
   }
 
-  // Render a small menu trigger button in the top-right of the active cell
+  // Compute the cell rect during render — no effect needed
   const cellDom = editor.getElementByKey(tableCellNode.getKey());
   if (!cellDom) {
     return null;
   }
+  const cellRect = cellDom.getBoundingClientRect();
 
-  return (
+  return createPortal(
     <>
-      {createPortal(
-        <TableCellMenuTrigger onMenuOpen={handleMenuOpen} />,
-        cellDom
-      )}
+      <TableCellMenuTrigger
+        onMenuOpen={handleMenuOpen}
+        cellRect={cellRect}
+      />
       {menuPosition && (
         <TableActionMenu
           editor={editor}
@@ -238,21 +245,27 @@ export function TableActionMenuPlugin(): JSX.Element | null {
           anchorPosition={menuPosition}
         />
       )}
-    </>
+    </>,
+    document.body
   );
 }
 
 function TableCellMenuTrigger({
   onMenuOpen,
+  cellRect,
 }: {
   onMenuOpen: (event: React.MouseEvent) => void;
+  cellRect: DOMRect;
 }) {
   return (
     <button
-      className="absolute right-0.5 top-0.5 flex h-5 w-5 items-center justify-center text-muted-foreground opacity-0 hover:opacity-100 focus:opacity-100 [td:hover>&]:opacity-60 [th:hover>&]:opacity-60"
+      className="fixed z-40 flex h-5 w-5 items-center justify-center text-muted-foreground opacity-60 hover:opacity-100 focus:opacity-100"
+      style={{
+        top: cellRect.top + 2,
+        left: cellRect.right - 22,
+      }}
       onClick={onMenuOpen}
       aria-label="Table cell actions"
-      contentEditable={false}
     >
       <MoreHorizontal className="h-3.5 w-3.5" />
     </button>


### PR DESCRIPTION
Closes #401

## What

Pressing Tab while the cursor is inside a table cell crashed the editor with a `NotFoundError: Failed to execute 'removeChild' on 'Node'`. The `TableActionMenuPlugin` portaled a React button directly into the Lexical-managed cell DOM element via `createPortal(trigger, cellDom)`. When the TablePlugin's Tab handler moved the selection to the next cell, Lexical reconciled the table DOM while React still held a reference to the old portal container, causing the removeChild error that propagated to the error boundary.

## How

- **`table-action-menu-plugin.tsx`**: Portal the menu trigger and action menu to `document.body` instead of into the cell DOM. The trigger button is positioned using `fixed` positioning derived from the cell's `getBoundingClientRect()`.
- **`list-tab-indentation-plugin.tsx`**: Added a `$isTableCellNode` guard that returns `false` early when the selection is inside a table cell, yielding to the TablePlugin's Tab handler at `COMMAND_PRIORITY_CRITICAL`. This prevents `$getNearestBlockElementAncestorOrThrow` from running in table cell contexts.

## Testing

- Replaced the skipped `"user can navigate between cells with Tab"` E2E test with a full regression test covering:
  - Tab navigates forward through header cells
  - Tab wraps from the last header cell to the first body row
  - Shift+Tab navigates backward
  - Table structure (3 rows × 3 columns) is preserved throughout
  - Text typed after each Tab lands in the correct cell
- All existing table E2E tests continue to pass
- `pnpm lint && pnpm typecheck && pnpm test` all pass