### PR TITLE
fix: skip captureSupabaseError for client-side RLS violations in page-tree (#455)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1187,6 +1187,33 @@ and finally checks the message for the RLS violation pattern. This ensures
 custom RPC messages like "Not a member of this workspace" are correctly
 identified as authorization errors in catch blocks.
 
+### Client-side RLS skip pattern
+
+The same `isInsufficientPrivilegeError` guard applies to client-side code
+(`"use client"` components), not just API routes. When a Supabase mutation
+returns an RLS violation (e.g. workspace page limits, membership checks),
+skip `captureSupabaseError` — the user already sees a toast error:
+
+```typescript
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
+
+const { data, error } = await supabase.from("pages").insert({ ... }).select().single();
+if (error) {
+  if (!isSchemaNotFoundError(error) && !isInsufficientPrivilegeError(error)) {
+    captureSupabaseError(error, "page-tree:create-page");
+  }
+  toast.error("Failed to create page", { duration: 8000 });
+  return;
+}
+```
+
+Always guard both `isSchemaNotFoundError` and `isInsufficientPrivilegeError`
+before calling `captureSupabaseError` in client-side error handlers.
+
 ## Usage Event Tracking
 
 Product analytics events are recorded via two modules — `src/lib/track-event-server.ts`

--- a/src/components/sidebar/page-tree-rls-guard.test.ts
+++ b/src/components/sidebar/page-tree-rls-guard.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for issue #455: captureSupabaseError calls for
+ * page-tree:create-page and page-tree:add-favorite must be guarded by
+ * isInsufficientPrivilegeError to prevent RLS violations (PostgreSQL 42501)
+ * from flooding Sentry with warnings.
+ *
+ * These operations trigger RLS violations when users hit workspace page
+ * limits (e.g. E2E test workspaces). The user already sees a toast error,
+ * so Sentry reporting is noise.
+ */
+
+const GUARDED_OPERATIONS = [
+  "page-tree:create-page",
+  "page-tree:add-favorite",
+];
+
+describe("page-tree RLS error guard", () => {
+  const filePath = join(__dirname, "page-tree.tsx");
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+
+  it("imports isInsufficientPrivilegeError from @/lib/sentry", () => {
+    expect(content).toMatch(
+      /import\s*\{[^}]*isInsufficientPrivilegeError[^}]*\}\s*from\s*["']@\/lib\/sentry["']/,
+    );
+  });
+
+  for (const op of GUARDED_OPERATIONS) {
+    it(`${op} is guarded by isInsufficientPrivilegeError`, () => {
+      const lineIndex = lines.findIndex(
+        (l) =>
+          l.includes("captureSupabaseError(") && l.includes(`"${op}"`),
+      );
+
+      // The operation must exist in the file (or was removed — skip)
+      if (lineIndex === -1) return;
+
+      const context = lines
+        .slice(Math.max(0, lineIndex - 5), lineIndex + 1)
+        .join("\n");
+
+      expect(
+        context,
+        `captureSupabaseError for "${op}" at line ${lineIndex + 1} must be guarded by isInsufficientPrivilegeError`,
+      ).toContain("isInsufficientPrivilegeError");
+    });
+  }
+});

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -15,7 +15,11 @@ import {
 } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError, isSchemaNotFoundError } from "@/lib/sentry";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
 import { trackEventClient } from "@/lib/track-event";
 import { retryOnNetworkError } from "@/lib/retry";
 import { usePersistedExpanded } from "@/lib/use-persisted-expanded";
@@ -242,7 +246,10 @@ export function PageTree({ userId }: PageTreeProps) {
           .single();
 
         if (error) {
-          if (!isSchemaNotFoundError(error)) {
+          if (
+            !isSchemaNotFoundError(error) &&
+            !isInsufficientPrivilegeError(error)
+          ) {
             captureSupabaseError(error, "page-tree:add-favorite");
           }
           toast.error("Failed to add favorite", { duration: 8000 });
@@ -296,7 +303,12 @@ export function PageTree({ userId }: PageTreeProps) {
         .single();
 
       if (error) {
-        captureSupabaseError(error, "page-tree:create-page");
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
+          captureSupabaseError(error, "page-tree:create-page");
+        }
         toast.error("Failed to create page", { duration: 8000 });
         return;
       }


### PR DESCRIPTION
Closes #455

## What

`page-tree:create-page` and `page-tree:add-favorite` operations in `page-tree.tsx` were reporting RLS violations (PostgreSQL 42501) to Sentry via `captureSupabaseError`, generating 1835+ events from E2E test workspaces hitting workspace page limits. These are expected authorization rejections — the user already sees a toast error, so Sentry reporting is noise.

## How

Added `isInsufficientPrivilegeError` guards before `captureSupabaseError` calls for both operations, matching the existing pattern used in API routes. Updated the import to include `isInsufficientPrivilegeError` alongside the already-imported `isSchemaNotFoundError`. Also extended `.agents/conventions.md` with a "Client-side RLS skip pattern" subsection documenting this guard for client-side code.

## Testing

- Added `page-tree-rls-guard.test.ts` — a static analysis regression test that verifies `captureSupabaseError` calls for `page-tree:create-page` and `page-tree:add-favorite` are guarded by `isInsufficientPrivilegeError`.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (555 tests, 0 failures).