### PR TITLE
fix(editor): add search input to page link dropdown (#460)

### DIFF
--- a/e2e/page-link-search.spec.ts
+++ b/e2e/page-link-search.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "./fixtures/auth";
+import { navigateToEditorPage } from "./fixtures/editor-helpers";
+
+test.describe("Page link dropdown search", () => {
+  test.beforeEach(async ({ authenticatedPage: page }) => {
+    await navigateToEditorPage(page);
+  });
+
+  test("slash command 'Link to page' opens dropdown with search input", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+
+    // Open slash command menu
+    await editor.pressSequentially("/");
+    await page.waitForTimeout(300);
+
+    // Select "Link to page"
+    const linkOption = page.getByRole("option", { name: /link to page/i });
+    await expect(linkOption).toBeVisible({ timeout: 3_000 });
+    await linkOption.click();
+    await page.waitForTimeout(300);
+
+    // The page link dropdown should appear with a search input
+    // Use placeholder to disambiguate from the sidebar search
+    const searchInput = page.locator('input[placeholder="Search pages…"]');
+    await expect(searchInput).toBeVisible({ timeout: 3_000 });
+    await expect(searchInput).toBeFocused();
+  });
+
+  test("search input filters pages by title", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+
+    // Open slash command menu and select "Link to page"
+    await editor.pressSequentially("/");
+    await page.waitForTimeout(300);
+
+    const linkOption = page.getByRole("option", { name: /link to page/i });
+    await expect(linkOption).toBeVisible({ timeout: 3_000 });
+    await linkOption.click();
+    await page.waitForTimeout(300);
+
+    const searchInput = page.locator('input[placeholder="Search pages…"]');
+    await expect(searchInput).toBeVisible({ timeout: 3_000 });
+
+    // Type a query that is unlikely to match any page
+    await searchInput.fill("zzz_nonexistent_page_xyz");
+    await page.waitForTimeout(300);
+
+    // Should show "No pages found"
+    await expect(page.getByText("No pages found")).toBeVisible({
+      timeout: 3_000,
+    });
+  });
+
+  test("keyboard navigation works in search dropdown", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+
+    // Open slash command menu and select "Link to page"
+    await editor.pressSequentially("/");
+    await page.waitForTimeout(300);
+
+    const linkOption = page.getByRole("option", { name: /link to page/i });
+    await expect(linkOption).toBeVisible({ timeout: 3_000 });
+    await linkOption.click();
+    await page.waitForTimeout(500);
+
+    const searchInput = page.locator('input[placeholder="Search pages…"]');
+    await expect(searchInput).toBeVisible({ timeout: 3_000 });
+
+    // Wait for results to load — options are inside the page link dropdown
+    const dropdown = searchInput.locator("..").locator("..");
+    const firstOption = dropdown.getByRole("option").first();
+    await expect(firstOption).toBeVisible({ timeout: 5_000 });
+
+    // First item should be selected by default
+    await expect(firstOption).toHaveAttribute("aria-selected", "true");
+
+    // Arrow down should move selection
+    await page.keyboard.press("ArrowDown");
+    await page.waitForTimeout(100);
+
+    const optionCount = await dropdown.getByRole("option").count();
+    if (optionCount > 1) {
+      const secondOption = dropdown.getByRole("option").nth(1);
+      await expect(secondOption).toHaveAttribute("aria-selected", "true");
+      await expect(firstOption).toHaveAttribute("aria-selected", "false");
+    }
+
+    // Escape should close the dropdown
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(300);
+    await expect(searchInput).not.toBeVisible();
+  });
+
+  test("[[ trigger shows search input with typed query", async ({
+    authenticatedPage: page,
+  }) => {
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+
+    // Type [[ to trigger page link menu
+    await editor.pressSequentially("[[");
+    await page.waitForTimeout(500);
+
+    // The search input should appear
+    const searchInput = page.locator('input[placeholder="Search pages…"]');
+    await expect(searchInput).toBeVisible({ timeout: 3_000 });
+
+    // The input should show the query (empty initially since nothing typed after [[)
+    await expect(searchInput).toHaveValue("");
+  });
+});

--- a/src/components/editor/page-link-plugin.tsx
+++ b/src/components/editor/page-link-plugin.tsx
@@ -23,7 +23,7 @@ import {
   $createPageLinkNode,
   PageLinkNode,
 } from "@/components/editor/page-link-node";
-import { FileText } from "lucide-react";
+import { FileText, Search } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
 import type { JSX } from "react";
 
@@ -50,8 +50,11 @@ export function PageLinkPlugin(): JSX.Element | null {
   const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const matchStartRef = useRef<number | null>(null);
   const matchNodeKeyRef = useRef<string | null>(null);
+  // Tracks whether the menu was opened via slash command (true) or [[ trigger (false)
+  const [isSlashCommandMode, setIsSlashCommandMode] = useState(false);
 
   // Resolve workspace slug to ID
   useEffect(() => {
@@ -113,14 +116,19 @@ export function PageLinkPlugin(): JSX.Element | null {
         setQuery("");
         matchStartRef.current = null;
         matchNodeKeyRef.current = null;
+        setIsSlashCommandMode(true);
 
-        // Position the menu at the current selection
+        // Position the menu at the current selection, then focus the search input
         requestAnimationFrame(() => {
           const domSelection = window.getSelection();
           if (domSelection && domSelection.rangeCount > 0) {
             const range = domSelection.getRangeAt(0);
             setAnchorRect(range.getBoundingClientRect());
           }
+          // Focus the search input after the portal renders
+          requestAnimationFrame(() => {
+            searchInputRef.current?.focus();
+          });
         });
         return true;
       },
@@ -143,7 +151,7 @@ export function PageLinkPlugin(): JSX.Element | null {
         .select("id, title, icon")
         .eq("workspace_id", workspaceId!)
         .order("updated_at", { ascending: false })
-        .limit(8);
+        .limit(10);
 
       if (query.trim()) {
         queryBuilder = queryBuilder.ilike("title", `%${query.trim()}%`);
@@ -169,6 +177,7 @@ export function PageLinkPlugin(): JSX.Element | null {
     setResults([]);
     matchStartRef.current = null;
     matchNodeKeyRef.current = null;
+    setIsSlashCommandMode(false);
   }, []);
 
   // Insert the selected page link and clean up the [[ trigger text
@@ -245,6 +254,7 @@ export function PageLinkPlugin(): JSX.Element | null {
           if (!textAfterTrigger.includes("]]")) {
             matchStartRef.current = triggerIndex;
             matchNodeKeyRef.current = anchorNode.getKey();
+            setIsSlashCommandMode(false);
             setQuery(textAfterTrigger);
             setIsOpen(true);
 
@@ -373,51 +383,104 @@ export function PageLinkPlugin(): JSX.Element | null {
     return () => document.removeEventListener("mousedown", handleClick);
   }, [isOpen, closeMenu]);
 
+  // Handle keyboard events on the search input (slash command mode)
+  const handleSearchInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev < results.length - 1 ? prev + 1 : 0,
+          );
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev > 0 ? prev - 1 : results.length - 1,
+          );
+          break;
+        case "Enter":
+        case "Tab":
+          if (results[selectedIndex]) {
+            e.preventDefault();
+            insertFromSlashCommand(results[selectedIndex]);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          closeMenu();
+          editor.focus();
+          break;
+      }
+    },
+    [results, selectedIndex, insertFromSlashCommand, closeMenu, editor],
+  );
+
   if (!isOpen || !anchorRect) return null;
 
   return createPortal(
     <div
       ref={menuRef}
-      className="fixed z-50 max-h-[300px] w-64 overflow-y-auto rounded-sm border border-white/[0.06] bg-popover p-1 shadow-md"
+      className="fixed z-50 w-64 overflow-hidden rounded-sm border border-white/[0.06] bg-popover shadow-md"
       style={{
         top: anchorRect.bottom + 4,
         left: anchorRect.left,
       }}
     >
-      {results.length === 0 && (
-        <div className="px-2 py-3 text-center text-xs text-muted-foreground">
-          {query.trim() ? "No pages found" : "No pages in workspace"}
-        </div>
-      )}
-      {results.map((page, index) => (
-        <button
-          key={page.id}
-          className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none ${
-            selectedIndex === index
-              ? "bg-white/[0.08] text-foreground"
-              : "text-muted-foreground hover:bg-white/[0.04]"
-          }`}
-          onClick={() => {
-            if (matchStartRef.current !== null) {
-              insertPageLink(page);
-            } else {
-              insertFromSlashCommand(page);
+      <div className="flex items-center gap-2 border-b border-white/[0.06] px-2 py-1.5">
+        <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <input
+          ref={searchInputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            if (isSlashCommandMode) {
+              setQuery(e.target.value);
             }
           }}
-          onMouseEnter={() => setSelectedIndex(index)}
-          role="option"
-          aria-selected={selectedIndex === index}
-        >
-          {page.icon ? (
-            <span className="shrink-0 text-sm">{page.icon}</span>
-          ) : (
-            <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-          )}
-          <span className="truncate text-sm font-medium text-foreground">
-            {page.title || "Untitled"}
-          </span>
-        </button>
-      ))}
+          onKeyDown={handleSearchInputKeyDown}
+          placeholder="Search pages…"
+          readOnly={!isSlashCommandMode}
+          className="h-6 w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
+          aria-label="Search pages"
+        />
+      </div>
+      <div className="max-h-[260px] overflow-y-auto p-1">
+        {results.length === 0 && (
+          <div className="px-2 py-3 text-center text-xs text-muted-foreground">
+            {query.trim() ? "No pages found" : "No pages in workspace"}
+          </div>
+        )}
+        {results.map((page, index) => (
+          <button
+            key={page.id}
+            className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none ${
+              selectedIndex === index
+                ? "bg-white/[0.08] text-foreground"
+                : "text-muted-foreground hover:bg-white/[0.04]"
+            }`}
+            onClick={() => {
+              if (matchStartRef.current !== null) {
+                insertPageLink(page);
+              } else {
+                insertFromSlashCommand(page);
+              }
+            }}
+            onMouseEnter={() => setSelectedIndex(index)}
+            role="option"
+            aria-selected={selectedIndex === index}
+          >
+            {page.icon ? (
+              <span className="shrink-0 text-sm">{page.icon}</span>
+            ) : (
+              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
+            <span className="truncate text-sm font-medium text-foreground">
+              {page.title || "Untitled"}
+            </span>
+          </button>
+        ))}
+      </div>
     </div>,
     document.body,
   );


### PR DESCRIPTION
Closes #460

## What

The page link dropdown (opened via the `/` slash command → "Link to page") showed a flat list of up to 8 recently updated pages with no way to search or filter. With growing workspaces this was unusable — users had to scroll through the list to find the target page.

## How

Added a visible search input at the top of the page link dropdown. When opened via slash command, the input auto-focuses and typing filters pages by title using the existing `ilike` Supabase query. When opened via the `[[` trigger, the input displays the current query text (driven by the editor's text content listener) as a visual indicator. Keyboard navigation (arrow keys, Enter, Escape) works with the search input focused. Also increased the result limit from 8 to 10.

## Testing

Added 4 Playwright E2E tests in `e2e/page-link-search.spec.ts`:
- Slash command opens dropdown with focused search input
- Typing in search input filters pages (verifies "No pages found" for non-matching query)
- Keyboard navigation (ArrowDown moves selection, Escape closes dropdown)
- `[[` trigger shows the search input with the current query value

Run: `npx playwright test e2e/page-link-search.spec.ts`