### PR TITLE
feat: add POST /api/feedback route for submitting user feedback (#394)

### DIFF
--- a/src/app/api/feedback/route.test.ts
+++ b/src/app/api/feedback/route.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@/lib/track-event-server", () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createClient } from "@/lib/supabase/server";
+import { trackEvent } from "@/lib/track-event-server";
+
+const mockedCreateClient = vi.mocked(createClient);
+const mockedTrackEvent = vi.mocked(trackEvent);
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost:3000/api/feedback", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function mockAuthenticatedClient(overrides: Record<string, unknown> = {}) {
+  const mockInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+  const mockFrom = vi.fn().mockReturnValue({ insert: mockInsert });
+  const mockGetUser = vi
+    .fn()
+    .mockResolvedValue({ data: { user: { id: "user-123" } } });
+
+  mockedCreateClient.mockResolvedValue({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+    ...overrides,
+  } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+  return { mockInsert, mockFrom, mockGetUser };
+}
+
+function validBody(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "bug",
+    message: "Something is broken",
+    page_path: "/workspace/abc/page/xyz",
+    page_title: "My Page",
+    screenshot_url: null,
+    metadata: { browser: "Chrome", viewport: "1920x1080" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = "test-key";
+});
+
+describe("POST /api/feedback", () => {
+  it("returns 503 when Supabase is not configured", async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+    const response = await POST(makeRequest(validBody()));
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe("Supabase not configured");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const request = new NextRequest("http://localhost:3000/api/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  it("returns 401 if user is not authenticated", async () => {
+    const mockGetUser = vi
+      .fn()
+      .mockResolvedValue({ data: { user: null } });
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await POST(makeRequest(validBody()));
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 if type is missing", async () => {
+    const response = await POST(makeRequest(validBody({ type: undefined })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Invalid type");
+  });
+
+  it("returns 400 if type is not one of bug, feature, general", async () => {
+    const response = await POST(makeRequest(validBody({ type: "complaint" })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Invalid type");
+  });
+
+  it("returns 400 if message is empty", async () => {
+    mockAuthenticatedClient();
+
+    const response = await POST(makeRequest(validBody({ message: "" })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Message is required");
+  });
+
+  it("returns 400 if message is whitespace only", async () => {
+    mockAuthenticatedClient();
+
+    const response = await POST(makeRequest(validBody({ message: "   " })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Message is required");
+  });
+
+  it("returns 400 if message exceeds 500 characters", async () => {
+    mockAuthenticatedClient();
+
+    const longMessage = "a".repeat(501);
+    const response = await POST(makeRequest(validBody({ message: longMessage })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("must not exceed 500 characters");
+  });
+
+  it("returns 400 if message is not a string", async () => {
+    mockAuthenticatedClient();
+
+    const response = await POST(makeRequest(validBody({ message: 123 })));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Message is required");
+  });
+
+  it("returns 201 on successful insert with { success: true }", async () => {
+    const { mockInsert, mockFrom } = mockAuthenticatedClient();
+
+    const response = await POST(makeRequest(validBody()));
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body).toEqual({ success: true });
+    expect(mockFrom).toHaveBeenCalledWith("user_feedback");
+    expect(mockInsert).toHaveBeenCalledWith({
+      user_id: "user-123",
+      type: "bug",
+      message: "Something is broken",
+      page_path: "/workspace/abc/page/xyz",
+      page_title: "My Page",
+      screenshot_url: null,
+      metadata: { browser: "Chrome", viewport: "1920x1080" },
+    });
+  });
+
+  it("sets user_id from authenticated session, not request body", async () => {
+    const { mockInsert } = mockAuthenticatedClient();
+
+    const response = await POST(
+      makeRequest(validBody({ user_id: "attacker-id" })),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: "user-123" }),
+    );
+  });
+
+  it("calls trackEvent on successful insert", async () => {
+    mockAuthenticatedClient();
+
+    await POST(makeRequest(validBody({ type: "feature" })));
+
+    expect(mockedTrackEvent).toHaveBeenCalledWith(
+      "feedback.submitted",
+      "user-123",
+      { metadata: { type: "feature" } },
+    );
+  });
+
+  it("returns 500 when Supabase insert fails", async () => {
+    const mockInsert = vi.fn().mockResolvedValue({
+      data: null,
+      error: Object.assign(new Error("Insert failed"), {
+        code: "23505",
+        details: "",
+        hint: "",
+      }),
+    });
+    const mockFrom = vi.fn().mockReturnValue({ insert: mockInsert });
+    const mockGetUser = vi
+      .fn()
+      .mockResolvedValue({ data: { user: { id: "user-123" } } });
+
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: mockFrom,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await POST(makeRequest(validBody()));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe("Failed to submit feedback");
+  });
+
+  it("accepts all valid feedback types", async () => {
+    for (const type of ["bug", "feature", "general"]) {
+      mockAuthenticatedClient();
+
+      const response = await POST(makeRequest(validBody({ type })));
+      expect(response.status).toBe(201);
+    }
+  });
+
+  it("handles optional fields as null", async () => {
+    const { mockInsert } = mockAuthenticatedClient();
+
+    const response = await POST(
+      makeRequest({
+        type: "general",
+        message: "Just a thought",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page_path: null,
+        page_title: null,
+        screenshot_url: null,
+        metadata: null,
+      }),
+    );
+  });
+});

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse, type NextRequest } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+import { createClient } from "@/lib/supabase/server";
+import { captureSupabaseError, isInsufficientPrivilegeError } from "@/lib/sentry";
+import { trackEvent } from "@/lib/track-event-server";
+import type { FeedbackType } from "@/lib/types";
+
+const VALID_TYPES: ReadonlySet<FeedbackType> = new Set(["bug", "feature", "general"]);
+const MAX_MESSAGE_LENGTH = 500;
+
+export async function POST(request: NextRequest) {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+  ) {
+    return NextResponse.json(
+      { error: "Supabase not configured" },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (_e) {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 },
+    );
+  }
+
+  const { type, message, page_path, page_title, screenshot_url, metadata } =
+    body as Record<string, unknown>;
+
+  if (!type || !VALID_TYPES.has(type as FeedbackType)) {
+    return NextResponse.json(
+      { error: "Invalid type: must be one of bug, feature, general" },
+      { status: 400 },
+    );
+  }
+
+  if (
+    typeof message !== "string" ||
+    message.trim().length === 0 ||
+    message.length > MAX_MESSAGE_LENGTH
+  ) {
+    return NextResponse.json(
+      { error: `Message is required and must not exceed ${MAX_MESSAGE_LENGTH} characters` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const supabase = await createClient();
+
+    const { data: user } = await supabase.auth.getUser();
+    if (!user.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { error } = await supabase.from("user_feedback").insert({
+      user_id: user.user.id,
+      type: type as FeedbackType,
+      message: message.trim(),
+      page_path: (page_path as string) ?? null,
+      page_title: (page_title as string) ?? null,
+      screenshot_url: (screenshot_url as string) ?? null,
+      metadata: (metadata as Record<string, unknown>) ?? null,
+    });
+
+    if (error) {
+      if (isInsufficientPrivilegeError(error)) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+      captureSupabaseError(error, "feedback.insert");
+      return NextResponse.json(
+        { error: "Failed to submit feedback" },
+        { status: 500 },
+      );
+    }
+
+    void trackEvent("feedback.submitted", user.user.id, {
+      metadata: { type },
+    });
+
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && isInsufficientPrivilegeError(error)) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    Sentry.captureException(error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
Closes #394

## What

Adds a `POST /api/feedback` API route that validates input, authenticates the user, inserts feedback into the `user_feedback` table, and tracks the event via `trackEvent()`.

## How

Follows the existing API route pattern from `src/app/api/search/route.ts`:
- Auth check via `supabase.auth.getUser()`
- Input validation (type enum, message length)
- Supabase insert with `user_id` from session (not request body)
- Error capture via `captureSupabaseError` and `Sentry.captureException`
- Fire-and-forget `trackEvent('feedback.submitted', ...)` on success

Request body shape:
```json
{
  "type": "bug" | "feature" | "general",
  "message": "string (max 500)",
  "page_path": "/workspace/abc/page/xyz",
  "page_title": "My Page" | null,
  "screenshot_url": "https://..." | null,
  "metadata": { "browser": "...", "viewport": "1920x1080" }
}
```

## Testing

15 integration tests covering:
- Successful submit (201 with `{ success: true }`)
- Unauthenticated request (401)
- Invalid type (400)
- Empty/whitespace message (400)
- Message exceeding 500 chars (400)
- Invalid JSON body (400)
- Supabase insert failure (500)
- All valid feedback types accepted
- `user_id` set from session, not request body
- `trackEvent` called on success
- Optional fields handled as null

All checks pass: `pnpm lint && pnpm typecheck && pnpm test`