### PR TITLE
docs: add database views architecture and spec

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -47,10 +47,42 @@ workspaces
         ├── content: jsonb (Lexical editor state — NOT a separate blocks table)
         ├── icon: text (emoji character for page icon, nullable)
         ├── cover_url: text (public URL of cover image in Supabase Storage, nullable)
+        ├── is_database: boolean (default false — when true, page is a database container)
         ├── position: integer (ordering among siblings)
         ├── created_by → profiles.id
         ├── deleted_at: timestamptz (nullable — NULL = active, non-null = trashed)
         └── search_vector: tsvector (generated, title weight A + content text weight B, GIN indexed)
+        When is_database = true:
+        ├── child pages (parent_id = this page) are database rows
+        ├── has many: database_properties (schema columns)
+        ├── has many: database_views (saved views: table, board, list, calendar, gallery)
+        └── row pages have many: row_values (property values per row per property)
+
+database_properties (schema definition — columns of a database)
+  ├── database_id → pages.id (ON DELETE CASCADE, where is_database = true)
+  ├── name: text (unique per database)
+  ├── type: text (text | number | select | multi_select | checkbox | date | url | email | phone | person | files | relation | formula | created_time | updated_time | created_by)
+  ├── config: jsonb (type-specific: select options, number format, formula expression, relation target)
+  ├── position: integer (column ordering)
+  └── Index: (database_id, position)
+  RLS: workspace members can CRUD properties for databases in their workspace.
+
+database_views (saved views on a database)
+  ├── database_id → pages.id (ON DELETE CASCADE)
+  ├── name: text (default 'Default view')
+  ├── type: text (table | board | list | calendar | gallery)
+  ├── config: jsonb (visible_properties, sorts, filters, plus type-specific config)
+  ├── position: integer (view tab ordering)
+  └── Index: (database_id, position)
+  RLS: workspace members can CRUD views for databases in their workspace.
+
+row_values (property values for each database row)
+  ├── row_id → pages.id (ON DELETE CASCADE — the row page)
+  ├── property_id → database_properties.id (ON DELETE CASCADE)
+  ├── value: jsonb (format depends on property type)
+  ├── UNIQUE(row_id, property_id)
+  └── Index: GIN on (property_id, value) for filtering
+  RLS: workspace members can CRUD values for rows in their workspace.
 
 page_visits (tracks recently visited pages per user per workspace)
   ├── workspace_id → workspaces.id
@@ -138,6 +170,9 @@ Sign-up flow (atomic, via DB trigger):
 | Full-text search | PostgreSQL `tsvector` + `tsquery` | Generated column on pages combining title (weight A) + extracted content text (weight B), GIN index, `search_pages` RPC |
 | Page ancestors | PostgreSQL recursive CTE | `get_page_ancestors` RPC walks `parent_id` chain to build breadcrumb path. Returns ancestors root-first. `security invoker` respects RLS. |
 | Soft delete | `deleted_at` column + RPCs | Pages are soft-deleted (moved to trash) instead of hard-deleted. `soft_delete_page` and `restore_page` RPCs use recursive CTEs to handle sub-pages. RLS policies split into active/trashed. `purge_old_trash` function for 30-day auto-purge, scheduled via Vercel Cron (`GET /api/cron/purge-trash` at 3 AM UTC daily) with pg_cron as a secondary mechanism when available. |
+| Database views | Pages with `is_database = true` | Databases are special pages. Rows are child pages. Schema in `database_properties`, values in `row_values`, views in `database_views`. Reuses all page infrastructure (RLS, search, trash, versioning, backlinks). Client-side filtering/sorting initially. |
+| Property type registry | `Record<PropertyType, {Renderer, Editor}>` | Extensible pattern — new property types added without modifying view components. Each type provides a cell renderer and inline editor. |
+| Inline databases | Lexical `DatabaseNode` (DecoratorNode) | Embeds a database view inside any page. Stores `databaseId` + `viewId`. Compact rendering with expand-to-full-page button. |
 
 ## Lexical Editor — Implementation Plan
 
@@ -179,6 +214,7 @@ Pin to a specific version to avoid breaking changes.
 | ListTabIndentationPlugin | N/A (custom) | Implemented |
 | PageLinkPlugin (`[[` trigger + search) | N/A (custom) | Implemented |
 | TablePlugin + TableActionMenuPlugin | `plugins/TablePlugin` | Implemented |
+| DatabasePlugin (inline database block) | N/A (custom) | Planned |
 | ToolbarPlugin (top toolbar) | `plugins/ToolbarPlugin` | Deferred |
 
 ### Custom nodes
@@ -191,6 +227,7 @@ Pin to a specific version to avoid breaking changes.
 | CollapsibleTitleNode | ElementNode | `<summary>` title for toggle blocks | Implemented |
 | CollapsibleContentNode | ElementNode | Content area for toggle blocks | Implemented |
 | PageLinkNode | DecoratorNode | Inline page link pill (stores pageId, renders title + icon) | Implemented |
+| DatabaseNode | DecoratorNode | Inline database embed (stores databaseId + viewId, renders compact view) | Planned |
 | DividerNode | HorizontalRuleNode (`@lexical/react`) | Horizontal divider | Built-in |
 
 ### Skipped plugins (not needed for MVP)
@@ -214,6 +251,77 @@ Auto-save: debounce 500ms on editor change → write to Supabase
 3. Client component hydrates, initializes Lexical editor with saved content from `pages.content`
 4. User edits content → Lexical editor state changes → debounced auto-save writes `editorState.toJSON()` to Supabase
 5. Errors captured by Sentry (client via `instrumentation-client.ts`, server via `src/instrumentation.ts`)
+
+## Database Views — Architecture
+
+Databases are pages with `is_database = true`. This reuses all existing page infrastructure
+(RLS, nesting, breadcrumbs, favorites, trash, search, version history, backlinks).
+
+### How it works
+
+```
+Database page (is_database = true)
+  ├── content: jsonb (optional Lexical content rendered above the database grid)
+  ├── database_properties[] (schema — the columns)
+  ├── database_views[] (saved views — table, board, list, calendar, gallery)
+  └── child pages (parent_id = database page) = rows
+       └── row_values[] (property values per row per property)
+```
+
+### Rendering flow
+
+1. `[pageId]/page.tsx` fetches the page and checks `is_database`
+2. If true, renders `DatabaseViewClient` instead of the standard `PageViewClient`
+3. `DatabaseViewClient` loads properties, views, and rows via Supabase
+4. Active view type determines which view component renders (TableView, BoardView, etc.)
+5. Filters and sorts are applied client-side on the loaded row data
+6. Cell edits write to `row_values` via Supabase (debounced auto-save)
+
+### Component structure (planned)
+
+```
+src/components/database/
+  ├── database-view-client.tsx     # Main client component: loads data, manages view state
+  ├── view-tabs.tsx                # Horizontal tab bar for switching views
+  ├── filter-bar.tsx               # Active filter pills + add filter UI
+  ├── sort-menu.tsx                # Sort configuration dropdown
+  ├── property-config.tsx          # Column header dropdown: rename, type change, delete
+  ├── property-editor.tsx          # Inline cell editor (dispatches to type-specific editors)
+  ├── property-renderer.tsx        # Cell renderer (dispatches to type-specific renderers)
+  ├── property-types/              # Registry of type-specific renderers and editors
+  │   ├── index.ts                 # PropertyTypeRegistry: Record<PropertyType, {Renderer, Editor}>
+  │   ├── text.tsx
+  │   ├── number.tsx
+  │   ├── select.tsx
+  │   ├── multi-select.tsx
+  │   ├── checkbox.tsx
+  │   ├── date.tsx
+  │   ├── url.tsx
+  │   ├── email.tsx
+  │   ├── phone.tsx
+  │   ├── person.tsx
+  │   ├── files.tsx
+  │   ├── relation.tsx
+  │   ├── formula.tsx
+  │   └── computed.tsx             # created_time, updated_time, created_by (read-only)
+  ├── views/
+  │   ├── table-view.tsx           # Spreadsheet grid with resizable columns
+  │   ├── board-view.tsx           # Kanban columns grouped by select property
+  │   ├── list-view.tsx            # Compact vertical list
+  │   ├── calendar-view.tsx        # Month grid with date-positioned items
+  │   └── gallery-view.tsx         # Responsive card grid with cover + title
+  ├── row-properties-header.tsx    # Properties displayed above editor when row opened as page
+  └── new-database-dialog.tsx      # Dialog for creating a new database
+```
+
+### Key design decisions
+
+- **Client-side filtering/sorting**: all rows loaded, filtered/sorted in browser. Server-side deferred.
+- **Property type registry**: `Record<PropertyType, { Renderer, Editor }>` pattern for extensibility.
+- **Formula evaluation**: simple recursive descent parser, evaluated at render time on the client.
+- **Select option colors**: fixed palette of 8-10 muted colors from the design token set.
+- **No new routes**: existing `[pageId]/page.tsx` handles both pages and databases.
+- **Inline databases**: `DatabaseNode` (Lexical DecoratorNode) stores `databaseId` + `viewId`, renders compact view.
 
 ## Component Map
 
@@ -295,7 +403,26 @@ src/
 │   │   ├── page-link-node.tsx         # PageLinkNode (DecoratorNode) — inline page link pill with realtime title/icon updates
 │   │   ├── page-link-plugin.tsx       # [[ trigger detection, page search dropdown, INSERT_PAGE_LINK_COMMAND
 │   │   ├── collapsible-plugin.tsx   # Collapsible insert command + toggle handling
-│   │   └── table-action-menu-plugin.tsx # Table cell context menu (add/delete rows/columns)
+│   │   ├── table-action-menu-plugin.tsx # Table cell context menu (add/delete rows/columns)
+│   │   ├── database-node.tsx        # DatabaseNode (DecoratorNode) — inline database embed (planned)
+│   │   └── database-plugin.tsx      # Database insert command + inline rendering (planned)
+│   ├── database/                # Database views system (planned)
+│   │   ├── database-view-client.tsx     # Main client component: loads data, manages view state
+│   │   ├── view-tabs.tsx                # Horizontal tab bar for switching views
+│   │   ├── filter-bar.tsx               # Active filter pills + add filter UI
+│   │   ├── sort-menu.tsx                # Sort configuration dropdown
+│   │   ├── property-config.tsx          # Column header dropdown: rename, type change, delete
+│   │   ├── property-editor.tsx          # Inline cell editor (dispatches to type-specific editors)
+│   │   ├── property-renderer.tsx        # Cell renderer (dispatches to type-specific renderers)
+│   │   ├── property-types/              # Registry of type-specific renderers and editors
+│   │   ├── views/
+│   │   │   ├── table-view.tsx           # Spreadsheet grid with resizable columns
+│   │   │   ├── board-view.tsx           # Kanban columns grouped by select property
+│   │   │   ├── list-view.tsx            # Compact vertical list
+│   │   │   ├── calendar-view.tsx        # Month grid with date-positioned items
+│   │   │   └── gallery-view.tsx         # Responsive card grid with cover + title
+│   │   ├── row-properties-header.tsx    # Properties displayed above editor when row opened as page
+│   │   └── new-database-dialog.tsx      # Dialog for creating a new database
 │   ├── delete-account-section.tsx # Account deletion danger zone with double-confirm dialog
 │   ├── emoji-picker.tsx         # Floating emoji grid with search, used by page icon picker
 │   ├── page-cover.tsx           # Page cover image: upload, display, change, remove (saves to pages.cover_url)

--- a/.agents/design.md
+++ b/.agents/design.md
@@ -308,6 +308,171 @@ Each block is a full-width element with consistent vertical spacing.
 
 ---
 
+## Database Views
+
+Database views render structured data within the existing page layout. When a page has
+`is_database = true`, the page view renders optional Lexical content above a database grid.
+
+### Layout
+
+```
+┌──────────────────────────────────────────────┐
+│  [Breadcrumb]                                │
+│  [Icon] [Title]                    [Menu]    │
+│  [Optional Lexical content above]            │
+│                                              │
+│  [View Tab 1] [View Tab 2] [+]   [Filter] [Sort] │
+│  ┌──────────────────────────────────────────┐│
+│  │  Database view (table/board/list/etc.)   ││
+│  │                                          ││
+│  └──────────────────────────────────────────┘│
+└──────────────────────────────────────────────┘
+```
+
+### View Tabs
+
+- Horizontal tab bar above the database grid, `text-sm`.
+- Active tab: `border-b-2 border-accent`, `text-foreground`.
+- Inactive tabs: `text-muted-foreground`, hover `text-foreground`.
+- `+` button at end of tab bar: opens dropdown to pick view type.
+- Tab icons: `Table2` (table), `Columns3` (board), `List` (list), `Calendar` (calendar), `LayoutGrid` (gallery) from lucide-react, 14px.
+- Tab bar background: transparent, `border-b border-white/[0.06]`.
+
+### Filter & Sort Bar
+
+- Position: between view tabs and the database grid.
+- Background: `bg-muted p-2`, sharp corners.
+- Active filters: `Badge` components with property name, operator, value. `variant="secondary"`, `text-xs`.
+- Remove filter: `X` icon (12px) on each badge, hover `text-destructive`.
+- `+ Add filter` button: `ghost` variant, `text-xs text-muted-foreground`.
+- Sort indicator in column headers: `ArrowUp` / `ArrowDown` icon (12px), `text-muted-foreground`.
+
+### Table View
+
+- Full-width spreadsheet grid within `max-w-3xl` content area (can overflow with horizontal scroll).
+- Column headers: `bg-muted`, `text-xs font-medium text-muted-foreground`, `uppercase tracking-widest`, `p-2`, `border-b border-white/[0.06]`.
+- Column resize: drag handle on right edge of header, `cursor-col-resize`, 2px `bg-accent` indicator while dragging.
+- Cells: `p-2 text-sm`, `border-b border-white/[0.06]`. Click to edit inline.
+- Row hover: `bg-white/[0.02]`.
+- Add row: button at bottom of table, full width, `text-muted-foreground`, `+ New`.
+- Add column: `+` button at right end of header row, `text-muted-foreground`.
+- Row height options: compact (`h-8`), default (`h-10`), tall (`h-14`).
+
+### Board View
+
+- Horizontal scrollable container of columns.
+- Column: `w-72`, `bg-muted/50`, `p-2`, sharp corners.
+- Column header: `text-xs font-medium uppercase tracking-widest text-muted-foreground`, `mb-2`.
+- Cards: `bg-muted`, `border border-white/[0.06]`, `p-3`, sharp corners, `mb-1.5`.
+- Card title: `text-sm font-medium`, truncated to 2 lines.
+- Card properties: `text-xs text-muted-foreground`, below title.
+- Drag: card at 50% opacity, `shadow-lg`, drop indicator as 2px `bg-accent` line.
+- Add card: `+ New` button at bottom of each column, `text-xs text-muted-foreground`.
+- Uncategorized column: labeled "No status" (or property name), listed last.
+
+### List View
+
+- Compact vertical list, one row per line.
+- Row: `flex items-center gap-2 px-3 py-2 text-sm`, `hover:bg-white/[0.04]`.
+- Title: `flex-1 truncate`, left side.
+- Visible properties: right side, `text-xs text-muted-foreground`, `gap-3`.
+- Click row to open as page.
+
+### Calendar View
+
+- Month grid: 7 columns (Sun–Sat), variable rows.
+- Header: month name + year (`text-lg font-medium`), prev/next buttons (`ChevronLeft`/`ChevronRight`, `ghost` variant), today button.
+- Day headers: `text-xs uppercase tracking-widest text-muted-foreground`, `text-center`.
+- Day cells: `min-h-24`, `border border-white/[0.06]`, `p-1`.
+- Today cell: `bg-accent/10`.
+- Other month days: `text-muted-foreground/50`.
+- Items in cells: `text-xs`, truncated, `bg-muted px-1 py-0.5 mb-0.5`, sharp corners. Max 3 visible, then "+N more" link.
+- Click cell: creates new row with that date pre-filled.
+- Click item: opens row as page.
+
+### Gallery View
+
+- Responsive card grid: `grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3`.
+- Card sizes: small (`h-40`), medium (`h-52`), large (`h-64`).
+- Card: `bg-muted`, `border border-white/[0.06]`, sharp corners, `overflow-hidden`.
+- Cover image: fills top portion of card, `object-cover`. No cover: `bg-muted` placeholder with `ImageIcon` (24px, `text-muted-foreground/30`).
+- Title: below cover, `p-3 text-sm font-medium`, truncated to 2 lines.
+- Click card: opens row as page.
+
+### Property Cells
+
+Inline cell rendering and editing patterns for each property type:
+
+| Type | Renderer | Editor |
+|---|---|---|
+| Text | Plain text, truncated | Input field, auto-focus |
+| Number | Right-aligned, formatted | Input `type="number"` |
+| Select | Colored badge | Dropdown with options, create new inline |
+| Multi-select | Multiple colored badges, wrapping | Dropdown with checkboxes, create new inline |
+| Checkbox | Centered checkbox icon | Toggle on click (no separate edit mode) |
+| Date | Formatted date string (`MMM D, YYYY`) | Date picker popover |
+| URL | Truncated link, `text-accent`, external icon | Input field |
+| Email | Truncated email, `text-accent` | Input field |
+| Phone | Formatted phone | Input field |
+| Person | Avatar circle(s), 20px | Member search dropdown |
+| Files | Thumbnail or file icon + name | Upload button + file list |
+| Relation | Page link pills (like PageLinkNode) | Database row search dropdown |
+| Formula | Computed value (read-only, `text-muted-foreground`) | Not editable |
+| Created time | Formatted timestamp (read-only) | Not editable |
+| Updated time | Formatted timestamp (read-only) | Not editable |
+| Created by | Avatar + name (read-only) | Not editable |
+
+### Select Option Colors
+
+Fixed palette of muted colors for select and multi-select options:
+
+| Name | Background | Text |
+|---|---|---|
+| Gray | `bg-white/[0.08]` | `text-foreground` |
+| Blue | `bg-blue-500/20` | `text-blue-400` |
+| Green | `bg-green-500/20` | `text-green-400` |
+| Yellow | `bg-yellow-500/20` | `text-yellow-400` |
+| Orange | `bg-orange-500/20` | `text-orange-400` |
+| Red | `bg-red-500/20` | `text-red-400` |
+| Purple | `bg-purple-500/20` | `text-purple-400` |
+| Pink | `bg-pink-500/20` | `text-pink-400` |
+| Cyan | `bg-cyan-500/20` | `text-cyan-400` |
+
+### Row-as-Page Properties Header
+
+When a database row is opened as a full page, properties display above the Lexical editor:
+
+- Position: between breadcrumb and page title.
+- Layout: vertical list of property name + value pairs.
+- Property name: `text-xs text-muted-foreground`, `w-32` fixed width, right-aligned.
+- Property value: `text-sm`, inline-editable (click to edit).
+- Separator: `border-b border-white/[0.06]` between the properties header and the editor content.
+- Collapse: if more than 5 properties, show first 5 with "Show N more" toggle.
+
+### Database in Sidebar
+
+- Database pages show `Table2` icon (16px) instead of `FileText` in the page tree.
+- "New Database" option in the sidebar create menu (alongside "New Page").
+- Database child pages (rows) are NOT shown in the sidebar tree — only the database page itself.
+
+### Inline Database Block
+
+- Spacing above: 12px (`mt-3`), same as table/code/callout blocks.
+- Border: `border border-white/[0.06]`, sharp corners.
+- Header: database title (linked, `text-sm font-medium text-accent`) + expand icon (`Maximize2`, 14px).
+- Compact view: shows the selected view with max 5 rows, no filter/sort bar.
+- Click expand: navigates to the database full page.
+
+### Empty Database
+
+- Centered empty state within the database grid area.
+- Icon: `Table2` from lucide-react, 48px, `text-muted-foreground`.
+- Heading: `text-lg font-medium`, "No rows yet".
+- Description: `text-sm text-muted-foreground`, "Add your first row to get started."
+- CTA: `Button` default variant, "Add a row".
+
+---
+
 ## Interaction Patterns
 
 ### Loading States

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -50,18 +50,23 @@ documentation, and project planning.
 7. **Members** — workspace owner/admin can invite users by email, roles (owner, admin, member), remove members. Users can be members of unlimited workspaces via invites.
 8. **App shell** — sidebar with page tree, workspace switcher, search, user menu. Responsive (sidebar collapses on mobile).
 
-### Out of Scope (MVP)
+### Post-MVP: Database Views
+
+9. **Database views** — Notion-style databases with structured properties, multiple view types, and rows-as-pages. Databases are special pages (`is_database = true`) that can also be embedded inline via a Lexical `DatabaseNode`. Full spec in `spec.md`.
+   - **View types**: Table, Board (Kanban), List, Calendar (month grid), Gallery (card grid)
+   - **Property types**: text, number, select, multi-select, checkbox, date, URL, email, phone, person, files, relation, formula, created_time, updated_time, created_by
+   - **Features**: multiple named views per database, sort by any property, filter with type-appropriate operators (AND-combined), inline cell editing, row opens as full page with Lexical editor
+   - **Inline databases**: `DatabaseNode` (Lexical DecoratorNode) embeds a database view inside any page, with expand-to-full-page
+
+### Out of Scope
 
 - Realtime collaboration (live cursors, co-editing) — post-MVP via Yjs
-- Database views / tables (Notion-style databases)
 - Third-party integrations (Slack, GitHub, etc.)
 - AI writing features
 - Offline support
 - Mobile native apps
 - Light mode
 - Comments on pages
-- Version history
-- OAuth providers (GitHub, Google) — buttons shown but non-functional
 
 ## Data Model
 
@@ -116,10 +121,47 @@ pages
   title: text (default '')
   content: jsonb (Lexical editor state JSON)
   icon: text (emoji, nullable)
+  is_database: boolean (default false — when true, page acts as a database container)
   position: integer (ordering among siblings)
   created_by: uuid (references profiles.id)
   created_at: timestamptz
   updated_at: timestamptz
+
+  When is_database = true:
+  - Child pages (parent_id = this page) are database rows
+  - database_properties defines the schema (columns)
+  - database_views defines saved views (table, board, list, calendar, gallery)
+  - Regular page features (icon, cover, content) still work — content renders above the database grid
+
+database_properties (schema definition — columns of a database)
+  id: uuid (PK)
+  database_id: uuid (references pages.id, on delete cascade)
+  name: text (not null)
+  type: text (not null — text | number | select | multi_select | checkbox | date | url | email | phone | person | files | relation | formula | created_time | updated_time | created_by)
+  config: jsonb (type-specific: select options, number format, formula expression, relation target)
+  position: integer (column ordering)
+  created_at: timestamptz
+  updated_at: timestamptz
+  UNIQUE(database_id, name)
+
+database_views (saved views on a database)
+  id: uuid (PK)
+  database_id: uuid (references pages.id, on delete cascade)
+  name: text (not null, default 'Default view')
+  type: text (not null — table | board | list | calendar | gallery)
+  config: jsonb (visible_properties, sorts, filters, plus type-specific config)
+  position: integer (view tab ordering)
+  created_at: timestamptz
+  updated_at: timestamptz
+
+row_values (property values for each database row)
+  id: uuid (PK)
+  row_id: uuid (references pages.id, on delete cascade — the row page)
+  property_id: uuid (references database_properties.id, on delete cascade)
+  value: jsonb (format depends on property type)
+  created_at: timestamptz
+  updated_at: timestamptz
+  UNIQUE(row_id, property_id)
 ```
 
 All tables have RLS enabled. Policies enforce workspace membership for all operations.
@@ -149,6 +191,36 @@ Each feature maps to one or more GitHub Issues. Phases map to priority labels:
 8. **Search** — full-text search across page titles and content within a workspace. Search UI in sidebar. PostgreSQL `tsvector`/`tsquery`. _Depends on: #5 (Pages CRUD)._
 9. **Import/Export** — Markdown import (upload .md → create page) and export (page → download .md). Uses `@lexical/markdown` transforms. _Depends on: #6 (Lexical editor — core)._
 10. **Members** — invite users by email, accept invite flow, role management (owner, admin, member), remove members. Only owner/admin can manage members. _Depends on: #4 (Workspace CRUD)._
+
+### Phase 4: Database Views — Foundation (`priority:1`)
+
+11. **Database schema migration** — Add `is_database` to pages, create `database_properties`, `database_views`, `row_values` tables with RLS. _No dependencies beyond existing schema._
+12. **Database CRUD operations** — Create/delete/rename databases. Property CRUD, row CRUD, view CRUD via Supabase. _Depends on: #11._
+13. **Table view component** — Spreadsheet grid with column headers, inline cell editing, add row/column, column resize. _Depends on: #12._
+14. **Property type renderers & editors** — Cell renderer and editor for: text, number, select, multi-select, checkbox, date, URL, email, phone. Registry pattern for extensibility. _Depends on: #12._
+15. **Database page detection & routing** — `[pageId]/page.tsx` detects `is_database`, renders database view. View tabs UI. _Depends on: #13._
+16. **Row-as-page support** — Clicking a row opens full page with properties header + Lexical editor. _Depends on: #14, #15._
+
+### Phase 5: Database Views — Additional Views (`priority:2`)
+
+17. **Sort & filter engine** — Client-side sort/filter on row data. Filter bar UI. Persisted per-view. _Depends on: #13._
+18. **Board view component** — Kanban grouped by select property. Drag cards between columns. _Depends on: #14, #17._
+19. **List view component** — Compact row list with title + visible properties. _Depends on: #14, #17._
+20. **Multi-view management** — Create, rename, delete, reorder views. View type picker. Independent config per view. _Depends on: #17._
+
+### Phase 6: Database Views — Advanced (`priority:2`)
+
+21. **Calendar view component** — Month grid, items on date cells, prev/next navigation. _Depends on: #14, #17._
+22. **Gallery view component** — Responsive card grid with cover image + title. _Depends on: #14, #17._
+23. **Person property type** — Member avatar picker, stores user IDs. _Depends on: #14._
+24. **Files property type** — Upload to Supabase Storage, render thumbnails. _Depends on: #14._
+25. **Relation property type** — Link rows across databases, render as pills. _Depends on: #14._
+
+### Phase 7: Database Views — Inline & Formulas (`priority:3`)
+
+26. **DatabaseNode (inline database block)** — Lexical DecoratorNode, slash command, compact view, expand button. _Depends on: #15, #20._
+27. **Formula property type** — Simple expression parser: math, string concat, if/else, now(), date math, prop() refs. _Depends on: #14._
+28. **Database in sidebar** — Grid icon for database pages, "New Database" in sidebar create menu. _Depends on: #15._
 
 ## Acceptance Criteria
 
@@ -220,6 +292,36 @@ These criteria are used by the Feature Planner to create GitHub Issues and by th
 - [ ] Member list visible in workspace settings
 - [ ] Personal workspace owner cannot be removed from their own personal workspace
 
+### Database Views
+- [ ] User can create a database from the sidebar ("New Database" button)
+- [ ] Database pages show a grid icon in the sidebar page tree
+- [ ] User can define properties (columns) with name and type
+- [ ] User can add, edit, and delete rows in table view
+- [ ] Inline cell editing works for all basic property types
+- [ ] Select/multi-select properties support creating new options inline
+- [ ] Database page shows optional rich text content above the database grid
+- [ ] Clicking a row opens it as a full page with properties header + Lexical editor
+- [ ] Row page shows breadcrumb: workspace → database → row
+- [ ] Created time, Updated time, Created by properties auto-derive from page metadata
+- [ ] User can create multiple views per database (table, board, list, calendar, gallery)
+- [ ] View tabs appear above the database, active view highlighted
+- [ ] Each view stores independent configuration (visible properties, sort, filter)
+- [ ] Table view: resizable columns, column reorder, add row/column
+- [ ] Board view: Kanban grouped by select property, drag cards between columns
+- [ ] List view: compact rows with title + visible properties
+- [ ] Calendar view: month grid, items on date cells, prev/next month navigation
+- [ ] Gallery view: card grid with cover image + title
+- [ ] User can sort by any property (ascending/descending), multiple sort rules
+- [ ] User can filter by property value with type-appropriate operators
+- [ ] Active filters shown as pills in filter bar, persisted per-view
+- [ ] User can insert a database block via slash command (`/database`)
+- [ ] Inline database renders a compact view with expand-to-full-page button
+- [ ] Person property shows member avatars, picker searches workspace members
+- [ ] Files property supports upload and renders thumbnails
+- [ ] Relation property links to rows in another database, renders as pills
+- [ ] Formula property evaluates simple expressions referencing other properties
+- [ ] All database data respects workspace RLS policies
+
 ### App Shell
 - [ ] Sidebar: workspace switcher, search, page tree, settings, user menu
 - [ ] Sidebar collapses on mobile (Sheet component)
@@ -236,7 +338,8 @@ These criteria are used by the Feature Planner to create GitHub Issues and by th
 /sign-up                          → (auth)/sign-up/page.tsx
 /                                 → redirect to personal workspace
 /[workspaceSlug]                  → (app)/[workspaceSlug]/page.tsx (workspace home / page list)
-/[workspaceSlug]/[pageId]         → (app)/[workspaceSlug]/[pageId]/page.tsx (page editor)
+/[workspaceSlug]/[pageId]         → (app)/[workspaceSlug]/[pageId]/page.tsx (page editor OR database view when is_database=true)
+/[workspaceSlug]/[pageId]?view=x  → database with specific view selected
 /[workspaceSlug]/settings         → (app)/[workspaceSlug]/settings/page.tsx (workspace settings)
 /[workspaceSlug]/settings/members → (app)/[workspaceSlug]/settings/members/page.tsx
 /invite/[token]                   → (auth)/invite/[token]/page.tsx (accept workspace invite)
@@ -260,3 +363,10 @@ Implementation hints for the Feature Builder. Reference `.agents/architecture.md
 - **Personal workspace creation**: Use a Supabase DB trigger on `auth.users` insert (or a `handle_new_user` function) that creates the profile, workspace (`is_personal = true`), and owner membership row atomically.
 - **Workspace creation limit**: Enforce via a PostgreSQL `BEFORE INSERT` trigger on `workspaces` that checks `SELECT count(*) FROM workspaces WHERE created_by = NEW.created_by` and raises an exception if ≥ 3. Also enforce client-side by disabling the "Create workspace" button when the count is reached.
 - **Personal workspace protection**: RLS policy on `workspaces` prevents `DELETE` where `is_personal = true`. The UI hides the delete option for personal workspaces.
+- **Database rows are pages**: each row in a database is a child page (`parent_id` = database page ID). This means search, favorites, trash, version history, and backlinks work on database rows automatically.
+- **Property type registry**: implement as `Record<PropertyType, { Renderer, Editor }>` so new types can be added without modifying view components.
+- **Client-side filtering/sorting**: load all rows and filter/sort in the browser for the initial implementation. Server-side filtering deferred until databases grow large.
+- **Calendar view**: build with Tailwind grid, no external calendar library.
+- **Formula evaluation**: simple recursive descent parser on the client. Evaluate at render time, not stored.
+- **Select option colors**: fixed palette of 8-10 muted colors derived from the design token set.
+- **DatabaseNode**: Lexical DecoratorNode referencing a database page ID. Renders compact view inline, expand icon opens full page.

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,360 @@
+# Database Views — Feature Specification
+
+## Problem Statement
+
+Memo currently stores all content as unstructured Lexical JSON inside pages. Users have
+no way to work with structured data — tracking tasks, contacts, projects, or any
+collection of items with consistent properties. Notion-style databases let users define
+custom schemas, enter structured rows, and view the same data through multiple lenses
+(table, board, list, calendar, gallery). This is the most-requested missing capability
+and the natural next step after the block editor is stable.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Database identity | Special page type (`is_database = true`) | Databases appear in the sidebar page tree like regular pages. Reuses existing page infrastructure (RLS, nesting, breadcrumbs, favorites, trash). |
+| Inline + full-page | Both | A database can be embedded as a block inside another page (inline) AND opened as its own full page. Inline databases reference a database page via ID. |
+| Rows are pages | Yes | Each database row is a child page (`parent_id` → database page). Clicking a row opens the full Lexical editor with properties displayed above the content. Reuses page CRUD, search, versioning, and backlinks. |
+| Property storage | `database_properties` table + `row_values` table | Properties (schema) stored per-database. Row values stored per-row-page per-property. Separating schema from values enables type validation, view configuration, and efficient queries. |
+| Views | Stored per-database in `database_views` table | Each database can have multiple named views. Each view has a type (table, board, list, calendar, gallery), visible properties, sort rules, and filter rules. |
+| Formula engine | Simple expressions | Basic math, string concat, if/else, now(), date math. ~10 functions. No full formula language. |
+| Created/Updated/CreatedBy | Auto from page metadata | Read-only properties derived from the row page's `created_at`, `updated_at`, `created_by`. No separate storage needed. |
+
+## Data Model
+
+### Modified tables
+
+```
+pages (add column)
+  is_database: boolean (default false)
+  — When true, this page acts as a database container.
+  — Child pages (parent_id = this page) are database rows.
+  — Regular page features (icon, cover, content) still work on database pages
+    (content appears above the database view, like Notion).
+```
+
+### New tables
+
+```
+database_properties (schema definition — columns of a database)
+  id: uuid (PK)
+  database_id: uuid (references pages.id ON DELETE CASCADE)
+  name: text (not null)
+  type: text (not null, check constraint — see Property Types below)
+  config: jsonb (type-specific config: select options, number format, formula expression, relation target, etc.)
+  position: integer (ordering of columns)
+  created_at: timestamptz
+  updated_at: timestamptz
+
+  Indexes:
+  - (database_id, position) for ordered column listing
+  - UNIQUE(database_id, name) to prevent duplicate column names
+
+  RLS: workspace members can CRUD properties for databases in their workspace.
+
+database_views (saved views on a database)
+  id: uuid (PK)
+  database_id: uuid (references pages.id ON DELETE CASCADE)
+  name: text (not null, default 'Default view')
+  type: text (not null, check: 'table' | 'board' | 'list' | 'calendar' | 'gallery')
+  config: jsonb (view-specific configuration — see View Config below)
+  position: integer (ordering of view tabs)
+  created_at: timestamptz
+  updated_at: timestamptz
+
+  Indexes:
+  - (database_id, position) for ordered view tabs
+
+  RLS: workspace members can CRUD views for databases in their workspace.
+
+row_values (property values for each row)
+  id: uuid (PK)
+  row_id: uuid (references pages.id ON DELETE CASCADE — the row page)
+  property_id: uuid (references database_properties.id ON DELETE CASCADE)
+  value: jsonb (the actual value — format depends on property type)
+  created_at: timestamptz
+  updated_at: timestamptz
+
+  Indexes:
+  - UNIQUE(row_id, property_id) — one value per property per row
+  - (property_id, value) for filtering/sorting queries (GIN index on value)
+
+  RLS: workspace members can CRUD values for rows in their workspace.
+```
+
+### Property Types
+
+| Type | `config` schema | `value` schema |
+|---|---|---|
+| `text` | `{}` | `{"text": "string"}` |
+| `number` | `{"format": "number" \| "currency" \| "percent"}` | `{"number": 42.5}` |
+| `select` | `{"options": [{"id": "uuid", "name": "str", "color": "str"}]}` | `{"selected": "option_id"}` |
+| `multi_select` | `{"options": [{"id": "uuid", "name": "str", "color": "str"}]}` | `{"selected": ["id1", "id2"]}` |
+| `checkbox` | `{}` | `{"checked": true}` |
+| `date` | `{}` | `{"date": "2026-04-21", "end_date": "2026-04-25" \| null}` |
+| `url` | `{}` | `{"url": "https://..."}` |
+| `email` | `{}` | `{"email": "user@example.com"}` |
+| `phone` | `{}` | `{"phone": "+1234567890"}` |
+| `person` | `{}` | `{"user_ids": ["uuid1", "uuid2"]}` |
+| `files` | `{}` | `{"files": [{"name": "str", "url": "str"}]}` |
+| `relation` | `{"database_id": "uuid"}` | `{"page_ids": ["uuid1", "uuid2"]}` |
+| `formula` | `{"expression": "prop(\"Price\") * prop(\"Quantity\")"}` | Computed at read time, not stored. |
+| `created_time` | `{}` | Derived from `pages.created_at`. Not stored in `row_values`. |
+| `updated_time` | `{}` | Derived from `pages.updated_at`. Not stored in `row_values`. |
+| `created_by` | `{}` | Derived from `pages.created_by`. Not stored in `row_values`. |
+
+### View Config Schema
+
+Each view type stores its configuration in `database_views.config`:
+
+```jsonc
+// All views share:
+{
+  "visible_properties": ["prop_id_1", "prop_id_2"],  // which columns to show
+  "sorts": [{"property_id": "uuid", "direction": "asc" | "desc"}],
+  "filters": [{"property_id": "uuid", "operator": "equals" | "contains" | "is_empty" | "is_not_empty" | "gt" | "lt", "value": <any>}]
+}
+
+// Table-specific:
+{
+  "column_widths": {"prop_id": 200},  // pixel widths
+  "row_height": "compact" | "default" | "tall"
+}
+
+// Board-specific:
+{
+  "group_by": "property_id",          // must be a select property
+  "hide_empty_groups": false
+}
+
+// List-specific:
+{
+  // No extra config beyond shared fields
+}
+
+// Calendar-specific:
+{
+  "date_property": "property_id"      // which date property positions items
+}
+
+// Gallery-specific:
+{
+  "card_size": "small" | "medium" | "large",
+  "cover_property": "property_id" | null  // files property for card cover, or null for page cover
+}
+```
+
+### Lexical Integration — DatabaseNode
+
+A new `DatabaseNode` (DecoratorNode) for embedding databases inline in pages:
+
+```
+DatabaseNode
+  type: "database"
+  databaseId: string (references pages.id where is_database = true)
+  viewId: string | null (which view to show inline; null = first view)
+```
+
+When rendered inline, the database shows a compact version of the selected view.
+Clicking the expand icon opens the database as a full page.
+
+## View Types
+
+### Table View
+- Spreadsheet-style grid with resizable columns
+- Inline cell editing (click to edit, Tab to move between cells)
+- Add row button at bottom, add column button at right
+- Column header: name, type icon, sort indicator, click to configure
+- Row checkbox for bulk actions (delete)
+
+### Board View
+- Kanban columns grouped by a select property
+- Cards show title + configured visible properties
+- Drag cards between columns to update the select value
+- Add card button at bottom of each column
+- Uncategorized column for rows without a value
+
+### List View
+- Compact vertical list, one row per line
+- Title on the left, visible properties on the right
+- Click row to open as page
+
+### Calendar View
+- Month grid with navigation (prev/next month, today button)
+- Items positioned by a date property
+- Items show title (truncated) + optional icon
+- Click date cell to create new row with that date pre-filled
+- Click item to open as page
+
+### Gallery View
+- Card grid (responsive: 2-4 columns depending on viewport)
+- Card shows: cover image (from files property or page cover) + title
+- Click card to open as page
+- No cover: show a muted placeholder or just the title
+
+## Filter & Sort
+
+### Sort
+- Sort by any property, ascending or descending
+- Multiple sort rules (primary, secondary, etc.)
+- Sort persisted per-view in `database_views.config`
+
+### Filters
+- Filter by property value with operators:
+  - Text: `contains`, `equals`, `is_empty`, `is_not_empty`
+  - Number: `equals`, `gt`, `lt`, `gte`, `lte`, `is_empty`, `is_not_empty`
+  - Select: `equals`, `is_empty`, `is_not_empty`
+  - Multi-select: `contains`, `is_empty`, `is_not_empty`
+  - Checkbox: `equals` (true/false)
+  - Date: `equals`, `before`, `after`, `is_empty`, `is_not_empty`
+  - Person: `contains`, `is_empty`, `is_not_empty`
+- Filters are AND-combined (no OR groups in this iteration)
+- Filter UI: toolbar above the view with active filter pills
+- Filters persisted per-view in `database_views.config`
+
+## URL Structure
+
+```
+/[workspaceSlug]/[pageId]                    → database full-page view (when page.is_database = true)
+/[workspaceSlug]/[pageId]?view=[viewId]      → specific view of a database
+/[workspaceSlug]/[pageId]/[rowPageId]        → row opened as page (existing page route)
+```
+
+No new route files needed — the existing `[pageId]/page.tsx` detects `is_database` and
+renders the database view instead of (or above) the editor.
+
+## UI Design
+
+Follows the existing design spec (`.agents/design.md`):
+
+- Dark mode only, sharp corners, JetBrains Mono
+- View tabs: horizontal tab bar above the database, `text-sm`, active tab has `border-b-2 border-accent`
+- New view button: `+` icon at end of tab bar, dropdown to pick view type
+- Property config: click column header → dropdown with rename, type change, delete, sort, filter
+- Cell editing: click to focus, inline editing, auto-save on blur
+- Board cards: `bg-muted`, `border border-white/[0.06]`, `p-3`, sharp corners
+- Calendar cells: `border border-white/[0.06]`, today highlighted with `bg-accent/10`
+- Gallery cards: `bg-muted`, cover image fills top half, title below, sharp corners
+- Filter bar: `bg-muted p-2`, filter pills as `Badge` components, `+ Add filter` button
+- Sort indicator: small arrow icon in column header
+- Empty database: centered empty state with "Add a row" CTA
+
+## Phased Delivery
+
+### Phase 1: Database Foundation (`priority:1`)
+The schema, core CRUD, and table view — enough to create and use a basic database.
+
+**Issues:**
+1. **Database schema migration** — Add `is_database` to pages, create `database_properties`, `database_views`, `row_values` tables with RLS policies and indexes. _No dependencies._
+2. **Database CRUD operations** — Create database (from sidebar "New Database" button and slash command), delete database, rename. Supabase queries for property CRUD, row CRUD, view CRUD. _Depends on: #1._
+3. **Table view component** — Spreadsheet grid with column headers, inline cell editing, add row/column, column resize. Renders database rows with their property values. _Depends on: #2._
+4. **Property type renderers & editors** — Cell renderer and inline editor for each property type: text, number, select, multi-select, checkbox, date, URL, email, phone. Reusable across all view types. _Depends on: #2._
+5. **Database page detection & routing** — Modify `[pageId]/page.tsx` to detect `is_database` and render database view. Database pages show optional Lexical content above the database grid. View tabs UI (even if only one view exists). _Depends on: #3._
+6. **Row-as-page support** — Clicking a row opens it as a full page (`/[workspaceSlug]/[rowPageId]`). Properties displayed above the Lexical editor in a structured header. Back-navigation to parent database. _Depends on: #4, #5._
+
+### Phase 2: Additional Views (`priority:2`)
+Board and List views, plus sort and filter.
+
+**Issues:**
+7. **Sort & filter engine** — Client-side sort and filter logic that operates on row data. Filter bar UI with property-aware operator selection. Sort UI in column headers and view config. Persisted in `database_views.config`. _Depends on: #3._
+8. **Board view component** — Kanban columns grouped by a select property. Drag-and-drop cards between columns. Card rendering with visible properties. _Depends on: #4, #7._
+9. **List view component** — Compact row list with title + visible properties. Click to open row as page. _Depends on: #4, #7._
+10. **Multi-view management** — Create, rename, delete, reorder views. View type picker. View tabs with active state. Each view stores independent sort/filter/visible properties config. _Depends on: #7._
+
+### Phase 3: Advanced Views & Properties (`priority:2`)
+Calendar, Gallery, and the remaining property types.
+
+**Issues:**
+11. **Calendar view component** — Month grid with prev/next navigation. Items positioned by date property. Click cell to create row. Click item to open row. _Depends on: #4, #7._
+12. **Gallery view component** — Responsive card grid. Cover image from files property or page cover. Title below cover. Click to open row as page. _Depends on: #4, #7._
+13. **Person property type** — Renders workspace member avatars. Picker searches workspace members. Stores user IDs. _Depends on: #4._
+14. **Files property type** — File upload to Supabase Storage. Renders file thumbnails/links. Reuses existing image upload infrastructure. _Depends on: #4._
+15. **Relation property type** — Links rows to rows in another database. Picker searches target database rows. Renders as linked page pills (similar to PageLinkNode). _Depends on: #4._
+
+### Phase 4: Inline Databases & Formulas (`priority:3`)
+Embedding databases in pages and computed properties.
+
+**Issues:**
+16. **DatabaseNode (inline database block)** — Lexical DecoratorNode that embeds a database view inside a page. Slash command to insert. Compact rendering with expand-to-full-page button. _Depends on: #5, #10._
+17. **Formula property type** — Expression parser and evaluator. Supports basic math, string concat, if/else, now(), date math, prop() references. Computed at read time. _Depends on: #4._
+18. **Database in sidebar** — Database pages show a distinct icon in the page tree (grid/table icon instead of document icon). "New Database" option in sidebar create menu. _Depends on: #5._
+
+## Issue Dependency Graph
+
+```
+#1 Database schema migration
+ └─► #2 Database CRUD operations
+      ├─► #3 Table view component ──────────────────┐
+      │    └─► #5 Database page detection & routing ─┤
+      │         └─► #6 Row-as-page support ◄─────────┤
+      └─► #4 Property type renderers & editors ──────┘
+           │    └─► #13 Person property
+           │    └─► #14 Files property
+           │    └─► #15 Relation property
+           │    └─► #17 Formula property
+           │
+           ├─► #7 Sort & filter engine ◄── #3
+           │    ├─► #8 Board view
+           │    ├─► #9 List view
+           │    ├─► #10 Multi-view management
+           │    │    └─► #16 DatabaseNode (inline)
+           │    ├─► #11 Calendar view
+           │    └─► #12 Gallery view
+           │
+           └─► #18 Database in sidebar ◄── #5
+```
+
+## Acceptance Criteria
+
+### Database Foundation
+- [ ] User can create a database from the sidebar (appears as a page with grid icon)
+- [ ] User can define properties (columns) with name and type
+- [ ] User can add, edit, and delete rows in table view
+- [ ] Inline cell editing works for all basic property types (text, number, select, multi-select, checkbox, date, URL, email, phone)
+- [ ] Select/multi-select properties support creating new options inline
+- [ ] Database page shows optional rich text content above the database grid
+- [ ] Clicking a row opens it as a full page with properties header + Lexical editor
+- [ ] Row page shows breadcrumb: workspace → database → row
+- [ ] Created time, Updated time, Created by properties auto-derive from page metadata
+- [ ] All database data respects workspace RLS policies
+
+### Views
+- [ ] User can create multiple views per database (table, board, list, calendar, gallery)
+- [ ] View tabs appear above the database, active view highlighted
+- [ ] Each view stores independent configuration (visible properties, sort, filter)
+- [ ] Table view: resizable columns, column reorder, add row/column
+- [ ] Board view: Kanban grouped by select property, drag cards between columns
+- [ ] List view: compact rows with title + visible properties
+- [ ] Calendar view: month grid, items on date cells, prev/next month navigation
+- [ ] Gallery view: card grid with cover image + title
+
+### Filter & Sort
+- [ ] User can sort by any property (ascending/descending)
+- [ ] User can add multiple sort rules
+- [ ] User can filter by property value with type-appropriate operators
+- [ ] Active filters shown as pills in filter bar
+- [ ] Filters and sorts persist per-view
+
+### Inline Database
+- [ ] User can insert a database block via slash command (`/database`)
+- [ ] Inline database renders a compact view of the referenced database
+- [ ] Expand button opens the database as a full page
+- [ ] Inline database respects the selected view's configuration
+
+### Advanced Properties
+- [ ] Person property shows member avatars, picker searches workspace members
+- [ ] Files property supports upload and renders thumbnails
+- [ ] Relation property links to rows in another database, renders as pills
+- [ ] Formula property evaluates simple expressions referencing other properties
+
+## Implementation Notes
+
+- **No new Supabase buckets needed** — file uploads for the files property reuse the existing `page-images` bucket.
+- **Reuse existing page infrastructure** — rows are pages, so search, favorites, trash, version history, backlinks all work on database rows automatically.
+- **Client-side filtering/sorting** — for the initial implementation, load all rows and filter/sort in the browser. Pagination and server-side filtering can be added later if databases grow large.
+- **Property type renderers** should be a registry pattern (`Record<PropertyType, { Renderer, Editor }>`) so new types can be added without modifying view components.
+- **Board drag-and-drop** — reuse the drag-and-drop patterns from the existing `DraggableBlockPlugin` and page tree.
+- **Calendar** — build from scratch with Tailwind grid, no external calendar library.
+- **Formula evaluation** — a simple recursive descent parser. No need for a full AST library. Evaluate on the client at render time.
+- **Select option colors** — use a fixed palette of 8-10 colors from the design token set (muted variants of accent, destructive, etc.).

--- a/src/lib/page-tree.test.ts
+++ b/src/lib/page-tree.test.ts
@@ -21,6 +21,7 @@ function makePage(overrides: Partial<Page> & { id: string }): Page {
     content: null,
     icon: null,
     cover_url: null,
+    is_database: false,
     position: 0,
     created_by: "user-1",
     created_at: "2024-01-01T00:00:00Z",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,7 @@ export interface Page {
   content: Record<string, unknown> | null;
   icon: string | null;
   cover_url: string | null;
+  is_database: boolean;
   position: number;
   created_by: string;
   created_at: string;
@@ -116,6 +117,97 @@ export interface PageLink {
 // Joined type for backlinks query (page_links joined with source page)
 export interface BacklinkWithPage extends PageLink {
   source_page: Pick<Page, "id" | "title" | "icon">;
+}
+
+// Database views types
+
+export type PropertyType =
+  | "text"
+  | "number"
+  | "select"
+  | "multi_select"
+  | "checkbox"
+  | "date"
+  | "url"
+  | "email"
+  | "phone"
+  | "person"
+  | "files"
+  | "relation"
+  | "formula"
+  | "created_time"
+  | "updated_time"
+  | "created_by";
+
+export type DatabaseViewType =
+  | "table"
+  | "board"
+  | "list"
+  | "calendar"
+  | "gallery";
+
+export interface SelectOption {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface DatabaseProperty {
+  id: string;
+  database_id: string;
+  name: string;
+  type: PropertyType;
+  config: Record<string, unknown>;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DatabaseViewConfig {
+  visible_properties?: string[];
+  sorts?: { property_id: string; direction: "asc" | "desc" }[];
+  filters?: {
+    property_id: string;
+    operator: string;
+    value: unknown;
+  }[];
+  // Table-specific
+  column_widths?: Record<string, number>;
+  row_height?: "compact" | "default" | "tall";
+  // Board-specific
+  group_by?: string;
+  hide_empty_groups?: boolean;
+  // Calendar-specific
+  date_property?: string;
+  // Gallery-specific
+  card_size?: "small" | "medium" | "large";
+  cover_property?: string | null;
+}
+
+export interface DatabaseView {
+  id: string;
+  database_id: string;
+  name: string;
+  type: DatabaseViewType;
+  config: DatabaseViewConfig;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RowValue {
+  id: string;
+  row_id: string;
+  property_id: string;
+  value: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+// Joined type for loading a database row with all its property values
+export interface DatabaseRow {
+  page: Pick<Page, "id" | "title" | "icon" | "cover_url" | "created_at" | "updated_at" | "created_by">;
+  values: Record<string, RowValue>; // keyed by property_id
 }
 
 export type FeedbackType = "bug" | "feature" | "general";


### PR DESCRIPTION
## Summary

Adds foundational documentation for Notion-style database views — the next major feature after the block editor is stable. This PR contains no code changes beyond types and a test fix; it establishes the architecture, design patterns, and phased delivery plan that the automation loop will use to implement the feature.

## Changes

- **`spec.md`** — Full feature specification: problem statement, data model, view types, filter/sort, phased delivery plan (18 issues across 4 phases), acceptance criteria, dependency graph
- **`docs/product-spec.md`** — Moved database views from "Out of Scope" to "Post-MVP". Added data model tables (`database_properties`, `database_views`, `row_values`), phases 4–7, acceptance criteria, URL structure, technical notes
- **`.agents/architecture.md`** — Database data model in the schema diagram, `DatabaseNode` in custom nodes/plugins, new "Database Views — Architecture" section with rendering flow, component structure, key technical decisions
- **`.agents/design.md`** — New "Database Views" section with UI patterns for all 5 view types (table, board, list, calendar, gallery), property cell renderers, select option color palette, filter/sort bar, row-as-page properties header, inline database block, empty state
- **`src/lib/types.ts`** — Added `PropertyType`, `DatabaseViewType`, `SelectOption`, `DatabaseProperty`, `DatabaseView`, `DatabaseViewConfig`, `RowValue`, `DatabaseRow` types. Added `is_database` field to `Page` interface
- **`src/lib/page-tree.test.ts`** — Added `is_database: false` to test helper to match updated `Page` type

## Key decisions

- Databases are pages with `is_database = true` — reuses all existing page infrastructure (RLS, search, trash, versioning, favorites, backlinks)
- Rows are child pages — clicking a row opens the full Lexical editor with a properties header
- Schema in `database_properties`, values in `row_values` (normalized), views in `database_views`
- Client-side filtering/sorting initially; server-side deferred
- No new routes — existing `[pageId]/page.tsx` detects `is_database` and switches rendering
- Property type registry pattern (`Record<PropertyType, {Renderer, Editor}>`) for extensibility

## Next steps

After merge, GitHub issues will be created for the 4-phase delivery plan (18 issues total) with dependency chains and labels for the Feature Builder automation.