### PR TITLE
feat: add feedback digest automation for Slack (#396)

### DIFF
--- a/.ona/automations/feedback-digest.yaml
+++ b/.ona/automations/feedback-digest.yaml
@@ -1,0 +1,163 @@
+name: Feedback Digest
+description: Reads new user feedback and usage events daily, then posts a categorized digest to Slack.
+triggers:
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: "0 8 * * *"
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      manual: {}
+action:
+    limits:
+        maxParallel: 1
+        maxTotal: 10
+    steps:
+        - agent:
+            prompt: |
+                You are the Feedback Digest automation. You read new user feedback and recent
+                usage events from Supabase, categorize the feedback, cross-reference it with
+                usage data, and post a digest to the #memo-user-feedback Slack channel.
+
+                ## Prerequisites
+
+                You need the Supabase service role key to read all feedback (RLS blocks regular
+                users from SELECT on user_feedback). The environment provides SUPABASE_URL and
+                SUPABASE_SERVICE_ROLE_KEY.
+
+                Slack is connected via MCP — use the Slack tools directly (slack_search_channels,
+                slack_send_message). Do NOT use curl or the Slack REST API.
+
+                ## Step 1: Query new feedback
+
+                Use the Supabase Management API or a direct SQL query via the service role to
+                fetch all rows from `user_feedback` where `status = 'new'`:
+
+                ```bash
+                curl -s "${SUPABASE_URL}/rest/v1/user_feedback?status=eq.new&order=created_at.asc" \
+                  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+                  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
+                ```
+
+                If the result is an empty array, post a brief message to Slack:
+                "📊 **Feedback Digest — YYYY-MM-DD** — No new feedback today."
+                Then stop.
+
+                ## Step 2: Query usage events (past 7 days)
+
+                Fetch usage events from the last 7 days, grouped by event_name:
+
+                ```bash
+                SEVEN_DAYS_AGO=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+                curl -s "${SUPABASE_URL}/rest/v1/rpc/usage_event_counts_7d" \
+                  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+                  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+                  -X POST -H "Content-Type: application/json" \
+                  -d "{}"
+                ```
+
+                If the RPC function does not exist, fall back to fetching raw events:
+
+                ```bash
+                curl -s "${SUPABASE_URL}/rest/v1/usage_events?created_at=gte.${SEVEN_DAYS_AGO}&order=event_name.asc&select=event_name" \
+                  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+                  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
+                ```
+
+                Then count occurrences of each event_name locally.
+
+                ## Step 3: Categorize feedback
+
+                Sort each feedback item into one of three categories:
+
+                1. **Bugs** — type = 'bug', or message describes broken behavior.
+                   For each: summarize the issue, include page_path, propose a next step
+                   (investigate, file an issue, or dismiss with reason).
+
+                2. **Feature Requests** — type = 'feature', or message requests new functionality.
+                   Group by theme (e.g., multiple requests about "PDF export" become one theme).
+                   For each theme: count of requests, summary, proposed next step.
+
+                3. **General / Noise** — type = 'general', or feedback that is not actionable.
+                   Briefly list or summarize. Propose dismiss with reason if not actionable.
+
+                ## Step 4: Cross-reference with usage data
+
+                Highlight interesting patterns:
+                - Features with feedback but LOW usage (< 10 events in 7 days) — may indicate
+                  discoverability issues.
+                - Features with HIGH usage (top 5 by count) but NO feedback — likely stable.
+                - Features with both high usage AND feedback — prioritize these.
+
+                If usage data is empty or unavailable, skip this section and note it.
+
+                ## Step 5: Compose and post the digest
+
+                Find the #memo-user-feedback channel:
+                ```
+                slack_search_channels(query="memo-user-feedback")
+                ```
+
+                Compose the digest message in this format:
+
+                ```
+                ## Feedback Digest — YYYY-MM-DD
+
+                **Summary:** N new items (X bugs, Y feature requests, Z general)
+
+                ### 🐛 Bugs
+                - "Error description" (page: /path) → Propose: investigate, likely related to X
+                - ...
+
+                ### 💡 Feature Requests
+                - Theme: "Feature name" (N requests) → Propose: file issue for feature
+                - ...
+
+                ### 💬 General
+                - "Comment summary" → Propose: dismiss, not actionable because X
+                - ...
+
+                ### 📈 Usage Highlights (past 7 days)
+                - Most used: event_name (N), event_name (N)
+                - Least used: event_name (N)
+                - Notable: event_name has N feedback items but only M uses this week
+
+                ### Proposed Actions
+                1. Investigate: "bug description"
+                2. File issue: "feature theme"
+                3. Dismiss: "noise item" — reason
+                ```
+
+                Post the digest using:
+                ```
+                slack_send_message(channel_id="<channel_id>", message="<digest>")
+                ```
+
+                ## Step 6: Mark feedback as reviewed
+
+                After successfully posting the digest, update all processed feedback rows
+                to `status = 'reviewed'`:
+
+                ```bash
+                curl -s "${SUPABASE_URL}/rest/v1/user_feedback?status=eq.new" \
+                  -X PATCH \
+                  -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+                  -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+                  -H "Content-Type: application/json" \
+                  -H "Prefer: return=minimal" \
+                  -d '{"status": "reviewed"}'
+                ```
+
+                Confirm the PATCH returned a 2xx status.
+
+                ## Rules
+
+                - Do NOT auto-file GitHub issues. Only propose actions in the Slack digest.
+                - If no new feedback exists, post a brief "no new feedback" message or skip.
+                - If Supabase or Slack calls fail, report the error clearly — do not silently exit.
+                - Keep the digest concise. Summarize, do not dump raw data.
+                - Use real data only. Do not fabricate feedback or usage numbers.

--- a/.ona/skills/automation-manager/references/registry.md
+++ b/.ona/skills/automation-manager/references/registry.md
@@ -17,6 +17,7 @@ Mapping between YAML files in `.ona/automations/` and their registered Ona autom
 | pr-shepherd.yaml | PR Shepherd | 019d8dcc-adc3-7d23-a2b9-39aa4fbd6463 |
 | tweet-drafter.yaml | Tweet Drafter | 019d8da2-46d3-7493-8bd5-7191a31f47ec |
 | ui-verifier.yaml | UI Verifier | 019d8d99-7474-725b-aa77-0310122b2c64 |
+| feedback-digest.yaml | Feedback Digest | 019db0ae-1ef0-722c-b83f-0fc9186c43c1 |
 | weekly-recap.yaml | Weekly Recap | 019d8d98-3e15-762d-a6e8-4ca0ea77acb5 |
 
 ## Keeping this file in sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ These automations work together to implement features and fix bugs autonomously:
 | Post-Merge Verifier | On PR merge | Smoke-tests production after merge |
 | UI Verifier | On PR merge | Checks design spec compliance |
 | Performance Monitor | Weekly | Checks latency, errors, build size |
+| Feedback Digest | Daily (8 AM UTC) | Posts categorized user feedback digest to Slack |
 | Needs-Human Requeue | Cron (30 min) | Re-queues issues after user responds |
 
 For full details on the development workflow, see `.ona/skills/development-workflow/SKILL.md`.


### PR DESCRIPTION
Closes #396

## What

Adds a daily Ona automation that reads new user feedback from the `user_feedback` table, cross-references it with `usage_events` data, categorizes the feedback (bugs, feature requests, general), and posts a digest to the `#memo-user-feedback` Slack channel.

## How

- New `.ona/automations/feedback-digest.yaml` with daily cron trigger (`0 8 * * *`) and manual trigger
- The automation prompt instructs the agent to:
  1. Query `user_feedback` where `status = 'new'` via Supabase REST API (service role)
  2. Query `usage_events` for the past 7 days, grouped by event name
  3. Categorize feedback into bugs, feature requests, and general/noise
  4. Cross-reference feedback with usage data to highlight patterns (high usage + feedback, low usage + feedback)
  5. Post a formatted digest to `#memo-user-feedback` via Slack MCP tools
  6. Mark processed feedback as `status = 'reviewed'`
- `maxParallel: 1`, `maxTotal: 10`
- Does NOT auto-file GitHub issues — only proposes actions in the Slack digest
- Registered with Ona CLI (ID: `019db0ae-1ef0-722c-b83f-0fc9186c43c1`)
- Updated automation registry and AGENTS.md automation table

## Testing

- `pnpm lint` — ✅ passes (0 errors)
- `pnpm typecheck` — ✅ passes
- `pnpm test` — ✅ 473 tests pass
- This is a YAML-only automation — no TypeScript code to test. Runtime behavior is verified by manual trigger after merge.