### PR TITLE
fix(sentry): detect custom RPC 42501 errors in catch blocks

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1164,6 +1164,21 @@ falling through to `Sentry.captureException`:
 This prevents 42501 errors from being reported at error level in Sentry and
 ensures the client receives 403 instead of 500.
 
+### Custom RPC RAISE EXCEPTION with errcode 42501
+
+When a PostgreSQL RPC uses `RAISE EXCEPTION '...' USING errcode = '42501'`,
+Supabase may surface the error in two ways:
+
+1. **`{ data, error }` path** — the error is a PostgrestError with `code: "42501"`
+2. **Thrown exception** — the error is a generic `Error` with a `code` property
+   but without `details`/`hint`, so it fails the `isPostgrestError` duck-type check
+
+`isInsufficientPrivilegeError` handles both shapes: it checks `isPostgrestError`
+first, then falls back to checking for a `code` property with value `"42501"`,
+and finally checks the message for the RLS violation pattern. This ensures
+custom RPC messages like "Not a member of this workspace" are correctly
+identified as authorization errors in catch blocks.
+
 ## Usage Event Tracking
 
 Product analytics events are recorded via two modules — `src/lib/track-event-server.ts`

--- a/src/app/api/search/route.test.ts
+++ b/src/app/api/search/route.test.ts
@@ -169,6 +169,29 @@ describe("GET /api/search", () => {
     expect(body.results).toEqual(mockResults);
   });
 
+  it("returns 403 when RPC throws 42501 in catch block (MEMO-14 regression)", async () => {
+    const mockGetUser = vi
+      .fn()
+      .mockResolvedValue({ data: { user: { id: "user-1" } } });
+    const thrownError = Object.assign(
+      new Error("Not a member of this workspace"),
+      { code: "42501" },
+    );
+    const mockRpc = vi.fn().mockRejectedValue(thrownError);
+    mockedCreateClient.mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      rpc: mockRpc,
+    } as unknown as Awaited<ReturnType<typeof createClient>>);
+
+    const response = await GET(
+      makeRequest({ q: "test", workspace_id: "ws-1" }) as never,
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe("Forbidden");
+  });
+
   it("returns 200 with empty array when no results", async () => {
     const mockGetUser = vi
       .fn()

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -118,14 +118,19 @@ export function isSchemaNotFoundError(error: Error): boolean {
  * (e.g. non-members calling workspace-scoped functions). It is an expected
  * authorization check, not an application bug — API routes should return 403.
  *
- * Matches both PostgrestError objects (with `code` property) and generic
- * Error instances whose message contains the RLS violation pattern. Supabase
- * may surface 42501 errors as thrown exceptions without PostgrestError shape
- * when the query builder promise rejects instead of returning `{ error }`.
+ * Matches three shapes:
+ * 1. PostgrestError objects with `code: "42501"` (from `{ data, error }` path)
+ * 2. Generic Error with a `code` property set to `"42501"` (thrown by Supabase
+ *    when an RPC rejects via RAISE EXCEPTION with errcode — the error object
+ *    has `code` but lacks `details`/`hint` so it fails the PostgrestError check)
+ * 3. Generic Error whose message contains the RLS violation pattern
  */
 export function isInsufficientPrivilegeError(error: Error): boolean {
   if (isPostgrestError(error)) {
     return error.code === "42501";
+  }
+  if ("code" in error && (error as Record<string, unknown>).code === "42501") {
+    return true;
   }
   return error.message.includes("violates row-level security policy");
 }

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -153,6 +153,30 @@ describe("isInsufficientPrivilegeError", () => {
     );
     expect(isInsufficientPrivilegeError(error)).toBe(true);
   });
+
+  it("detects custom RPC 42501 thrown as Error with code property (MEMO-14 regression)", () => {
+    const error = Object.assign(
+      new Error("Not a member of this workspace"),
+      { code: "42501" },
+    );
+    expect(isInsufficientPrivilegeError(error)).toBe(true);
+  });
+
+  it("detects RPC 42501 with code but without details/hint (non-PostgrestError shape)", () => {
+    const error = Object.assign(
+      new Error("Workspace access denied"),
+      { code: "42501", details: null, hint: null },
+    );
+    expect(isInsufficientPrivilegeError(error)).toBe(true);
+  });
+
+  it("returns false for generic Error with non-42501 code property", () => {
+    const error = Object.assign(
+      new Error("duplicate key"),
+      { code: "23505" },
+    );
+    expect(isInsufficientPrivilegeError(error)).toBe(false);
+  });
 });
 
 describe("captureSupabaseError", () => {


### PR DESCRIPTION
## Summary

`isInsufficientPrivilegeError` missed 42501 errors thrown by PostgreSQL RPCs with custom messages, causing them to be reported to Sentry at error level instead of being handled as 403 responses.

Sentry issues: [MEMO-14](https://ona-2j.sentry.io/issues/MEMO-14), [MEMO-13](https://ona-2j.sentry.io/issues/MEMO-13)

Closes #416

## Root Cause

PostgreSQL RPCs using `RAISE EXCEPTION '...' USING errcode = '42501'` produce errors that Supabase may throw as generic `Error` objects with a `code` property but without `details`/`hint`. The `isPostgrestError` duck-type check requires all three properties, so these errors fail the check. The fallback message check only matched \"violates row-level security policy\", missing custom messages like \"Not a member of this workspace\".

In the search route (`GET /api/search`), the `search_pages` RPC throws \"Not a member of this workspace\" with errcode 42501 for non-members. The catch block correctly calls `isInsufficientPrivilegeError(error)`, but it returned false — the error fell through to `Sentry.captureException(error)` at error level.

## Changes

- **`src/lib/sentry.ts`**: Added a middle check in `isInsufficientPrivilegeError` for a `code` property with value `\"42501\"` on non-PostgrestError objects
- **`src/lib/sentry.unit.test.ts`**: Added 3 regression tests for the new detection path (custom RPC message, code without details/hint, non-42501 code)
- **`src/app/api/search/route.test.ts`**: Added regression test for the catch block returning 403 on thrown RPC 42501
- **`.agents/conventions.md`**: Documented the custom RPC RAISE EXCEPTION pattern

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 485 tests pass (56 files)