### PR TITLE
feat(database): CRUD operations — create, delete, rename databases, properties, rows, views (#432)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -465,6 +465,7 @@ src/
 │   ├── utils.ts            # cn() utility (clsx + tailwind-merge)
 │   ├── types.ts            # Database entity types
 │   ├── workspace.ts        # Workspace utilities: slug generation, validation, limits
+│   ├── database.ts         # Database CRUD: create/delete databases, property/row/view CRUD, data loading
 │   └── supabase/
 │       ├── client.ts       # Browser client (createBrowserClient)
 │       ├── server.ts       # Server component client (createServerClient + cookies)

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1226,6 +1226,41 @@ trackEventClient(supabase, "page.created", userId, {
 - When the Supabase client isn't already available (e.g. `handleExport`), use
   `getClient().then(supabase => trackEventClient(...)).catch(() => {})`.
 
+## Database CRUD Layer
+
+Database operations live in `src/lib/database.ts`. All functions use the browser
+Supabase client and return `{ data, error }` tuples (matching the Supabase SDK
+convention). Errors are reported via `captureSupabaseError` inside the function —
+callers only need to check `error` and show a toast.
+
+```typescript
+import { createDatabase, addRow, loadDatabase } from "@/lib/database";
+
+// Create a database (page + default property + default view)
+const { data, error } = await createDatabase(workspaceId, userId, "Tasks");
+if (error) {
+  toast.error("Failed to create database", { duration: 8000 });
+  return;
+}
+
+// Load all data for a database view
+const { data: db, error: loadError } = await loadDatabase(databaseId);
+if (db) {
+  // db.properties, db.views, db.rows are ready
+}
+```
+
+Key patterns:
+- `createDatabase` is pseudo-atomic: creates page → property → view, cleans up
+  the page on partial failure.
+- `deleteView` prevents deleting the last view (returns an error).
+- `addRow` looks up `workspace_id` from the database page automatically.
+- `updateRowValue` uses upsert on the `(row_id, property_id)` unique constraint.
+- `loadDatabase` fetches properties, views, and rows in parallel via `Promise.all`,
+  then loads row values in a single batch query and groups them client-side.
+- Position auto-calculation: `addProperty`, `addView`, and `addRow` query the max
+  position and increment. Reorder functions accept an ordered ID array.
+
 ## This file evolves
 
 When you discover a new pattern that should be replicated, or an anti-pattern that

--- a/src/lib/database.test.ts
+++ b/src/lib/database.test.ts
@@ -1,0 +1,781 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const captureSupabaseErrorMock = vi.fn();
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: (error: unknown, operation: unknown) =>
+    captureSupabaseErrorMock(error, operation),
+}));
+
+/**
+ * Creates a chainable Supabase query builder mock.
+ * Every method returns the builder itself. The builder is thenable,
+ * so `await supabase.from("x").update({}).eq(...)` resolves to `resolvedValue`.
+ * `.single()` and `.maybeSingle()` also resolve to `resolvedValue`.
+ */
+function createChainMock(resolvedValue: {
+  data: unknown;
+  error: unknown;
+  count?: number | null;
+}) {
+  const calls: Record<string, unknown[][]> = {};
+
+  const handler: ProxyHandler<object> = {
+    get(_target, prop: string) {
+      // Make the proxy thenable so bare `await chain` works
+      if (prop === "then") {
+        return (
+          resolve: (v: unknown) => void,
+          reject?: (e: unknown) => void,
+        ) => Promise.resolve(resolvedValue).then(resolve, reject);
+      }
+      if (prop === "catch" || prop === "finally") {
+        return (...args: unknown[]) =>
+          Promise.resolve(resolvedValue)[prop as "catch" | "finally"](
+            ...(args as [never]),
+          );
+      }
+
+      // Track calls for assertions
+      return (...args: unknown[]) => {
+        if (!calls[prop]) calls[prop] = [];
+        calls[prop].push(args);
+        return proxy;
+      };
+    },
+  };
+
+  const proxy = new Proxy({}, handler);
+  return { proxy, calls };
+}
+
+// Per-table mock registry.
+let tableMocks: Record<string, ReturnType<typeof createChainMock>>;
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      const mock = tableMocks[table];
+      if (!mock) throw new Error(`No mock configured for table: ${table}`);
+      return mock.proxy;
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  createDatabase,
+  deleteDatabase,
+  addProperty,
+  updateProperty,
+  deleteProperty,
+  reorderProperties,
+  addRow,
+  updateRowValue,
+  addView,
+  updateView,
+  deleteView,
+  reorderViews,
+  loadDatabase,
+  loadRow,
+} from "./database";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tableMocks = {};
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockTable(
+  table: string,
+  resolvedValue: { data: unknown; error: unknown; count?: number | null },
+) {
+  const mock = createChainMock(resolvedValue);
+  tableMocks[table] = mock;
+  return mock;
+}
+
+const FAKE_PAGE = {
+  id: "page-1",
+  workspace_id: "ws-1",
+  parent_id: null,
+  title: "Test DB",
+  content: null,
+  icon: null,
+  cover_url: null,
+  is_database: true,
+  position: 0,
+  created_by: "user-1",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  deleted_at: null,
+};
+
+const FAKE_PROPERTY = {
+  id: "prop-1",
+  database_id: "page-1",
+  name: "Title",
+  type: "text",
+  config: {},
+  position: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const FAKE_VIEW = {
+  id: "view-1",
+  database_id: "page-1",
+  name: "Default view",
+  type: "table",
+  config: {},
+  position: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+// ---------------------------------------------------------------------------
+// createDatabase
+// ---------------------------------------------------------------------------
+
+describe("createDatabase", () => {
+  it("creates page, default property, and default view", async () => {
+    mockTable("pages", { data: FAKE_PAGE, error: null });
+    mockTable("database_properties", { data: FAKE_PROPERTY, error: null });
+    mockTable("database_views", { data: FAKE_VIEW, error: null });
+
+    const result = await createDatabase("ws-1", "user-1", "Test DB");
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+    expect(result.data!.page.id).toBe("page-1");
+    expect(result.data!.property.name).toBe("Title");
+    expect(result.data!.view.type).toBe("table");
+  });
+
+  it("returns error and captures to Sentry when page insert fails", async () => {
+    const dbError = new Error("RLS violation");
+    mockTable("pages", { data: null, error: dbError });
+
+    const result = await createDatabase("ws-1", "user-1");
+
+    expect(result.error).toBe(dbError);
+    expect(result.data).toBeNull();
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.create:page",
+    );
+  });
+
+  it("cleans up page when property insert fails", async () => {
+    mockTable("pages", { data: FAKE_PAGE, error: null });
+    const propError = new Error("property insert failed");
+    mockTable("database_properties", { data: null, error: propError });
+
+    const result = await createDatabase("ws-1", "user-1");
+
+    expect(result.error).toBe(propError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      propError,
+      "database.create:property",
+    );
+    expect(tableMocks["pages"].calls["delete"]).toBeDefined();
+  });
+
+  it("cleans up page when view insert fails", async () => {
+    mockTable("pages", { data: FAKE_PAGE, error: null });
+    mockTable("database_properties", { data: FAKE_PROPERTY, error: null });
+    const viewError = new Error("view insert failed");
+    mockTable("database_views", { data: null, error: viewError });
+
+    const result = await createDatabase("ws-1", "user-1");
+
+    expect(result.error).toBe(viewError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      viewError,
+      "database.create:view",
+    );
+    expect(tableMocks["pages"].calls["delete"]).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteDatabase
+// ---------------------------------------------------------------------------
+
+describe("deleteDatabase", () => {
+  it("soft-deletes the database page", async () => {
+    mockTable("pages", { data: null, error: null });
+
+    const result = await deleteDatabase("page-1");
+
+    expect(result.error).toBeNull();
+    expect(tableMocks["pages"].calls["update"]).toBeDefined();
+    const eqCalls = tableMocks["pages"].calls["eq"];
+    expect(eqCalls).toContainEqual(["id", "page-1"]);
+    expect(eqCalls).toContainEqual(["is_database", true]);
+  });
+
+  it("captures error on failure", async () => {
+    const dbError = new Error("delete failed");
+    mockTable("pages", { data: null, error: dbError });
+
+    const result = await deleteDatabase("page-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.delete",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addProperty
+// ---------------------------------------------------------------------------
+
+describe("addProperty", () => {
+  it("inserts a property with auto-calculated position", async () => {
+    mockTable("database_properties", {
+      data: { ...FAKE_PROPERTY, id: "prop-new", position: 3 },
+      error: null,
+    });
+
+    const result = await addProperty("page-1", "Status", "select", {
+      options: [],
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+    expect(tableMocks["database_properties"].calls["insert"]).toBeDefined();
+  });
+
+  it("captures error on failure", async () => {
+    const dbError = new Error("duplicate name");
+    mockTable("database_properties", { data: null, error: dbError });
+
+    const result = await addProperty("page-1", "Title", "text");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.addProperty",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateProperty
+// ---------------------------------------------------------------------------
+
+describe("updateProperty", () => {
+  it("updates property name", async () => {
+    const updated = { ...FAKE_PROPERTY, name: "New Name" };
+    mockTable("database_properties", { data: updated, error: null });
+
+    const result = await updateProperty("prop-1", { name: "New Name" });
+
+    expect(result.error).toBeNull();
+    expect(result.data!.name).toBe("New Name");
+  });
+
+  it("captures error on failure", async () => {
+    const dbError = new Error("update failed");
+    mockTable("database_properties", { data: null, error: dbError });
+
+    const result = await updateProperty("prop-1", { name: "X" });
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.updateProperty",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteProperty
+// ---------------------------------------------------------------------------
+
+describe("deleteProperty", () => {
+  it("deletes a property", async () => {
+    mockTable("database_properties", { data: null, error: null });
+
+    const result = await deleteProperty("prop-1");
+
+    expect(result.error).toBeNull();
+    expect(tableMocks["database_properties"].calls["delete"]).toBeDefined();
+  });
+
+  it("captures error on failure", async () => {
+    const dbError = new Error("delete failed");
+    mockTable("database_properties", { data: null, error: dbError });
+
+    const result = await deleteProperty("prop-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.deleteProperty",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorderProperties
+// ---------------------------------------------------------------------------
+
+describe("reorderProperties", () => {
+  it("updates position for each property in order", async () => {
+    mockTable("database_properties", { data: null, error: null });
+
+    const result = await reorderProperties("page-1", [
+      "prop-b",
+      "prop-a",
+      "prop-c",
+    ]);
+
+    expect(result.error).toBeNull();
+    expect(tableMocks["database_properties"].calls["update"]).toHaveLength(3);
+  });
+
+  it("stops and returns error on first failure", async () => {
+    const dbError = new Error("update failed");
+    mockTable("database_properties", { data: null, error: dbError });
+
+    const result = await reorderProperties("page-1", ["prop-a", "prop-b"]);
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.reorderProperties",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addRow
+// ---------------------------------------------------------------------------
+
+describe("addRow", () => {
+  it("creates a child page for the database", async () => {
+    mockTable("pages", {
+      data: {
+        ...FAKE_PAGE,
+        id: "row-1",
+        is_database: false,
+        parent_id: "page-1",
+        workspace_id: "ws-1",
+      },
+      error: null,
+    });
+
+    const result = await addRow("page-1", "user-1");
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+    expect(tableMocks["pages"].calls["insert"]).toBeDefined();
+  });
+
+  it("inserts initial values when provided", async () => {
+    mockTable("pages", {
+      data: {
+        ...FAKE_PAGE,
+        id: "row-1",
+        is_database: false,
+        workspace_id: "ws-1",
+      },
+      error: null,
+    });
+    mockTable("row_values", { data: null, error: null });
+
+    const result = await addRow("page-1", "user-1", {
+      "prop-1": { text: "Hello" },
+    });
+
+    expect(result.error).toBeNull();
+    expect(tableMocks["row_values"].calls["insert"]).toBeDefined();
+  });
+
+  it("captures error when page lookup fails", async () => {
+    const dbError = new Error("not found");
+    mockTable("pages", { data: null, error: dbError });
+
+    const result = await addRow("page-1", "user-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.addRow:lookup",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateRowValue
+// ---------------------------------------------------------------------------
+
+describe("updateRowValue", () => {
+  it("upserts a row value", async () => {
+    const fakeValue = {
+      id: "val-1",
+      row_id: "row-1",
+      property_id: "prop-1",
+      value: { text: "Hello" },
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    mockTable("row_values", { data: fakeValue, error: null });
+
+    const result = await updateRowValue("row-1", "prop-1", { text: "Hello" });
+
+    expect(result.error).toBeNull();
+    expect(result.data!.value).toEqual({ text: "Hello" });
+    expect(tableMocks["row_values"].calls["upsert"]).toBeDefined();
+  });
+
+  it("captures error on failure", async () => {
+    const dbError = new Error("upsert failed");
+    mockTable("row_values", { data: null, error: dbError });
+
+    const result = await updateRowValue("row-1", "prop-1", { text: "X" });
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.updateRowValue",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addView
+// ---------------------------------------------------------------------------
+
+describe("addView", () => {
+  it("inserts a view with auto-calculated position", async () => {
+    mockTable("database_views", {
+      data: { ...FAKE_VIEW, id: "view-new", name: "Board", type: "board" },
+      error: null,
+    });
+
+    const result = await addView("page-1", "Board", "board");
+
+    expect(result.error).toBeNull();
+    expect(result.data!.type).toBe("board");
+    expect(tableMocks["database_views"].calls["insert"]).toBeDefined();
+  });
+
+  it("captures error on failure", async () => {
+    const dbError = new Error("insert failed");
+    mockTable("database_views", { data: null, error: dbError });
+
+    const result = await addView("page-1", "Board", "board");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.addView",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateView
+// ---------------------------------------------------------------------------
+
+describe("updateView", () => {
+  it("updates view name", async () => {
+    const updated = { ...FAKE_VIEW, name: "My Table" };
+    mockTable("database_views", { data: updated, error: null });
+
+    const result = await updateView("view-1", { name: "My Table" });
+
+    expect(result.error).toBeNull();
+    expect(result.data!.name).toBe("My Table");
+  });
+
+  it("captures error on failure", async () => {
+    const dbError = new Error("update failed");
+    mockTable("database_views", { data: null, error: dbError });
+
+    const result = await updateView("view-1", { name: "X" });
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.updateView",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteView
+// ---------------------------------------------------------------------------
+
+describe("deleteView", () => {
+  it("rejects deleting the last view", async () => {
+    mockTable("database_views", {
+      data: { database_id: "page-1" },
+      error: null,
+      count: 1,
+    });
+
+    const result = await deleteView("view-1");
+
+    expect(result.error).not.toBeNull();
+    expect(result.error!.message).toBe(
+      "Cannot delete the last view of a database",
+    );
+  });
+
+  it("deletes a view when more than one exists", async () => {
+    mockTable("database_views", {
+      data: { database_id: "page-1" },
+      error: null,
+      count: 2,
+    });
+
+    const result = await deleteView("view-1");
+
+    expect(result.error).toBeNull();
+    expect(tableMocks["database_views"].calls["delete"]).toBeDefined();
+  });
+
+  it("captures error when lookup fails", async () => {
+    const dbError = new Error("not found");
+    mockTable("database_views", { data: null, error: dbError });
+
+    const result = await deleteView("view-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.deleteView:lookup",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorderViews
+// ---------------------------------------------------------------------------
+
+describe("reorderViews", () => {
+  it("updates position for each view in order", async () => {
+    mockTable("database_views", { data: null, error: null });
+
+    const result = await reorderViews("page-1", ["view-b", "view-a"]);
+
+    expect(result.error).toBeNull();
+    expect(tableMocks["database_views"].calls["update"]).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadDatabase
+// ---------------------------------------------------------------------------
+
+describe("loadDatabase", () => {
+  it("loads properties, views, and rows with values in parallel", async () => {
+    const props = [FAKE_PROPERTY];
+    const views = [FAKE_VIEW];
+    const rowPages = [
+      {
+        id: "row-1",
+        title: "Row 1",
+        icon: null,
+        cover_url: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+        created_by: "user-1",
+      },
+    ];
+    const fakeValues = [
+      {
+        id: "val-1",
+        row_id: "row-1",
+        property_id: "prop-1",
+        value: { text: "Hello" },
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+    ];
+
+    mockTable("database_properties", { data: props, error: null });
+    mockTable("database_views", { data: views, error: null });
+    mockTable("pages", { data: rowPages, error: null });
+    mockTable("row_values", { data: fakeValues, error: null });
+
+    const result = await loadDatabase("page-1");
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+    expect(result.data!.properties).toHaveLength(1);
+    expect(result.data!.views).toHaveLength(1);
+    expect(result.data!.rows).toHaveLength(1);
+    expect(result.data!.rows[0].values["prop-1"].value).toEqual({
+      text: "Hello",
+    });
+  });
+
+  it("returns empty rows array when database has no rows", async () => {
+    mockTable("database_properties", {
+      data: [FAKE_PROPERTY],
+      error: null,
+    });
+    mockTable("database_views", { data: [FAKE_VIEW], error: null });
+    mockTable("pages", { data: [], error: null });
+    mockTable("row_values", { data: [], error: null });
+
+    const result = await loadDatabase("page-1");
+
+    expect(result.error).toBeNull();
+    expect(result.data!.rows).toHaveLength(0);
+  });
+
+  it("returns error when properties query fails", async () => {
+    const dbError = new Error("properties failed");
+    mockTable("database_properties", { data: null, error: dbError });
+    mockTable("database_views", { data: [], error: null });
+    mockTable("pages", { data: [], error: null });
+
+    const result = await loadDatabase("page-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.load:properties",
+    );
+  });
+
+  it("returns error when views query fails", async () => {
+    const dbError = new Error("views failed");
+    mockTable("database_properties", {
+      data: [FAKE_PROPERTY],
+      error: null,
+    });
+    mockTable("database_views", { data: null, error: dbError });
+    mockTable("pages", { data: [], error: null });
+
+    const result = await loadDatabase("page-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.load:views",
+    );
+  });
+
+  it("returns error when rows query fails", async () => {
+    const dbError = new Error("rows failed");
+    mockTable("database_properties", {
+      data: [FAKE_PROPERTY],
+      error: null,
+    });
+    mockTable("database_views", { data: [FAKE_VIEW], error: null });
+    mockTable("pages", { data: null, error: dbError });
+
+    const result = await loadDatabase("page-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.load:rows",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadRow
+// ---------------------------------------------------------------------------
+
+describe("loadRow", () => {
+  it("loads a row page with its values keyed by property_id", async () => {
+    const rowPage = {
+      id: "row-1",
+      title: "Row 1",
+      icon: null,
+      cover_url: null,
+      created_at: "2026-01-01",
+      updated_at: "2026-01-01",
+      created_by: "user-1",
+    };
+    const fakeValues = [
+      {
+        id: "val-1",
+        row_id: "row-1",
+        property_id: "prop-1",
+        value: { text: "A" },
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+      {
+        id: "val-2",
+        row_id: "row-1",
+        property_id: "prop-2",
+        value: { number: 42 },
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+    ];
+
+    mockTable("pages", { data: rowPage, error: null });
+    mockTable("row_values", { data: fakeValues, error: null });
+
+    const result = await loadRow("row-1");
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+    expect(result.data!.page.id).toBe("row-1");
+    expect(result.data!.values["prop-1"].value).toEqual({ text: "A" });
+    expect(result.data!.values["prop-2"].value).toEqual({ number: 42 });
+  });
+
+  it("returns error when page lookup fails", async () => {
+    const dbError = new Error("not found");
+    mockTable("pages", { data: null, error: dbError });
+    mockTable("row_values", { data: [], error: null });
+
+    const result = await loadRow("row-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.loadRow:page",
+    );
+  });
+
+  it("returns error when values query fails", async () => {
+    const dbError = new Error("values failed");
+    mockTable("pages", {
+      data: {
+        id: "row-1",
+        title: "",
+        icon: null,
+        cover_url: null,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+        created_by: "user-1",
+      },
+      error: null,
+    });
+    mockTable("row_values", { data: null, error: dbError });
+
+    const result = await loadRow("row-1");
+
+    expect(result.error).toBe(dbError);
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database.loadRow:values",
+    );
+  });
+});

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,0 +1,650 @@
+// Database CRUD operations for database pages, properties, rows, views.
+// Uses the browser Supabase client for client-side mutations.
+
+import { createClient } from "@/lib/supabase/client";
+import { captureSupabaseError } from "@/lib/sentry";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  DatabaseView,
+  DatabaseViewConfig,
+  DatabaseViewType,
+  Page,
+  PropertyType,
+  RowValue,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getClient() {
+  return createClient();
+}
+
+/**
+ * Get the next position value for an ordered table.
+ * Queries the max position for the given parent and returns max + 1.
+ */
+async function nextPosition(
+  table: "database_properties" | "database_views",
+  parentColumn: "database_id",
+  parentId: string,
+): Promise<number> {
+  const supabase = getClient();
+  const { data } = await supabase
+    .from(table)
+    .select("position")
+    .eq(parentColumn, parentId)
+    .order("position", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return data ? data.position + 1 : 0;
+}
+
+/**
+ * Get the next position for a child page (row) within a database.
+ */
+async function nextPagePosition(parentId: string): Promise<number> {
+  const supabase = getClient();
+  const { data } = await supabase
+    .from("pages")
+    .select("position")
+    .eq("parent_id", parentId)
+    .is("deleted_at", null)
+    .order("position", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return data ? data.position + 1 : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Database CRUD
+// ---------------------------------------------------------------------------
+
+export interface CreateDatabaseResult {
+  page: Page;
+  property: DatabaseProperty;
+  view: DatabaseView;
+}
+
+/**
+ * Create a database page with a default "Title" property and "Default view" table view.
+ * If any step fails, the created page is cleaned up.
+ */
+export async function createDatabase(
+  workspaceId: string,
+  userId: string,
+  title?: string,
+): Promise<{ data: CreateDatabaseResult | null; error: Error | null }> {
+  const supabase = getClient();
+
+  // 1. Create the database page
+  const { data: page, error: pageError } = await supabase
+    .from("pages")
+    .insert({
+      workspace_id: workspaceId,
+      title: title ?? "Untitled Database",
+      is_database: true,
+      position: 0,
+      created_by: userId,
+    })
+    .select()
+    .single();
+
+  if (pageError) {
+    captureSupabaseError(pageError, "database.create:page");
+    return { data: null, error: pageError };
+  }
+
+  // 2. Create default "Title" text property
+  const { data: property, error: propError } = await supabase
+    .from("database_properties")
+    .insert({
+      database_id: page.id,
+      name: "Title",
+      type: "text",
+      config: {},
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (propError) {
+    captureSupabaseError(propError, "database.create:property");
+    // Clean up the page
+    await supabase.from("pages").delete().eq("id", page.id);
+    return { data: null, error: propError };
+  }
+
+  // 3. Create default table view
+  const { data: view, error: viewError } = await supabase
+    .from("database_views")
+    .insert({
+      database_id: page.id,
+      name: "Default view",
+      type: "table",
+      config: {},
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (viewError) {
+    captureSupabaseError(viewError, "database.create:view");
+    // Clean up the page (cascades to property)
+    await supabase.from("pages").delete().eq("id", page.id);
+    return { data: null, error: viewError };
+  }
+
+  return {
+    data: {
+      page: page as Page,
+      property: property as DatabaseProperty,
+      view: view as DatabaseView,
+    },
+    error: null,
+  };
+}
+
+/**
+ * Soft-delete a database page. Cascading FK constraints handle
+ * properties, views, and row values when the page is eventually purged.
+ */
+export async function deleteDatabase(
+  pageId: string,
+): Promise<{ error: Error | null }> {
+  const supabase = getClient();
+  const { error } = await supabase
+    .from("pages")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", pageId)
+    .eq("is_database", true);
+
+  if (error) {
+    captureSupabaseError(error, "database.delete");
+  }
+  return { error };
+}
+
+// ---------------------------------------------------------------------------
+// Property CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a new property (column) to a database.
+ */
+export async function addProperty(
+  databaseId: string,
+  name: string,
+  type: PropertyType,
+  config?: Record<string, unknown>,
+): Promise<{ data: DatabaseProperty | null; error: Error | null }> {
+  const supabase = getClient();
+  const position = await nextPosition(
+    "database_properties",
+    "database_id",
+    databaseId,
+  );
+
+  const { data, error } = await supabase
+    .from("database_properties")
+    .insert({
+      database_id: databaseId,
+      name,
+      type,
+      config: config ?? {},
+      position,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    captureSupabaseError(error, "database.addProperty");
+    return { data: null, error };
+  }
+  return { data: data as DatabaseProperty, error: null };
+}
+
+/**
+ * Update a property: rename, change type, or update config.
+ */
+export async function updateProperty(
+  propertyId: string,
+  updates: Partial<Pick<DatabaseProperty, "name" | "type" | "config">>,
+): Promise<{ data: DatabaseProperty | null; error: Error | null }> {
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from("database_properties")
+    .update(updates)
+    .eq("id", propertyId)
+    .select()
+    .single();
+
+  if (error) {
+    captureSupabaseError(error, "database.updateProperty");
+    return { data: null, error };
+  }
+  return { data: data as DatabaseProperty, error: null };
+}
+
+/**
+ * Delete a property. Cascades to row_values for that property via FK.
+ */
+export async function deleteProperty(
+  propertyId: string,
+): Promise<{ error: Error | null }> {
+  const supabase = getClient();
+  const { error } = await supabase
+    .from("database_properties")
+    .delete()
+    .eq("id", propertyId);
+
+  if (error) {
+    captureSupabaseError(error, "database.deleteProperty");
+  }
+  return { error };
+}
+
+/**
+ * Reorder properties by updating their position values.
+ * `orderedIds` is the desired order — index becomes the new position.
+ */
+export async function reorderProperties(
+  databaseId: string,
+  orderedIds: string[],
+): Promise<{ error: Error | null }> {
+  const supabase = getClient();
+
+  // Update each property's position in sequence.
+  // Supabase JS doesn't support batch updates with different values per row,
+  // so we issue individual updates. The number of properties per database
+  // is small (typically < 20), so this is acceptable.
+  for (let i = 0; i < orderedIds.length; i++) {
+    const { error } = await supabase
+      .from("database_properties")
+      .update({ position: i })
+      .eq("id", orderedIds[i])
+      .eq("database_id", databaseId);
+
+    if (error) {
+      captureSupabaseError(error, "database.reorderProperties");
+      return { error };
+    }
+  }
+
+  return { error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Row CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a row to a database. Creates a child page and optionally sets initial values.
+ * `initialValues` maps property_id → value jsonb.
+ */
+export async function addRow(
+  databaseId: string,
+  userId: string,
+  initialValues?: Record<string, Record<string, unknown>>,
+): Promise<{ data: Page | null; error: Error | null }> {
+  const supabase = getClient();
+
+  // Look up the workspace_id from the database page
+  const { data: dbPage, error: dbError } = await supabase
+    .from("pages")
+    .select("workspace_id")
+    .eq("id", databaseId)
+    .single();
+
+  if (dbError) {
+    captureSupabaseError(dbError, "database.addRow:lookup");
+    return { data: null, error: dbError };
+  }
+
+  const position = await nextPagePosition(databaseId);
+
+  const { data: rowPage, error: rowError } = await supabase
+    .from("pages")
+    .insert({
+      workspace_id: dbPage.workspace_id,
+      parent_id: databaseId,
+      title: "",
+      is_database: false,
+      position,
+      created_by: userId,
+    })
+    .select()
+    .single();
+
+  if (rowError) {
+    captureSupabaseError(rowError, "database.addRow:page");
+    return { data: null, error: rowError };
+  }
+
+  // Insert initial values if provided
+  if (initialValues && Object.keys(initialValues).length > 0) {
+    const rows = Object.entries(initialValues).map(
+      ([propertyId, value]) => ({
+        row_id: rowPage.id,
+        property_id: propertyId,
+        value,
+      }),
+    );
+
+    const { error: valError } = await supabase
+      .from("row_values")
+      .insert(rows);
+
+    if (valError) {
+      captureSupabaseError(valError, "database.addRow:values");
+      // Row page was created but values failed — don't roll back the page,
+      // the user can still edit values later.
+    }
+  }
+
+  return { data: rowPage as Page, error: null };
+}
+
+/**
+ * Upsert a cell value for a row + property combination.
+ */
+export async function updateRowValue(
+  rowId: string,
+  propertyId: string,
+  value: Record<string, unknown>,
+): Promise<{ data: RowValue | null; error: Error | null }> {
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from("row_values")
+    .upsert(
+      { row_id: rowId, property_id: propertyId, value },
+      { onConflict: "row_id,property_id" },
+    )
+    .select()
+    .single();
+
+  if (error) {
+    captureSupabaseError(error, "database.updateRowValue");
+    return { data: null, error };
+  }
+  return { data: data as RowValue, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// View CRUD
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a new view to a database.
+ */
+export async function addView(
+  databaseId: string,
+  name: string,
+  type: DatabaseViewType,
+  config?: DatabaseViewConfig,
+): Promise<{ data: DatabaseView | null; error: Error | null }> {
+  const supabase = getClient();
+  const position = await nextPosition(
+    "database_views",
+    "database_id",
+    databaseId,
+  );
+
+  const { data, error } = await supabase
+    .from("database_views")
+    .insert({
+      database_id: databaseId,
+      name,
+      type,
+      config: config ?? {},
+      position,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    captureSupabaseError(error, "database.addView");
+    return { data: null, error };
+  }
+  return { data: data as DatabaseView, error: null };
+}
+
+/**
+ * Update a view's name or config.
+ */
+export async function updateView(
+  viewId: string,
+  updates: Partial<Pick<DatabaseView, "name" | "type" | "config">>,
+): Promise<{ data: DatabaseView | null; error: Error | null }> {
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from("database_views")
+    .update(updates)
+    .eq("id", viewId)
+    .select()
+    .single();
+
+  if (error) {
+    captureSupabaseError(error, "database.updateView");
+    return { data: null, error };
+  }
+  return { data: data as DatabaseView, error: null };
+}
+
+/**
+ * Delete a view. Rejects if it's the last view for the database.
+ */
+export async function deleteView(
+  viewId: string,
+): Promise<{ error: Error | null }> {
+  const supabase = getClient();
+
+  // Look up the database_id to check view count
+  const { data: view, error: lookupError } = await supabase
+    .from("database_views")
+    .select("database_id")
+    .eq("id", viewId)
+    .single();
+
+  if (lookupError) {
+    captureSupabaseError(lookupError, "database.deleteView:lookup");
+    return { error: lookupError };
+  }
+
+  // Count views for this database
+  const { count, error: countError } = await supabase
+    .from("database_views")
+    .select("id", { count: "exact", head: true })
+    .eq("database_id", view.database_id);
+
+  if (countError) {
+    captureSupabaseError(countError, "database.deleteView:count");
+    return { error: countError };
+  }
+
+  if (count !== null && count <= 1) {
+    const err = new Error("Cannot delete the last view of a database");
+    return { error: err };
+  }
+
+  const { error } = await supabase
+    .from("database_views")
+    .delete()
+    .eq("id", viewId);
+
+  if (error) {
+    captureSupabaseError(error, "database.deleteView");
+  }
+  return { error };
+}
+
+/**
+ * Reorder views by updating their position values.
+ */
+export async function reorderViews(
+  databaseId: string,
+  orderedIds: string[],
+): Promise<{ error: Error | null }> {
+  const supabase = getClient();
+
+  for (let i = 0; i < orderedIds.length; i++) {
+    const { error } = await supabase
+      .from("database_views")
+      .update({ position: i })
+      .eq("id", orderedIds[i])
+      .eq("database_id", databaseId);
+
+    if (error) {
+      captureSupabaseError(error, "database.reorderViews");
+      return { error };
+    }
+  }
+
+  return { error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Data Loading
+// ---------------------------------------------------------------------------
+
+export interface LoadDatabaseResult {
+  properties: DatabaseProperty[];
+  views: DatabaseView[];
+  rows: DatabaseRow[];
+}
+
+/**
+ * Load a database: properties, views, and rows with their values in parallel.
+ */
+export async function loadDatabase(
+  databaseId: string,
+): Promise<{ data: LoadDatabaseResult | null; error: Error | null }> {
+  const supabase = getClient();
+
+  const [propertiesResult, viewsResult, rowsResult] = await Promise.all([
+    supabase
+      .from("database_properties")
+      .select("*")
+      .eq("database_id", databaseId)
+      .order("position"),
+    supabase
+      .from("database_views")
+      .select("*")
+      .eq("database_id", databaseId)
+      .order("position"),
+    supabase
+      .from("pages")
+      .select("id, title, icon, cover_url, created_at, updated_at, created_by")
+      .eq("parent_id", databaseId)
+      .is("deleted_at", null)
+      .order("position"),
+  ]);
+
+  if (propertiesResult.error) {
+    captureSupabaseError(propertiesResult.error, "database.load:properties");
+    return { data: null, error: propertiesResult.error };
+  }
+  if (viewsResult.error) {
+    captureSupabaseError(viewsResult.error, "database.load:views");
+    return { data: null, error: viewsResult.error };
+  }
+  if (rowsResult.error) {
+    captureSupabaseError(rowsResult.error, "database.load:rows");
+    return { data: null, error: rowsResult.error };
+  }
+
+  const properties = propertiesResult.data as DatabaseProperty[];
+  const views = viewsResult.data as DatabaseView[];
+  const rowPages = rowsResult.data as Pick<
+    Page,
+    "id" | "title" | "icon" | "cover_url" | "created_at" | "updated_at" | "created_by"
+  >[];
+
+  // Load all row values for these rows in a single query
+  const rowIds = rowPages.map((r) => r.id);
+  let allValues: RowValue[] = [];
+
+  if (rowIds.length > 0) {
+    const { data: valuesData, error: valuesError } = await supabase
+      .from("row_values")
+      .select("*")
+      .in("row_id", rowIds);
+
+    if (valuesError) {
+      captureSupabaseError(valuesError, "database.load:values");
+      return { data: null, error: valuesError };
+    }
+    allValues = valuesData as RowValue[];
+  }
+
+  // Group values by row_id, keyed by property_id
+  const valuesByRow = new Map<string, Record<string, RowValue>>();
+  for (const val of allValues) {
+    let rowMap = valuesByRow.get(val.row_id);
+    if (!rowMap) {
+      rowMap = {};
+      valuesByRow.set(val.row_id, rowMap);
+    }
+    rowMap[val.property_id] = val;
+  }
+
+  const rows: DatabaseRow[] = rowPages.map((page) => ({
+    page,
+    values: valuesByRow.get(page.id) ?? {},
+  }));
+
+  return {
+    data: { properties, views, rows },
+    error: null,
+  };
+}
+
+/**
+ * Load a single row with all its values, joined with property type info.
+ */
+export async function loadRow(
+  rowId: string,
+): Promise<{ data: DatabaseRow | null; error: Error | null }> {
+  const supabase = getClient();
+
+  const [pageResult, valuesResult] = await Promise.all([
+    supabase
+      .from("pages")
+      .select("id, title, icon, cover_url, created_at, updated_at, created_by")
+      .eq("id", rowId)
+      .single(),
+    supabase
+      .from("row_values")
+      .select("*")
+      .eq("row_id", rowId),
+  ]);
+
+  if (pageResult.error) {
+    captureSupabaseError(pageResult.error, "database.loadRow:page");
+    return { data: null, error: pageResult.error };
+  }
+  if (valuesResult.error) {
+    captureSupabaseError(valuesResult.error, "database.loadRow:values");
+    return { data: null, error: valuesResult.error };
+  }
+
+  const values: Record<string, RowValue> = {};
+  for (const val of valuesResult.data as RowValue[]) {
+    values[val.property_id] = val;
+  }
+
+  return {
+    data: {
+      page: pageResult.data as Pick<
+        Page,
+        "id" | "title" | "icon" | "cover_url" | "created_at" | "updated_at" | "created_by"
+      >,
+      values,
+    },
+    error: null,
+  };
+}


### PR DESCRIPTION
Closes #432

## What

Implements the Supabase query layer for all database CRUD operations in `src/lib/database.ts`. This is the data access layer that all database UI components will use.

## Functions

| Function | Purpose |
|---|---|
| `createDatabase` | Creates page (`is_database=true`) + default "Title" text property + default table view. Cleans up on partial failure. |
| `deleteDatabase` | Soft-deletes the database page via `deleted_at`. FK cascades handle cleanup on purge. |
| `addProperty` | Inserts a new column with auto-calculated position. |
| `updateProperty` | Renames, changes type, or updates config. |
| `deleteProperty` | Removes column (FK cascades to row_values). |
| `reorderProperties` | Updates position values from an ordered ID array. |
| `addRow` | Creates a child page + optional initial row_values. Looks up workspace_id automatically. |
| `updateRowValue` | Upserts a cell value on the `(row_id, property_id)` unique constraint. |
| `addView` | Creates a new view with auto-calculated position. |
| `updateView` | Updates view name, type, or config. |
| `deleteView` | Removes a view. Rejects if it's the last view for the database. |
| `reorderViews` | Updates position values from an ordered ID array. |
| `loadDatabase` | Fetches properties, views, and rows with values in parallel via `Promise.all`. Groups values by row_id client-side. |
| `loadRow` | Fetches a single row page with all its values keyed by property_id. |

## How

- All functions use the browser Supabase client and return `{ data, error }` tuples.
- Every error path calls `captureSupabaseError` for Sentry reporting.
- RLS enforcement is handled by the existing policies from #431.
- No new dependencies added.

## Testing

- 35 unit tests covering all functions, success paths, error paths, and edge cases (last-view deletion rejection, cleanup on partial failure).
- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — clean
- `pnpm test` — 543/543 passing

## Knowledge base updates

- `.agents/architecture.md` — added `database.ts` to the component map.
- `.agents/conventions.md` — added "Database CRUD Layer" section documenting the pattern.