### PR TITLE
fix: skip captureSupabaseError for client-side RLS violations (#455)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1187,6 +1187,35 @@ and finally checks the message for the RLS violation pattern. This ensures
 custom RPC messages like "Not a member of this workspace" are correctly
 identified as authorization errors in catch blocks.
 
+### Client-side RLS skip pattern
+
+Client-side Supabase operations (e.g. sidebar page-tree inserts) can also hit
+RLS violations — typically when a user exceeds workspace limits. The user already
+sees a toast error, so reporting to Sentry is pure noise. Skip
+`captureSupabaseError` for both `isSchemaNotFoundError` and
+`isInsufficientPrivilegeError`:
+
+```typescript
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
+
+const { data, error } = await supabase.from("table").insert({ ... }).select().single();
+if (error) {
+  if (!isSchemaNotFoundError(error) && !isInsufficientPrivilegeError(error)) {
+    captureSupabaseError(error, "feature:operation");
+  }
+  toast.error("Failed to do thing", { duration: 8000 });
+  return;
+}
+```
+
+This applies to any client-side mutation where the RLS rejection is an expected
+authorization boundary (workspace limits, non-member access) and the user is
+already notified via toast.
+
 ## Usage Event Tracking
 
 Product analytics events are recorded via two modules — `src/lib/track-event-server.ts`

--- a/src/components/sidebar/favorites-section.tsx
+++ b/src/components/sidebar/favorites-section.tsx
@@ -5,7 +5,11 @@ import { useParams, useRouter } from "next/navigation";
 import { FileText, StarOff } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError, isSchemaNotFoundError } from "@/lib/sentry";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import type { FavoriteWithPage } from "@/lib/types";
 
@@ -81,8 +85,9 @@ export function FavoritesSection({ userId }: FavoritesSectionProps) {
       if (cancelled) return;
 
       if (error) {
-        // Table missing (migration not applied yet) — degrade gracefully
-        if (isSchemaNotFoundError(error)) return;
+        // Table missing or RLS rejection — degrade gracefully
+        if (isSchemaNotFoundError(error) || isInsufficientPrivilegeError(error))
+          return;
         captureSupabaseError(error, "favorites:fetch");
         return;
       }
@@ -111,7 +116,10 @@ export function FavoritesSection({ userId }: FavoritesSectionProps) {
         .eq("id", favoriteId);
 
       if (error) {
-        if (!isSchemaNotFoundError(error)) {
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
           captureSupabaseError(error, "favorites:remove");
         }
         toast.error("Failed to remove favorite", { duration: 8000 });
@@ -216,7 +224,10 @@ export function useFavorite({
       if (cancelled) return;
 
       if (error) {
-        if (!isSchemaNotFoundError(error)) {
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
           captureSupabaseError(error, "favorites:check");
         }
       }
@@ -244,7 +255,10 @@ export function useFavorite({
         .eq("id", favoriteId);
 
       if (error) {
-        if (!isSchemaNotFoundError(error)) {
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
           captureSupabaseError(error, "favorites:toggle-remove");
         }
         toast.error("Failed to remove favorite", { duration: 8000 });
@@ -266,7 +280,10 @@ export function useFavorite({
         .single();
 
       if (error) {
-        if (!isSchemaNotFoundError(error)) {
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
           captureSupabaseError(error, "favorites:toggle-add");
         }
         toast.error("Failed to add favorite", { duration: 8000 });

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -15,7 +15,11 @@ import {
 } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError, isSchemaNotFoundError } from "@/lib/sentry";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
 import { trackEventClient } from "@/lib/track-event";
 import { retryOnNetworkError } from "@/lib/retry";
 import { usePersistedExpanded } from "@/lib/use-persisted-expanded";
@@ -242,7 +246,10 @@ export function PageTree({ userId }: PageTreeProps) {
           .single();
 
         if (error) {
-          if (!isSchemaNotFoundError(error)) {
+          if (
+            !isSchemaNotFoundError(error) &&
+            !isInsufficientPrivilegeError(error)
+          ) {
             captureSupabaseError(error, "page-tree:add-favorite");
           }
           toast.error("Failed to add favorite", { duration: 8000 });
@@ -296,7 +303,12 @@ export function PageTree({ userId }: PageTreeProps) {
         .single();
 
       if (error) {
-        captureSupabaseError(error, "page-tree:create-page");
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
+          captureSupabaseError(error, "page-tree:create-page");
+        }
         toast.error("Failed to create page", { duration: 8000 });
         return;
       }

--- a/src/components/sidebar/trash-section.tsx
+++ b/src/components/sidebar/trash-section.tsx
@@ -5,7 +5,11 @@ import { useParams, useRouter } from "next/navigation";
 import { FileText, RotateCcw, Trash2, X } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError } from "@/lib/sentry";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import { Button } from "@/components/ui/button";
 import {
@@ -66,7 +70,12 @@ export function TrashSection() {
     }).then(({ data, error }) => {
       if (cancelled) return;
       if (error) {
-        captureSupabaseError(error, "trash:workspace-lookup");
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
+          captureSupabaseError(error, "trash:workspace-lookup");
+        }
         return;
       }
       if (data) setWorkspaceId(data.id);
@@ -97,7 +106,12 @@ export function TrashSection() {
       if (cancelled) return;
 
       if (error) {
-        captureSupabaseError(error, "trash:fetch");
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
+          captureSupabaseError(error, "trash:fetch");
+        }
         return;
       }
 
@@ -125,7 +139,12 @@ export function TrashSection() {
       });
 
       if (error) {
-        captureSupabaseError(error, "trash:restore");
+        if (
+          !isSchemaNotFoundError(error) &&
+          !isInsufficientPrivilegeError(error)
+        ) {
+          captureSupabaseError(error, "trash:restore");
+        }
         toast.error("Failed to restore page", { duration: 8000 });
       } else {
         setTrashedPages((prev) => prev.filter((p) => p.id !== page.id));
@@ -149,7 +168,12 @@ export function TrashSection() {
       .eq("id", permanentDeleteTarget.id);
 
     if (error) {
-      captureSupabaseError(error, "trash:permanent-delete");
+      if (
+        !isSchemaNotFoundError(error) &&
+        !isInsufficientPrivilegeError(error)
+      ) {
+        captureSupabaseError(error, "trash:permanent-delete");
+      }
       toast.error("Failed to permanently delete page", { duration: 8000 });
     } else {
       setTrashedPages((prev) =>
@@ -172,7 +196,12 @@ export function TrashSection() {
     });
 
     if (error) {
-      captureSupabaseError(error, "trash:empty");
+      if (
+        !isSchemaNotFoundError(error) &&
+        !isInsufficientPrivilegeError(error)
+      ) {
+        captureSupabaseError(error, "trash:empty");
+      }
       toast.error("Failed to empty trash", { duration: 8000 });
     } else {
       setTrashedPages([]);

--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -5,7 +5,11 @@ import { useRouter } from "next/navigation";
 import { FileText, Plus, Search } from "lucide-react";
 import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError } from "@/lib/sentry";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
 import { trackEventClient } from "@/lib/track-event";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -115,7 +119,12 @@ export function WorkspaceHome({
       .single();
 
     if (error) {
-      captureSupabaseError(error, "workspace-home:create-page");
+      if (
+        !isSchemaNotFoundError(error) &&
+        !isInsufficientPrivilegeError(error)
+      ) {
+        captureSupabaseError(error, "workspace-home:create-page");
+      }
       toast.error("Failed to create page", { duration: 8000 });
       return;
     }

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -173,4 +173,54 @@ describe("error handling conventions", () => {
         `Use captureSupabaseError() to report to Sentry and show a generic message instead:\n${violations.join("\n")}`,
     ).toEqual([]);
   });
+
+  it("client components with Supabase mutations guard RLS violations before captureSupabaseError", () => {
+    /**
+     * Client-side Supabase mutations (insert/update/delete) can hit RLS
+     * violations (42501) that are expected authorization boundaries (workspace
+     * limits, non-member access). Files performing these mutations must import
+     * isInsufficientPrivilegeError to skip Sentry reporting for expected
+     * rejections. See .agents/conventions.md "Client-side RLS skip pattern".
+     *
+     * Files that only do reads, auth operations, or storage uploads are
+     * allowlisted — they won't encounter RLS 42501 violations.
+     */
+    const RLS_GUARD_ALLOWLIST = new Set([
+      "src/components/auth/oauth-buttons.tsx", // auth sign-in, not a table mutation
+      "src/components/delete-account-section.tsx", // account deletion via RPC
+      "src/components/editor/image-plugin.tsx", // storage upload, not table RLS
+      "src/components/members/invite-accept.tsx", // RPC call, returns app-level error
+      "src/components/members/invite-form.tsx", // insert into invites, admin-only
+      "src/components/members/members-page.tsx", // admin-only member management
+      "src/components/page-cover.tsx", // storage upload + page update
+      "src/components/page-icon.tsx", // page update (owner-only)
+      "src/components/page-menu.tsx", // page duplication (owner-only)
+      "src/components/page-title.tsx", // page update (owner-only)
+      "src/components/sidebar/create-workspace-dialog.tsx", // RPC workspace creation
+      "src/components/sidebar/page-search.tsx", // read-only search
+      "src/components/workspace-settings-form.tsx", // admin-only workspace settings
+    ]);
+
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const rel = toRelative(file);
+      if (rel.includes("src/app/api/")) continue;
+      if (RLS_GUARD_ALLOWLIST.has(rel)) continue;
+
+      const content = readFileSync(file, "utf-8");
+      if (!content.startsWith('"use client"')) continue;
+      if (!content.includes("captureSupabaseError")) continue;
+
+      if (!content.includes("isInsufficientPrivilegeError")) {
+        violations.push(rel);
+      }
+    }
+
+    expect(
+      violations,
+      `Client components calling captureSupabaseError must also import isInsufficientPrivilegeError ` +
+        `to guard against expected RLS violations. See .agents/conventions.md "Client-side RLS skip pattern":\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #455

## What

Client-side Supabase operations in the sidebar (page creation, favorites, trash) were reporting RLS 42501 violations to Sentry. These are expected authorization boundaries — workspace page limits, non-member access — and the user already sees a toast error. The Sentry events are noise, not bugs.

- [MEMO-E](https://ona-2j.sentry.io/issues/MEMO-E): 1835 events, 24 users — `page-tree:create-page` RLS on `pages` table
- [MEMO-G](https://ona-2j.sentry.io/issues/MEMO-G): 5 events, 2 users — `page-tree:add-favorite` RLS on `favorites` table

## Root cause

The convention for skipping `captureSupabaseError` on `isInsufficientPrivilegeError` was documented only for API routes. Client-side code in `page-tree.tsx` called `captureSupabaseError` without the guard. `captureSupabaseError` already downgrades 42501 to warning level, but the events still generate Sentry noise.

## Changes

- **page-tree.tsx**: Add `isInsufficientPrivilegeError` guard to `create-page` and `add-favorite`
- **favorites-section.tsx**: Add guard to all favorites CRUD operations (fetch, check, remove, toggle-add, toggle-remove)
- **trash-section.tsx**: Add guard to all trash operations (workspace-lookup, fetch, restore, permanent-delete, empty)
- **workspace-home.tsx**: Add guard to `create-page`
- **conventions.md**: Document the client-side RLS skip pattern
- **sentry.test.ts**: Static analysis test that flags client components calling `captureSupabaseError` without importing `isInsufficientPrivilegeError`

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 553 tests pass (including new convention check)