### PR TITLE
fix(e2e): disambiguate slash command locators after Turn Into addition (#427)

### DIFF
--- a/e2e/editor-slash-commands.spec.ts
+++ b/e2e/editor-slash-commands.spec.ts
@@ -33,14 +33,14 @@ test.describe("Editor slash commands", () => {
     await page.keyboard.press("Enter");
     await page.keyboard.type("/head");
 
-    // Should show heading options, filtered
+    // Should show heading options, filtered.
+    // "head" matches Heading 1/2/3 and their "Turn into" variants (up to 6).
     const options = page.locator('[role="option"]');
     await expect(options.first()).toBeVisible({ timeout: 3_000 });
 
     const count = await options.count();
-    // "head" should match Heading 1, Heading 2, Heading 3
     expect(count).toBeGreaterThanOrEqual(1);
-    expect(count).toBeLessThanOrEqual(3);
+    expect(count).toBeLessThanOrEqual(6);
   });
 
   test("selecting a heading option inserts a heading block", async ({
@@ -57,8 +57,11 @@ test.describe("Editor slash commands", () => {
     await page.keyboard.press("Enter");
     await page.keyboard.type("/");
 
-    // Wait for menu
-    const heading1Option = page.locator('[role="option"]').filter({ hasText: "Heading 1" });
+    // Wait for menu — use exact text match on the title span to avoid
+    // matching "Turn into Heading 1" alongside "Heading 1"
+    const heading1Option = page
+      .locator('[role="option"]')
+      .filter({ has: page.locator("span.font-medium", { hasText: /^Heading 1$/ }) });
     await expect(heading1Option).toBeVisible({ timeout: 3_000 });
     await heading1Option.click();
 


### PR DESCRIPTION
Closes #427

## What

PR #424 added "Turn into" entries to the slash command menu (e.g., "Turn into Heading 1", "Turn into Heading 2"). Two E2E tests in `editor-slash-commands.spec.ts` broke because their locators matched both the original entries and the new "Turn into" variants — `filter({ hasText: 'Heading 1' })` matched both "Heading 1" and "Turn into Heading 1", and typing `/head` now returns 6 options instead of 3.

## How

- **"slash menu filters options on typing"**: Updated the upper bound assertion from `count <= 3` to `count <= 6` to account for the 3 "Turn into Heading N" entries that also match the `/head` filter.
- **"selecting a heading option inserts a heading block"**: Replaced the broad `filter({ hasText: 'Heading 1' })` with a precise locator that targets the option whose `span.font-medium` title text is exactly "Heading 1" using a regex anchor (`/^Heading 1$/`), excluding "Turn into Heading 1".

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — all 507 unit tests pass
- E2E tests fail at the auth fixture level (environment-wide issue unrelated to this change) — the locator fixes are structurally correct and target the exact DOM elements rendered by the slash command menu