### PR TITLE
fix: table action menu trigger position drifts on scroll (#403)

### DIFF
--- a/e2e/editor-table.spec.ts
+++ b/e2e/editor-table.spec.ts
@@ -246,18 +246,99 @@ test.describe("Editor table blocks", () => {
     );
   });
 
-  // Bug: The TableActionMenuPlugin uses createPortal to render a trigger
-  // button into the table cell DOM, but Lexical's DOM reconciler removes
-  // the portaled content. The trigger button never appears in the DOM.
-  test.skip("user can add a row via the table action menu", async () => {
-    // Blocked by: table action menu trigger not rendering
+  test("user can add a row via the table action menu", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    const table = await insertTable(page);
+
+    // Default: 3 rows (1 header + 2 body)
+    await expect(table.locator("tr")).toHaveCount(3);
+
+    // Focus the first header cell to activate the trigger
+    await focusFirstCell(page);
+
+    const trigger = page.locator('button[aria-label="Table cell actions"]');
+    await expect(trigger).toBeVisible({ timeout: 5_000 });
+    await trigger.click();
+
+    const insertBelow = page.getByText("Insert row below");
+    await expect(insertBelow).toBeVisible({ timeout: 3_000 });
+    await insertBelow.click();
+
+    // Now 4 rows
+    await expect(table.locator("tr")).toHaveCount(4, { timeout: 3_000 });
+    // Column count unchanged
+    await expect(table.locator("th")).toHaveCount(3);
   });
 
-  test.skip("user can add a column via the table action menu", async () => {
-    // Blocked by: table action menu trigger not rendering
+  test("user can add a column via the table action menu", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    const table = await insertTable(page);
+
+    // Default: 3 columns
+    await expect(table.locator("th")).toHaveCount(3);
+
+    await focusFirstCell(page);
+
+    const trigger = page.locator('button[aria-label="Table cell actions"]');
+    await expect(trigger).toBeVisible({ timeout: 5_000 });
+    await trigger.click();
+
+    const insertRight = page.getByText("Insert column right");
+    await expect(insertRight).toBeVisible({ timeout: 3_000 });
+    await insertRight.click();
+
+    // Now 4 columns in the header row
+    await expect(table.locator("th")).toHaveCount(4, { timeout: 3_000 });
+    // Body rows also have 4 cells each (2 body rows × 4 = 8)
+    await expect(table.locator("td")).toHaveCount(8, { timeout: 3_000 });
+    // Row count unchanged
+    await expect(table.locator("tr")).toHaveCount(3);
   });
 
-  test.skip("user can delete a row and a column via the table action menu", async () => {
-    // Blocked by: table action menu trigger not rendering
+  test("user can delete a row and a column via the table action menu", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    const table = await insertTable(page);
+
+    // Default: 3 rows, 3 columns
+    await expect(table.locator("tr")).toHaveCount(3);
+    await expect(table.locator("th")).toHaveCount(3);
+
+    // Click into a body cell (first td) to delete a body row
+    const firstTd = table.locator("td").first();
+    await expect(firstTd).toBeVisible({ timeout: 3_000 });
+    await firstTd.click();
+    await page.waitForTimeout(500);
+
+    const trigger = page.locator('button[aria-label="Table cell actions"]');
+    await expect(trigger).toBeVisible({ timeout: 5_000 });
+    await trigger.click();
+
+    const deleteRow = page.getByText("Delete row");
+    await expect(deleteRow).toBeVisible({ timeout: 3_000 });
+    await deleteRow.click();
+
+    // Now 2 rows (1 header + 1 body)
+    await expect(table.locator("tr")).toHaveCount(2, { timeout: 3_000 });
+
+    // Focus a cell again to delete a column
+    await focusFirstCell(page);
+
+    await expect(trigger).toBeVisible({ timeout: 5_000 });
+    await trigger.click();
+
+    const deleteCol = page.getByText("Delete column");
+    await expect(deleteCol).toBeVisible({ timeout: 3_000 });
+    await deleteCol.click();
+
+    // Now 2 columns
+    await expect(table.locator("th")).toHaveCount(2, { timeout: 3_000 });
+    // 1 body row × 2 columns = 2 td cells
+    await expect(table.locator("td")).toHaveCount(2, { timeout: 3_000 });
   });
 });

--- a/src/components/editor/table-action-menu-plugin.tsx
+++ b/src/components/editor/table-action-menu-plugin.tsx
@@ -176,19 +176,22 @@ function TableActionMenu({
  * document.body instead of into the Lexical-managed cell DOM.
  * Portaling React content into Lexical DOM nodes causes removeChild
  * errors when Lexical reconciles the table (e.g. on Tab cell navigation).
+ *
+ * The trigger position is kept in sync with the active cell via
+ * scroll/resize listeners so it doesn't drift when the page scrolls.
  */
 export function TableActionMenuPlugin(): JSX.Element | null {
   const [editor] = useLexicalComposerContext();
   const [tableCellNode, setTableCellNode] = useState<TableCellNode | null>(
     null
   );
+  const [cellDom, setCellDom] = useState<HTMLElement | null>(null);
   const [menuPosition, setMenuPosition] = useState<{
     x: number;
     y: number;
   } | null>(null);
 
   const handleClose = useCallback(() => {
-    setTableCellNode(null);
     setMenuPosition(null);
   }, []);
 
@@ -198,18 +201,30 @@ export function TableActionMenuPlugin(): JSX.Element | null {
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) {
           setTableCellNode(null);
+          setCellDom(null);
           return;
         }
         const anchor = selection.anchor.getNode();
         const cellNode = $getTableCellNodeFromLexicalNode(anchor);
         if (cellNode) {
           setTableCellNode(cellNode);
+          const element = editor.getElementByKey(cellNode.getKey());
+          setCellDom(element);
         } else {
           setTableCellNode(null);
+          setCellDom(null);
         }
       });
     });
   }, [editor]);
+
+  // Close the dropdown menu on scroll so it doesn't float detached
+  useEffect(() => {
+    if (!menuPosition) return;
+    const handleScroll = () => setMenuPosition(null);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => window.removeEventListener("scroll", handleScroll, true);
+  }, [menuPosition]);
 
   const handleMenuOpen = useCallback(
     (event: React.MouseEvent) => {
@@ -220,22 +235,15 @@ export function TableActionMenuPlugin(): JSX.Element | null {
     []
   );
 
-  if (!tableCellNode) {
+  if (!tableCellNode || !cellDom) {
     return null;
   }
-
-  // Compute the cell rect during render — no effect needed
-  const cellDom = editor.getElementByKey(tableCellNode.getKey());
-  if (!cellDom) {
-    return null;
-  }
-  const cellRect = cellDom.getBoundingClientRect();
 
   return createPortal(
     <>
       <TableCellMenuTrigger
         onMenuOpen={handleMenuOpen}
-        cellRect={cellRect}
+        cellDom={cellDom}
       />
       {menuPosition && (
         <TableActionMenu
@@ -250,20 +258,47 @@ export function TableActionMenuPlugin(): JSX.Element | null {
   );
 }
 
+/**
+ * Trigger button that tracks the active cell's position via
+ * getBoundingClientRect in an effect, with scroll/resize listeners
+ * to stay anchored when the viewport changes.
+ */
 function TableCellMenuTrigger({
   onMenuOpen,
-  cellRect,
+  cellDom,
 }: {
   onMenuOpen: (event: React.MouseEvent) => void;
-  cellRect: DOMRect;
+  cellDom: HTMLElement;
 }) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const updatePosition = useCallback(() => {
+    const button = buttonRef.current;
+    if (!button) return;
+    const rect = cellDom.getBoundingClientRect();
+    button.style.top = `${rect.top + 2}px`;
+    button.style.left = `${rect.right - 22}px`;
+  }, [cellDom]);
+
+  // Position on mount and whenever the cell element changes
+  useEffect(() => {
+    updatePosition();
+  }, [updatePosition]);
+
+  // Re-position on scroll and resize
+  useEffect(() => {
+    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener("resize", updatePosition);
+    return () => {
+      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [updatePosition]);
+
   return (
     <button
+      ref={buttonRef}
       className="fixed z-40 flex h-5 w-5 items-center justify-center text-muted-foreground opacity-60 hover:opacity-100 focus:opacity-100"
-      style={{
-        top: cellRect.top + 2,
-        left: cellRect.right - 22,
-      }}
       onClick={onMenuOpen}
       aria-label="Table cell actions"
     >


### PR DESCRIPTION
Closes #403

## What

The `TableCellMenuTrigger` computed its position via `getBoundingClientRect()` during the React render phase — a one-time snapshot that became stale on scroll or resize. The trigger button would drift away from the active cell. Additionally, the dropdown action menu would remain floating at its original position after scrolling.

## How

- Track the cell DOM element in state and pass it to the trigger component instead of a static `DOMRect`
- Use a ref on the trigger button and update its position via `getBoundingClientRect()` in an effect, with `scroll` (capture) and `resize` listeners to keep it anchored to the cell
- Close the dropdown menu on scroll to prevent detached menus
- Simplify `handleClose` to only clear menu position (cell node is managed by the editor update listener)

## Testing

- Unskipped and implemented 3 previously blocked E2E tests:
  - "user can add a row via the table action menu" — inserts a row and verifies count goes from 3 to 4
  - "user can add a column via the table action menu" — inserts a column and verifies header count goes from 3 to 4
  - "user can delete a row and a column via the table action menu" — deletes a body row then a column, verifying counts at each step
- All 8 table E2E tests pass (0 skipped)
- `pnpm lint && pnpm typecheck && pnpm test` all pass