### PR TITLE
fix: detect Node.js native fetch errors in isTransientNetworkError (#430)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -195,9 +195,17 @@ The helper accepts `PostgrestError` (from query results) and generic `Error` (fr
 catch blocks). It tags the Sentry event with the operation name, error code, and
 message so errors are filterable in the Sentry dashboard.
 
-Transient network errors (`TypeError: Failed to fetch`, `Load failed`, etc.) are
-automatically captured at `warning` level instead of `error` — they are not
-application bugs and should not trigger error-level alerts.
+Transient network errors are automatically captured at `warning` level instead of
+`error` — they are not application bugs and should not trigger error-level alerts.
+
+Browser-style messages: `TypeError: Failed to fetch`, `Failed to fetch`,
+`Load failed`, `NetworkError when attempting to fetch resource.`,
+`The Internet connection appears to be offline.`, `Network request failed`.
+
+Node.js native fetch (undici) messages: `fetch failed` (top-level), with the real
+cause wrapped in `error.cause` — look for `ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`,
+`UND_ERR_SOCKET` in the cause message. Always check the `cause` chain for
+server-side fetch errors, not just the top-level message.
 
 ### Retrying transient network errors
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -136,15 +136,31 @@ export function isInsufficientPrivilegeError(error: Error): boolean {
 }
 
 /**
+ * Node.js native fetch (undici) wraps the real network error in the `cause`
+ * property. These substrings in the cause message indicate transient failures.
+ */
+const NODE_FETCH_CAUSE_PATTERNS = [
+  "ECONNRESET",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_SOCKET",
+];
+
+/**
  * True when the error is a transient network failure (e.g. offline, DNS
  * timeout, connection reset). These are not application bugs and should be
  * reported at warning level so they don't trigger error-level alerts.
+ *
+ * Checks both browser-style fetch errors (top-level message) and Node.js
+ * native fetch errors (undici), which use `"fetch failed"` as the message
+ * and wrap the real cause (ECONNRESET, ENOTFOUND, etc.) in `error.cause`.
  */
 export function isTransientNetworkError(error: Error): boolean {
   const msg = error.message;
   const details = isPostgrestError(error) ? error.details : "";
 
-  return (
+  // Browser-style fetch errors
+  if (
     msg === "TypeError: Failed to fetch" ||
     details === "TypeError: Failed to fetch" ||
     msg === "Failed to fetch" ||
@@ -152,7 +168,25 @@ export function isTransientNetworkError(error: Error): boolean {
     msg === "NetworkError when attempting to fetch resource." ||
     msg === "The Internet connection appears to be offline." ||
     msg === "Network request failed"
-  );
+  ) {
+    return true;
+  }
+
+  // Node.js native fetch (undici): top-level message is "fetch failed"
+  if (msg === "fetch failed") {
+    return true;
+  }
+
+  // Node.js native fetch wraps the real error in the cause chain
+  const causeMsg = error.cause instanceof Error ? error.cause.message : "";
+  if (
+    causeMsg &&
+    NODE_FETCH_CAUSE_PATTERNS.some((pattern) => causeMsg.includes(pattern))
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -72,6 +72,56 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("detects Node.js native fetch 'fetch failed' message", () => {
+    const error = new Error("fetch failed");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects ECONNRESET in error cause chain (Node.js native fetch)", () => {
+    const cause = new Error(
+      "Client network socket disconnected before secure TLS connection was established",
+    );
+    cause.message += " (ECONNRESET)";
+    const error = new Error("fetch failed", { cause });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects ENOTFOUND in error cause chain (DNS failure)", () => {
+    const cause = new Error("getaddrinfo ENOTFOUND example.com");
+    const error = new Error("fetch failed", { cause });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects ETIMEDOUT in error cause chain (connection timeout)", () => {
+    const cause = new Error("connect ETIMEDOUT 10.0.0.1:443");
+    const error = new Error("fetch failed", { cause });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects UND_ERR_SOCKET in error cause chain (undici socket error)", () => {
+    const cause = new Error("other side closed - Loss of signal (UND_ERR_SOCKET)");
+    const error = new Error("fetch failed", { cause });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects cause chain errors even when top-level message is not 'fetch failed'", () => {
+    const cause = new Error("connect ECONNRESET 10.0.0.1:443");
+    const error = new Error("request to https://example.com failed", { cause });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns false when cause exists but is not a transient network error", () => {
+    const cause = new Error("SQLITE_BUSY: database is locked");
+    const error = new Error("fetch failed", { cause });
+    // "fetch failed" message alone is enough to be transient
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns false when cause is not an Error instance", () => {
+    const error = new Error("some error", { cause: "string cause" });
+    expect(isTransientNetworkError(error)).toBe(false);
+  });
+
   it("returns false for a regular PostgrestError", () => {
     const error = makePostgrestError({
       message: "new row violates row-level security policy",
@@ -242,6 +292,20 @@ describe("captureSupabaseError", () => {
     expect(opts.level).toBe("warning");
     expect(opts.extra.operation).toBe("page-tree:create-page");
     expect(opts.extra.code).toBe("42501");
+  });
+
+  it("captures Node.js native fetch errors at warning level (MEMO-15)", async () => {
+    const cause = new Error(
+      "Client network socket disconnected before secure TLS connection was established (ECONNRESET)",
+    );
+    const error = new Error("fetch failed", { cause });
+    captureSupabaseError(error, "usage-events:track");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("usage-events:track");
   });
 
   it("captures non-network, non-RLS errors at default (error) level", async () => {


### PR DESCRIPTION
Closes #430

## What

`isTransientNetworkError` only recognized browser-style fetch error messages (`"Failed to fetch"`, `"Load failed"`, etc.) and missed Node.js native fetch (undici) errors. Server-side routes hitting transient network failures (e.g. `ECONNRESET` during a TLS handshake) were reported at error level in Sentry instead of warning level, creating false alerts.

## How

Added detection for Node.js native fetch patterns:
- `"fetch failed"` top-level message (undici's error message format)
- `ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`, `UND_ERR_SOCKET` in the `error.cause` chain (Node.js wraps the real network error in `cause`)

Updated `.agents/conventions.md` to document both browser and Node.js fetch error patterns, preventing the same gap from recurring.

## Testing

Added 8 regression tests to `sentry.unit.test.ts`:
- `"fetch failed"` message detection
- `ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`, `UND_ERR_SOCKET` in cause chain
- Cause chain detection with non-standard top-level messages
- Non-Error cause values (returns false)
- `captureSupabaseError` integration test verifying Node.js fetch errors are captured at warning level

All 516 tests pass: `pnpm lint && pnpm typecheck && pnpm test`