### PR TITLE
feat(database): sort and filter engine — client-side filtering, sorting, and filter bar UI (#437)

### DIFF
--- a/src/components/database/filter-bar.stories.tsx
+++ b/src/components/database/filter-bar.stories.tsx
@@ -1,0 +1,177 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import { useState } from "react";
+import { FilterBar } from "./filter-bar";
+import type { DatabaseProperty } from "@/lib/types";
+import type { FilterRule } from "@/lib/database-filters";
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockProperties: DatabaseProperty[] = [
+  {
+    id: "prop-name",
+    database_id: "db-1",
+    name: "Name",
+    type: "text",
+    config: {},
+    position: 0,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-status",
+    database_id: "db-1",
+    name: "Status",
+    type: "select",
+    config: {},
+    position: 1,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-score",
+    database_id: "db-1",
+    name: "Score",
+    type: "number",
+    config: {},
+    position: 2,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-due",
+    database_id: "db-1",
+    name: "Due Date",
+    type: "date",
+    config: {},
+    position: 3,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-done",
+    database_id: "db-1",
+    name: "Done",
+    type: "checkbox",
+    config: {},
+    position: 4,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-url",
+    database_id: "db-1",
+    name: "Link",
+    type: "url",
+    config: {},
+    position: 5,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof FilterBar> = {
+  title: "Database/FilterBar",
+  component: FilterBar,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-3xl bg-background p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    properties: mockProperties,
+    onFiltersChange: fn(),
+  },
+};
+
+export { meta as default };
+
+type Story = StoryObj<typeof FilterBar>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** No active filters — bar is hidden until a filter is added. */
+export const Empty: Story = {
+  args: {
+    filters: [],
+  },
+};
+
+/** Single active text filter. */
+export const SingleFilter: Story = {
+  args: {
+    filters: [
+      { property_id: "prop-name", operator: "contains", value: "design" },
+    ],
+  },
+};
+
+/** Multiple active filters showing AND logic. */
+export const MultipleFilters: Story = {
+  args: {
+    filters: [
+      { property_id: "prop-name", operator: "contains", value: "design" },
+      { property_id: "prop-score", operator: "gte", value: 5 },
+      { property_id: "prop-done", operator: "equals", value: true },
+    ],
+  },
+};
+
+/** Filters with is_empty / is_not_empty operators (no value shown). */
+export const EmptyOperators: Story = {
+  args: {
+    filters: [
+      { property_id: "prop-due", operator: "is_not_empty", value: null },
+      { property_id: "prop-url", operator: "is_empty", value: null },
+    ],
+  },
+};
+
+/** Many filters to test wrapping behavior. */
+export const ManyFilters: Story = {
+  args: {
+    filters: [
+      { property_id: "prop-name", operator: "contains", value: "project" },
+      { property_id: "prop-status", operator: "equals", value: "Active" },
+      { property_id: "prop-score", operator: "gt", value: 10 },
+      { property_id: "prop-due", operator: "before", value: "2026-06-01" },
+      { property_id: "prop-done", operator: "equals", value: false },
+      { property_id: "prop-url", operator: "is_not_empty", value: null },
+    ],
+  },
+};
+
+/** Interactive story with state management. */
+export const Interactive: Story = {
+  render: function InteractiveFilterBar() {
+    const [filters, setFilters] = useState<FilterRule[]>([
+      { property_id: "prop-name", operator: "contains", value: "alpha" },
+    ]);
+
+    return (
+      <div className="space-y-4">
+        <FilterBar
+          properties={mockProperties}
+          filters={filters}
+          onFiltersChange={setFilters}
+        />
+        <div className="text-xs text-muted-foreground">
+          Active filters: {filters.length === 0 ? "none" : JSON.stringify(filters, null, 2)}
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/database/filter-bar.tsx
+++ b/src/components/database/filter-bar.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Plus, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PROPERTY_TYPE_ICON } from "@/lib/property-icons";
+import type { DatabaseProperty } from "@/lib/types";
+import {
+  getOperatorsForType,
+  getOperatorLabel,
+  operatorNeedsValue,
+  type FilterOperator,
+  type FilterRule,
+} from "@/lib/database-filters";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface FilterBarProps {
+  properties: DatabaseProperty[];
+  filters: FilterRule[];
+  onFiltersChange: (filters: FilterRule[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Add-filter flow state
+// ---------------------------------------------------------------------------
+
+type AddFilterStep =
+  | { step: "closed" }
+  | { step: "pick-property" }
+  | { step: "pick-operator"; propertyId: string }
+  | { step: "pick-value"; propertyId: string; operator: FilterOperator };
+
+// ---------------------------------------------------------------------------
+// FilterBar
+// ---------------------------------------------------------------------------
+
+export function FilterBar({
+  properties,
+  filters,
+  onFiltersChange,
+}: FilterBarProps) {
+  const [addState, setAddState] = useState<AddFilterStep>({ step: "closed" });
+  const [valueInput, setValueInput] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    if (addState.step === "closed") return;
+
+    function handleClick(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        e.target instanceof Node &&
+        !dropdownRef.current.contains(e.target)
+      ) {
+        setAddState({ step: "closed" });
+        setValueInput("");
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [addState.step]);
+
+  const removeFilter = useCallback(
+    (index: number) => {
+      onFiltersChange(filters.filter((_, i) => i !== index));
+    },
+    [filters, onFiltersChange],
+  );
+
+  const handlePropertySelect = useCallback((propertyId: string) => {
+    setAddState({ step: "pick-operator", propertyId });
+  }, []);
+
+  const handleOperatorSelect = useCallback(
+    (operator: FilterOperator) => {
+      if (addState.step !== "pick-operator") return;
+
+      if (!operatorNeedsValue(operator)) {
+        // is_empty / is_not_empty — add filter immediately
+        onFiltersChange([
+          ...filters,
+          {
+            property_id: addState.propertyId,
+            operator,
+            value: null,
+          },
+        ]);
+        setAddState({ step: "closed" });
+        return;
+      }
+
+      setAddState({
+        step: "pick-value",
+        propertyId: addState.propertyId,
+        operator,
+      });
+      setValueInput("");
+    },
+    [addState, filters, onFiltersChange],
+  );
+
+  const handleValueSubmit = useCallback(() => {
+    if (addState.step !== "pick-value") return;
+    const trimmed = valueInput.trim();
+    if (!trimmed) return;
+
+    // Coerce to number for number properties
+    const prop = properties.find((p) => p.id === addState.propertyId);
+    let value: unknown = trimmed;
+    if (prop?.type === "number") {
+      const n = Number(trimmed);
+      if (!Number.isNaN(n)) value = n;
+    }
+    if (prop?.type === "checkbox") {
+      value = trimmed === "true" || trimmed === "1";
+    }
+
+    onFiltersChange([
+      ...filters,
+      {
+        property_id: addState.propertyId,
+        operator: addState.operator,
+        value,
+      },
+    ]);
+    setAddState({ step: "closed" });
+    setValueInput("");
+  }, [addState, valueInput, filters, onFiltersChange, properties]);
+
+  // Don't render the bar if there are no filters and the add flow is closed
+  if (filters.length === 0 && addState.step === "closed") {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 bg-muted p-2">
+      {/* Active filter badges */}
+      {filters.map((filter, index) => {
+        const prop = properties.find((p) => p.id === filter.property_id);
+        const propName = prop?.name ?? "Unknown";
+        const opLabel = getOperatorLabel(filter.operator);
+        const valueLabel = operatorNeedsValue(filter.operator)
+          ? ` ${String(filter.value ?? "")}`
+          : "";
+
+        return (
+          <Badge
+            key={`${filter.property_id}-${filter.operator}-${index}`}
+            variant="secondary"
+            className="gap-1 text-xs"
+          >
+            <span>{propName}</span>
+            <span className="text-muted-foreground">{opLabel}</span>
+            {valueLabel && <span>{valueLabel}</span>}
+            <button
+              type="button"
+              onClick={() => removeFilter(index)}
+              className="ml-0.5 text-muted-foreground hover:text-destructive"
+              aria-label={`Remove ${propName} filter`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        );
+      })}
+
+      {/* Add filter button + dropdown */}
+      <div className="relative" ref={dropdownRef}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 px-2 text-xs text-muted-foreground"
+          onClick={() =>
+            setAddState((prev) =>
+              prev.step === "closed"
+                ? { step: "pick-property" }
+                : { step: "closed" },
+            )
+          }
+        >
+          <Plus className="h-3 w-3" />
+          Add filter
+        </Button>
+
+        {/* Step 1: Pick property */}
+        {addState.step === "pick-property" && (
+          <PropertyPicker
+            properties={properties}
+            onSelect={handlePropertySelect}
+          />
+        )}
+
+        {/* Step 2: Pick operator */}
+        {addState.step === "pick-operator" && (
+          <OperatorPicker
+            propertyType={
+              properties.find((p) => p.id === addState.propertyId)?.type ??
+              "text"
+            }
+            onSelect={handleOperatorSelect}
+          />
+        )}
+
+        {/* Step 3: Enter value */}
+        {addState.step === "pick-value" && (
+          <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background p-2 shadow-md">
+            <Input
+              autoFocus
+              value={valueInput}
+              onChange={(e) => setValueInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleValueSubmit();
+                if (e.key === "Escape") {
+                  setAddState({ step: "closed" });
+                  setValueInput("");
+                }
+              }}
+              placeholder="Enter value…"
+              className="h-7 text-xs"
+              type={
+                properties.find((p) => p.id === addState.propertyId)?.type ===
+                "number"
+                  ? "number"
+                  : "text"
+              }
+            />
+            <Button
+              size="sm"
+              className="mt-1.5 h-6 w-full text-xs"
+              onClick={handleValueSubmit}
+            >
+              Apply
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PropertyPicker dropdown
+// ---------------------------------------------------------------------------
+
+function PropertyPicker({
+  properties,
+  onSelect,
+}: {
+  properties: DatabaseProperty[];
+  onSelect: (propertyId: string) => void;
+}) {
+  return (
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background py-1 shadow-md">
+      {properties.map((prop) => {
+        const Icon = PROPERTY_TYPE_ICON[prop.type];
+        return (
+          <button
+            key={prop.id}
+            type="button"
+            onClick={() => onSelect(prop.id)}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-white/[0.04]"
+          >
+            <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+            <span>{prop.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OperatorPicker dropdown
+// ---------------------------------------------------------------------------
+
+function OperatorPicker({
+  propertyType,
+  onSelect,
+}: {
+  propertyType: DatabaseProperty["type"];
+  onSelect: (operator: FilterOperator) => void;
+}) {
+  const operators = getOperatorsForType(propertyType);
+
+  return (
+    <div className="absolute left-0 top-full z-50 mt-1 w-48 border border-border bg-background py-1 shadow-md">
+      {operators.map((op) => (
+        <button
+          key={op}
+          type="button"
+          onClick={() => onSelect(op)}
+          className={cn(
+            "flex w-full items-center px-3 py-1.5 text-sm hover:bg-white/[0.04]",
+          )}
+        >
+          {getOperatorLabel(op)}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/database/sort-menu.stories.tsx
+++ b/src/components/database/sort-menu.stories.tsx
@@ -1,0 +1,132 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import { useState } from "react";
+import { SortMenu } from "./sort-menu";
+import type { DatabaseProperty } from "@/lib/types";
+import type { SortRule } from "@/lib/database-filters";
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockProperties: DatabaseProperty[] = [
+  {
+    id: "prop-name",
+    database_id: "db-1",
+    name: "Name",
+    type: "text",
+    config: {},
+    position: 0,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-status",
+    database_id: "db-1",
+    name: "Status",
+    type: "select",
+    config: {},
+    position: 1,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-score",
+    database_id: "db-1",
+    name: "Score",
+    type: "number",
+    config: {},
+    position: 2,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: "prop-due",
+    database_id: "db-1",
+    name: "Due Date",
+    type: "date",
+    config: {},
+    position: 3,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof SortMenu> = {
+  title: "Database/SortMenu",
+  component: SortMenu,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex max-w-3xl justify-end bg-background p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    properties: mockProperties,
+    onSortsChange: fn(),
+  },
+};
+
+export { meta as default };
+
+type Story = StoryObj<typeof SortMenu>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** No active sorts. */
+export const NoSorts: Story = {
+  args: {
+    sorts: [],
+  },
+};
+
+/** Single sort rule. */
+export const SingleSort: Story = {
+  args: {
+    sorts: [{ property_id: "prop-name", direction: "asc" }],
+  },
+};
+
+/** Multiple sort rules. */
+export const MultipleSorts: Story = {
+  args: {
+    sorts: [
+      { property_id: "prop-status", direction: "asc" },
+      { property_id: "prop-score", direction: "desc" },
+    ],
+  },
+};
+
+/** Interactive story with state management. */
+export const Interactive: Story = {
+  render: function InteractiveSortMenu() {
+    const [sorts, setSorts] = useState<SortRule[]>([
+      { property_id: "prop-name", direction: "asc" },
+    ]);
+
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-end">
+          <SortMenu
+            properties={mockProperties}
+            sorts={sorts}
+            onSortsChange={setSorts}
+          />
+        </div>
+        <div className="text-xs text-muted-foreground">
+          Active sorts: {sorts.length === 0 ? "none" : JSON.stringify(sorts, null, 2)}
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/database/sort-menu.tsx
+++ b/src/components/database/sort-menu.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Plus, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { PROPERTY_TYPE_ICON } from "@/lib/property-icons";
+import type { DatabaseProperty } from "@/lib/types";
+import type { SortRule } from "@/lib/database-filters";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface SortMenuProps {
+  properties: DatabaseProperty[];
+  sorts: SortRule[];
+  onSortsChange: (sorts: SortRule[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// SortMenu — dropdown button that shows active sorts and lets users add/remove
+// ---------------------------------------------------------------------------
+
+export function SortMenu({
+  properties,
+  sorts,
+  onSortsChange,
+}: SortMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [pickingProperty, setPickingProperty] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClick(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        e.target instanceof Node &&
+        !containerRef.current.contains(e.target)
+      ) {
+        setOpen(false);
+        setPickingProperty(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  const removeSort = useCallback(
+    (index: number) => {
+      onSortsChange(sorts.filter((_, i) => i !== index));
+    },
+    [sorts, onSortsChange],
+  );
+
+  const toggleDirection = useCallback(
+    (index: number) => {
+      const updated = sorts.map((s, i) =>
+        i === index
+          ? { ...s, direction: s.direction === "asc" ? ("desc" as const) : ("asc" as const) }
+          : s,
+      );
+      onSortsChange(updated);
+    },
+    [sorts, onSortsChange],
+  );
+
+  const addSort = useCallback(
+    (propertyId: string) => {
+      onSortsChange([...sorts, { property_id: propertyId, direction: "asc" }]);
+      setPickingProperty(false);
+    },
+    [sorts, onSortsChange],
+  );
+
+  // Properties not already used in a sort rule
+  const availableProperties = properties.filter(
+    (p) => !sorts.some((s) => s.property_id === p.id),
+  );
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <Button
+        variant="ghost"
+        size="sm"
+        className={cn(
+          "h-7 gap-1 px-2 text-xs",
+          sorts.length > 0
+            ? "text-foreground"
+            : "text-muted-foreground",
+        )}
+        onClick={() => {
+          setOpen((prev) => !prev);
+          setPickingProperty(false);
+        }}
+      >
+        <ArrowUpDown className="h-3.5 w-3.5" />
+        Sort
+        {sorts.length > 0 && (
+          <span className="ml-0.5 text-muted-foreground">
+            ({sorts.length})
+          </span>
+        )}
+      </Button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-64 border border-border bg-background shadow-md">
+          {/* Active sorts */}
+          {sorts.length > 0 && (
+            <div className="border-b border-border px-1 py-1">
+              {sorts.map((sort, index) => {
+                const prop = properties.find(
+                  (p) => p.id === sort.property_id,
+                );
+                const propName = prop?.name ?? "Unknown";
+                return (
+                  <div
+                    key={`${sort.property_id}-${index}`}
+                    className="flex items-center gap-1.5 px-2 py-1"
+                  >
+                    <span className="flex-1 truncate text-xs">
+                      {propName}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => toggleDirection(index)}
+                      className="flex items-center gap-0.5 text-xs text-muted-foreground hover:text-foreground"
+                      aria-label={`Sort ${sort.direction === "asc" ? "ascending" : "descending"}`}
+                    >
+                      {sort.direction === "asc" ? (
+                        <ArrowUp className="h-3 w-3" />
+                      ) : (
+                        <ArrowDown className="h-3 w-3" />
+                      )}
+                      <span>{sort.direction === "asc" ? "Asc" : "Desc"}</span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeSort(index)}
+                      className="text-muted-foreground hover:text-destructive"
+                      aria-label={`Remove ${propName} sort`}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Add sort */}
+          {!pickingProperty && availableProperties.length > 0 && (
+            <div className="px-1 py-1">
+              <button
+                type="button"
+                onClick={() => setPickingProperty(true)}
+                className="flex w-full items-center gap-1.5 px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <Plus className="h-3 w-3" />
+                Add sort
+              </button>
+            </div>
+          )}
+
+          {/* Property picker for adding a sort */}
+          {pickingProperty && (
+            <div className="max-h-48 overflow-y-auto px-1 py-1">
+              {availableProperties.map((prop) => {
+                const Icon = PROPERTY_TYPE_ICON[prop.type];
+                return (
+                  <button
+                    key={prop.id}
+                    type="button"
+                    onClick={() => addSort(prop.id)}
+                    className="flex w-full items-center gap-2 px-2 py-1.5 text-sm hover:bg-white/[0.04]"
+                  >
+                    <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span>{prop.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {sorts.length === 0 && !pickingProperty && (
+            <div className="px-3 py-2 text-xs text-muted-foreground">
+              No sorts applied
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -9,20 +9,13 @@ import {
 } from "react";
 import Link from "next/link";
 import {
-  Calendar,
-  CheckSquare,
-  Clock,
+  ArrowDown,
+  ArrowUp,
   FileText,
-  Hash,
-  Link as LinkIcon,
-  List,
-  Mail,
-  Phone,
   Plus,
-  Type,
-  User,
-  Users,
 } from "lucide-react";
+import { PROPERTY_TYPE_ICON } from "@/lib/property-icons";
+import type { SortRule } from "@/lib/database-filters";
 import { cn } from "@/lib/utils";
 import type {
   DatabaseProperty,
@@ -47,29 +40,6 @@ const ROW_HEIGHT_CLASS: Record<NonNullable<DatabaseViewConfig["row_height"]>, st
 };
 
 // ---------------------------------------------------------------------------
-// Property type → icon mapping
-// ---------------------------------------------------------------------------
-
-const PROPERTY_TYPE_ICON: Record<PropertyType, React.ComponentType<{ className?: string }>> = {
-  text: Type,
-  number: Hash,
-  select: List,
-  multi_select: List,
-  checkbox: CheckSquare,
-  date: Calendar,
-  url: LinkIcon,
-  email: Mail,
-  phone: Phone,
-  person: User,
-  files: FileText,
-  relation: LinkIcon,
-  formula: Hash,
-  created_time: Clock,
-  updated_time: Clock,
-  created_by: Users,
-};
-
-// ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
@@ -88,6 +58,10 @@ export interface TableViewProps {
   onColumnWidthsChange?: (widths: Record<string, number>) => void;
   /** Called when a column header is clicked (for property config). */
   onColumnHeaderClick?: (propertyId: string) => void;
+  /** Active sort rules (for displaying sort indicators in column headers). */
+  sorts?: SortRule[];
+  /** Called when a column header sort indicator is clicked. Cycles: unsorted → asc → desc → unsorted. */
+  onSortToggle?: (propertyId: string) => void;
   /** Loading state — shows skeleton. */
   loading?: boolean;
 }
@@ -115,6 +89,8 @@ export function TableView({
   onAddColumn,
   onColumnWidthsChange,
   onColumnHeaderClick,
+  sorts = [],
+  onSortToggle,
   loading = false,
 }: TableViewProps) {
   // Column widths: merge persisted widths with defaults.
@@ -344,20 +320,43 @@ export function TableView({
 
         {visibleProperties.map((prop) => {
           const Icon = PROPERTY_TYPE_ICON[prop.type];
+          const sortRule = sorts.find((s) => s.property_id === prop.id);
           return (
             <div
               key={prop.id}
               className="group/header sticky top-0 z-10 border-b border-white/[0.06] bg-muted p-2"
               role="columnheader"
             >
-              <button
-                type="button"
-                className="flex w-full items-center gap-1.5 text-left text-xs font-medium uppercase tracking-widest text-muted-foreground hover:text-foreground"
-                onClick={() => onColumnHeaderClick?.(prop.id)}
-              >
-                <Icon className="h-3 w-3 shrink-0" />
-                <span className="truncate">{prop.name}</span>
-              </button>
+              <div className="flex w-full items-center gap-1.5">
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center gap-1.5 text-left text-xs font-medium uppercase tracking-widest text-muted-foreground hover:text-foreground"
+                  onClick={() => onColumnHeaderClick?.(prop.id)}
+                >
+                  <Icon className="h-3 w-3 shrink-0" />
+                  <span className="truncate">{prop.name}</span>
+                </button>
+                {/* Sort indicator — click to cycle */}
+                {onSortToggle && (
+                  <button
+                    type="button"
+                    onClick={() => onSortToggle(prop.id)}
+                    className={cn(
+                      "shrink-0",
+                      sortRule
+                        ? "text-muted-foreground"
+                        : "text-transparent group-hover/header:text-muted-foreground/50",
+                    )}
+                    aria-label={`Sort by ${prop.name}`}
+                  >
+                    {sortRule?.direction === "desc" ? (
+                      <ArrowDown className="h-3 w-3" />
+                    ) : (
+                      <ArrowUp className="h-3 w-3" />
+                    )}
+                  </button>
+                )}
+              </div>
               {/* Resize handle */}
               <div
                 className={cn(

--- a/src/lib/database-filters.test.ts
+++ b/src/lib/database-filters.test.ts
@@ -1,0 +1,527 @@
+import { describe, it, expect } from "vitest";
+import {
+  sortRows,
+  filterRows,
+  getOperatorsForType,
+  getOperatorLabel,
+  operatorNeedsValue,
+  type SortRule,
+  type FilterRule,
+} from "./database-filters";
+import type { DatabaseProperty, DatabaseRow } from "./types";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(
+  id: string,
+  name: string,
+  type: DatabaseProperty["type"],
+  config: Record<string, unknown> = {},
+): DatabaseProperty {
+  return {
+    id,
+    database_id: "db-1",
+    name,
+    type,
+    config,
+    position: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeRow(
+  id: string,
+  title: string,
+  values: Record<string, Record<string, unknown>>,
+  overrides?: Partial<DatabaseRow["page"]>,
+): DatabaseRow {
+  const rowValues: DatabaseRow["values"] = {};
+  for (const [propId, val] of Object.entries(values)) {
+    rowValues[propId] = {
+      id: `rv-${id}-${propId}`,
+      row_id: id,
+      property_id: propId,
+      value: val,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+  }
+  return {
+    page: {
+      id,
+      title,
+      icon: null,
+      cover_url: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-15T00:00:00Z",
+      created_by: "user-1",
+      ...overrides,
+    },
+    values: rowValues,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared test data
+// ---------------------------------------------------------------------------
+
+const textProp = makeProp("p-text", "Name", "text");
+const numberProp = makeProp("p-num", "Score", "number");
+const selectProp = makeProp("p-sel", "Status", "select");
+const multiSelectProp = makeProp("p-ms", "Tags", "multi_select");
+const checkboxProp = makeProp("p-cb", "Done", "checkbox");
+const dateProp = makeProp("p-date", "Due", "date");
+const urlProp = makeProp("p-url", "Link", "url");
+const createdTimeProp = makeProp("p-ct", "Created", "created_time");
+const createdByProp = makeProp("p-cby", "Creator", "created_by");
+
+const allProps = [
+  textProp,
+  numberProp,
+  selectProp,
+  multiSelectProp,
+  checkboxProp,
+  dateProp,
+  urlProp,
+  createdTimeProp,
+  createdByProp,
+];
+
+const rows: DatabaseRow[] = [
+  makeRow("r1", "Alpha", {
+    "p-text": { value: "Alpha" },
+    "p-num": { value: 10 },
+    "p-sel": { value: "Done", color: "green" },
+    "p-ms": { value: ["tag-a", "tag-b"] },
+    "p-cb": { value: true },
+    "p-date": { value: "2026-03-01" },
+    "p-url": { value: "https://alpha.com" },
+  }),
+  makeRow("r2", "Beta", {
+    "p-text": { value: "Beta" },
+    "p-num": { value: 5 },
+    "p-sel": { value: "In Progress", color: "blue" },
+    "p-ms": { value: ["tag-c"] },
+    "p-cb": { value: false },
+    "p-date": { value: "2026-05-15" },
+    "p-url": { value: "https://beta.com" },
+  }),
+  makeRow(
+    "r3",
+    "Gamma",
+    {
+      "p-text": { value: "Gamma" },
+      "p-num": { value: 20 },
+      "p-sel": { value: "To Do", color: "gray" },
+      "p-ms": { value: [] },
+      "p-cb": { value: false },
+      "p-date": { value: "2026-01-10" },
+    },
+    {
+      created_at: "2026-02-01T00:00:00Z",
+      updated_at: "2026-02-15T00:00:00Z",
+      created_by: "user-2",
+    },
+  ),
+  makeRow("r4", "Delta", {
+    "p-text": { value: "" },
+    "p-num": { value: null as unknown as number },
+  }),
+];
+
+// ---------------------------------------------------------------------------
+// Sort tests
+// ---------------------------------------------------------------------------
+
+describe("sortRows", () => {
+  it("returns the same array reference when no sorts", () => {
+    const result = sortRows(rows, [], allProps);
+    expect(result).toEqual(rows);
+  });
+
+  it("sorts by text ascending", () => {
+    const sorts: SortRule[] = [{ property_id: "p-text", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1", "r2", "r3", "r4"]);
+  });
+
+  it("sorts by text descending", () => {
+    const sorts: SortRule[] = [{ property_id: "p-text", direction: "desc" }];
+    const result = sortRows(rows, sorts, allProps);
+    // Gamma > Beta > Alpha, then empty (r4) last
+    expect(result.map((r) => r.page.id)).toEqual(["r3", "r2", "r1", "r4"]);
+  });
+
+  it("sorts by number ascending — null sorts last", () => {
+    const sorts: SortRule[] = [{ property_id: "p-num", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r2", "r1", "r3", "r4"]);
+  });
+
+  it("sorts by number descending — null sorts last", () => {
+    const sorts: SortRule[] = [{ property_id: "p-num", direction: "desc" }];
+    const result = sortRows(rows, sorts, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r3", "r1", "r2", "r4"]);
+  });
+
+  it("sorts by select (alphabetical by option name)", () => {
+    const sorts: SortRule[] = [{ property_id: "p-sel", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    // Done < In Progress < To Do, r4 has no select → last
+    expect(result.map((r) => r.page.id)).toEqual(["r1", "r2", "r3", "r4"]);
+  });
+
+  it("sorts by checkbox — false before true ascending", () => {
+    const sorts: SortRule[] = [{ property_id: "p-cb", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    // false (0) < true (1); r4 has no checkbox value
+    const ids = result.map((r) => r.page.id);
+    // r2, r3 are false (0), r1 is true (1), r4 has no value
+    expect(ids.indexOf("r1")).toBeGreaterThan(ids.indexOf("r2"));
+    expect(ids.indexOf("r1")).toBeGreaterThan(ids.indexOf("r3"));
+  });
+
+  it("sorts by date ascending", () => {
+    const sorts: SortRule[] = [{ property_id: "p-date", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    // 2026-01-10 < 2026-03-01 < 2026-05-15, r4 has no date → last
+    expect(result.map((r) => r.page.id)).toEqual(["r3", "r1", "r2", "r4"]);
+  });
+
+  it("sorts by multi_select (first option name)", () => {
+    const sorts: SortRule[] = [{ property_id: "p-ms", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    // tag-a < tag-c, r3 has empty array → last, r4 has no value → last
+    expect(result[0].page.id).toBe("r1");
+    expect(result[1].page.id).toBe("r2");
+  });
+
+  it("sorts by computed created_time", () => {
+    const sorts: SortRule[] = [{ property_id: "p-ct", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    // r1, r2, r4 have 2026-01-01, r3 has 2026-02-01
+    expect(result[result.length - 1].page.id).toBe("r3");
+  });
+
+  it("sorts by computed created_by", () => {
+    const sorts: SortRule[] = [{ property_id: "p-cby", direction: "asc" }];
+    const result = sortRows(rows, sorts, allProps);
+    // user-1 < user-2
+    const user1Rows = result.filter((r) => r.page.created_by === "user-1");
+    const user2Rows = result.filter((r) => r.page.created_by === "user-2");
+    expect(result.indexOf(user1Rows[0])).toBeLessThan(
+      result.indexOf(user2Rows[0]),
+    );
+  });
+
+  it("applies multiple sort rules in order", () => {
+    const sorts: SortRule[] = [
+      { property_id: "p-cb", direction: "asc" },
+      { property_id: "p-num", direction: "desc" },
+    ];
+    const result = sortRows(rows, sorts, allProps);
+    // First sort by checkbox: false (r2=5, r3=20) then true (r1=10), r4 last
+    // Within false group, sort by number desc: r3(20) > r2(5)
+    expect(result[0].page.id).toBe("r3");
+    expect(result[1].page.id).toBe("r2");
+    expect(result[2].page.id).toBe("r1");
+  });
+
+  it("does not mutate the input array", () => {
+    const original = [...rows];
+    const sorts: SortRule[] = [{ property_id: "p-num", direction: "desc" }];
+    sortRows(rows, sorts, allProps);
+    expect(rows.map((r) => r.page.id)).toEqual(original.map((r) => r.page.id));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter tests
+// ---------------------------------------------------------------------------
+
+describe("filterRows", () => {
+  it("returns all rows when no filters", () => {
+    const result = filterRows(rows, [], allProps);
+    expect(result).toEqual(rows);
+  });
+
+  // Text filters
+  it("filters text contains", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-text", operator: "contains", value: "alp" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1"]);
+  });
+
+  it("filters text contains (case-insensitive)", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-text", operator: "contains", value: "BETA" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r2"]);
+  });
+
+  it("filters text equals", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-text", operator: "equals", value: "gamma" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r3"]);
+  });
+
+  it("filters text is_empty", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-text", operator: "is_empty", value: null },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r4"]);
+  });
+
+  it("filters text is_not_empty", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-text", operator: "is_not_empty", value: null },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1", "r2", "r3"]);
+  });
+
+  // Number filters
+  it("filters number equals", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-num", operator: "equals", value: 10 },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1"]);
+  });
+
+  it("filters number gt", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-num", operator: "gt", value: 5 },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1", "r3"]);
+  });
+
+  it("filters number lt", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-num", operator: "lt", value: 10 },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r2"]);
+  });
+
+  it("filters number gte", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-num", operator: "gte", value: 10 },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1", "r3"]);
+  });
+
+  it("filters number lte", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-num", operator: "lte", value: 10 },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1", "r2"]);
+  });
+
+  it("filters number is_empty", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-num", operator: "is_empty", value: null },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r4"]);
+  });
+
+  // Select filters
+  it("filters select equals", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-sel", operator: "equals", value: "Done" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1"]);
+  });
+
+  // Multi-select filters
+  it("filters multi_select contains", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-ms", operator: "contains", value: "tag-a" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1"]);
+  });
+
+  it("filters multi_select is_empty", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-ms", operator: "is_empty", value: null },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    // r3 has empty array, r4 has no value
+    expect(result.map((r) => r.page.id)).toEqual(["r3", "r4"]);
+  });
+
+  // Checkbox filters
+  it("filters checkbox equals true", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-cb", operator: "equals", value: true },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1"]);
+  });
+
+  it("filters checkbox equals false", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-cb", operator: "equals", value: false },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    // r2 and r3 are false, r4 has no checkbox value (null ≠ false)
+    expect(result.map((r) => r.page.id)).toEqual(["r2", "r3"]);
+  });
+
+  // Date filters
+  it("filters date equals", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-date", operator: "equals", value: "2026-03-01" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1"]);
+  });
+
+  it("filters date before", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-date", operator: "before", value: "2026-04-01" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1", "r3"]);
+  });
+
+  it("filters date after", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-date", operator: "after", value: "2026-04-01" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r2"]);
+  });
+
+  // URL filters
+  it("filters url contains", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-url", operator: "contains", value: "alpha" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r1"]);
+  });
+
+  // Computed property filters
+  it("filters created_time after", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-ct", operator: "after", value: "2026-01-15" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    // r3 has created_at 2026-02-01
+    expect(result.map((r) => r.page.id)).toEqual(["r3"]);
+  });
+
+  it("filters created_by contains", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-cby", operator: "contains", value: "user-2" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.map((r) => r.page.id)).toEqual(["r3"]);
+  });
+
+  // AND logic
+  it("applies multiple filters with AND logic", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-num", operator: "gte", value: 5 },
+      { property_id: "p-cb", operator: "equals", value: false },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    // r2 (num=5, cb=false) and r3 (num=20, cb=false)
+    expect(result.map((r) => r.page.id)).toEqual(["r2", "r3"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const original = [...rows];
+    const filters: FilterRule[] = [
+      { property_id: "p-text", operator: "contains", value: "alpha" },
+    ];
+    filterRows(rows, filters, allProps);
+    expect(rows.map((r) => r.page.id)).toEqual(original.map((r) => r.page.id));
+  });
+
+  it("passes through rows with unknown property in filter", () => {
+    const filters: FilterRule[] = [
+      { property_id: "p-nonexistent", operator: "equals", value: "x" },
+    ];
+    const result = filterRows(rows, filters, allProps);
+    expect(result.length).toBe(rows.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Utility function tests
+// ---------------------------------------------------------------------------
+
+describe("getOperatorsForType", () => {
+  it("returns type-appropriate operators for number", () => {
+    const ops = getOperatorsForType("number");
+    expect(ops).toContain("gt");
+    expect(ops).toContain("lt");
+    expect(ops).not.toContain("contains");
+  });
+
+  it("returns type-appropriate operators for text", () => {
+    const ops = getOperatorsForType("text");
+    expect(ops).toContain("contains");
+    expect(ops).toContain("equals");
+    expect(ops).not.toContain("gt");
+  });
+
+  it("returns type-appropriate operators for checkbox", () => {
+    const ops = getOperatorsForType("checkbox");
+    expect(ops).toEqual(["equals"]);
+  });
+
+  it("returns type-appropriate operators for date", () => {
+    const ops = getOperatorsForType("date");
+    expect(ops).toContain("before");
+    expect(ops).toContain("after");
+    expect(ops).not.toContain("gt");
+  });
+
+  it("returns type-appropriate operators for select", () => {
+    const ops = getOperatorsForType("select");
+    expect(ops).toContain("equals");
+    expect(ops).not.toContain("contains");
+  });
+});
+
+describe("getOperatorLabel", () => {
+  it("returns human-readable labels", () => {
+    expect(getOperatorLabel("contains")).toBe("contains");
+    expect(getOperatorLabel("equals")).toBe("is");
+    expect(getOperatorLabel("is_empty")).toBe("is empty");
+    expect(getOperatorLabel("gt")).toBe(">");
+    expect(getOperatorLabel("before")).toBe("before");
+  });
+});
+
+describe("operatorNeedsValue", () => {
+  it("returns false for is_empty and is_not_empty", () => {
+    expect(operatorNeedsValue("is_empty")).toBe(false);
+    expect(operatorNeedsValue("is_not_empty")).toBe(false);
+  });
+
+  it("returns true for all other operators", () => {
+    expect(operatorNeedsValue("contains")).toBe(true);
+    expect(operatorNeedsValue("equals")).toBe(true);
+    expect(operatorNeedsValue("gt")).toBe(true);
+    expect(operatorNeedsValue("before")).toBe(true);
+  });
+});

--- a/src/lib/database-filters.ts
+++ b/src/lib/database-filters.ts
@@ -1,0 +1,568 @@
+// Pure sort and filter functions for database rows.
+// Operates on loaded DatabaseRow[] — no data fetching.
+
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  PropertyType,
+  RowValue,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SortRule {
+  property_id: string;
+  direction: "asc" | "desc";
+}
+
+export type FilterOperator =
+  | "contains"
+  | "equals"
+  | "is_empty"
+  | "is_not_empty"
+  | "gt"
+  | "lt"
+  | "gte"
+  | "lte"
+  | "before"
+  | "after";
+
+export interface FilterRule {
+  property_id: string;
+  operator: FilterOperator;
+  value: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Operator registry per property type
+// ---------------------------------------------------------------------------
+
+const TEXT_OPERATORS: FilterOperator[] = [
+  "contains",
+  "equals",
+  "is_empty",
+  "is_not_empty",
+];
+const NUMBER_OPERATORS: FilterOperator[] = [
+  "equals",
+  "gt",
+  "lt",
+  "gte",
+  "lte",
+  "is_empty",
+  "is_not_empty",
+];
+const SELECT_OPERATORS: FilterOperator[] = [
+  "equals",
+  "is_empty",
+  "is_not_empty",
+];
+const MULTI_SELECT_OPERATORS: FilterOperator[] = [
+  "contains",
+  "is_empty",
+  "is_not_empty",
+];
+const CHECKBOX_OPERATORS: FilterOperator[] = ["equals"];
+const DATE_OPERATORS: FilterOperator[] = [
+  "equals",
+  "before",
+  "after",
+  "is_empty",
+  "is_not_empty",
+];
+const PERSON_OPERATORS: FilterOperator[] = [
+  "contains",
+  "is_empty",
+  "is_not_empty",
+];
+const STRING_LIKE_OPERATORS: FilterOperator[] = [
+  "contains",
+  "equals",
+  "is_empty",
+  "is_not_empty",
+];
+
+const OPERATORS_BY_TYPE: Record<PropertyType, FilterOperator[]> = {
+  text: TEXT_OPERATORS,
+  number: NUMBER_OPERATORS,
+  select: SELECT_OPERATORS,
+  multi_select: MULTI_SELECT_OPERATORS,
+  checkbox: CHECKBOX_OPERATORS,
+  date: DATE_OPERATORS,
+  url: STRING_LIKE_OPERATORS,
+  email: STRING_LIKE_OPERATORS,
+  phone: STRING_LIKE_OPERATORS,
+  person: PERSON_OPERATORS,
+  files: ["is_empty", "is_not_empty"],
+  relation: ["contains", "is_empty", "is_not_empty"],
+  formula: TEXT_OPERATORS,
+  created_time: DATE_OPERATORS,
+  updated_time: DATE_OPERATORS,
+  created_by: PERSON_OPERATORS,
+};
+
+/** Return the valid filter operators for a given property type. */
+export function getOperatorsForType(type: PropertyType): FilterOperator[] {
+  return OPERATORS_BY_TYPE[type] ?? TEXT_OPERATORS;
+}
+
+/** Human-readable label for a filter operator. */
+export function getOperatorLabel(operator: FilterOperator): string {
+  switch (operator) {
+    case "contains":
+      return "contains";
+    case "equals":
+      return "is";
+    case "is_empty":
+      return "is empty";
+    case "is_not_empty":
+      return "is not empty";
+    case "gt":
+      return ">";
+    case "lt":
+      return "<";
+    case "gte":
+      return "≥";
+    case "lte":
+      return "≤";
+    case "before":
+      return "before";
+    case "after":
+      return "after";
+  }
+}
+
+/** Whether the operator requires a user-provided value. */
+export function operatorNeedsValue(operator: FilterOperator): boolean {
+  return operator !== "is_empty" && operator !== "is_not_empty";
+}
+
+// ---------------------------------------------------------------------------
+// Value extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a comparable primitive from a RowValue.
+ * RowValue.value is `Record<string, unknown>` — the inner shape depends on
+ * the property type. Most types store `{ value: <primitive> }`.
+ */
+function extractPrimitive(
+  rv: RowValue | undefined,
+): string | number | boolean | null {
+  if (!rv) return null;
+  const inner = rv.value?.value;
+  if (inner === undefined || inner === null || inner === "") return null;
+  return inner as string | number | boolean;
+}
+
+/**
+ * Extract a string value for text-like comparisons.
+ */
+function extractString(rv: RowValue | undefined): string {
+  const v = extractPrimitive(rv);
+  if (v === null) return "";
+  return String(v);
+}
+
+/**
+ * Extract a numeric value.
+ */
+function extractNumber(rv: RowValue | undefined): number | null {
+  const v = extractPrimitive(rv);
+  if (v === null) return null;
+  const n = Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * Extract a date string (ISO 8601) for date comparisons.
+ */
+function extractDate(rv: RowValue | undefined): string | null {
+  const v = extractPrimitive(rv);
+  if (v === null) return null;
+  return String(v);
+}
+
+/**
+ * Check if a RowValue is empty (no value set or value is null/empty string).
+ */
+function isEmpty(rv: RowValue | undefined): boolean {
+  if (!rv) return true;
+  const inner = rv.value?.value;
+  if (inner === undefined || inner === null || inner === "") return true;
+  if (Array.isArray(inner) && inner.length === 0) return true;
+  return false;
+}
+
+/**
+ * Extract the first selected option name from a multi-select value.
+ * Multi-select stores `{ value: string[] }` or `{ value: ["opt1", "opt2"] }`.
+ */
+function extractMultiSelectValues(rv: RowValue | undefined): string[] {
+  if (!rv) return [];
+  const inner = rv.value?.value;
+  if (Array.isArray(inner)) return inner.map(String);
+  return [];
+}
+
+/**
+ * Get a computed property value from page metadata.
+ * Computed types (created_time, updated_time, created_by) derive from the page.
+ */
+function getComputedValue(
+  row: DatabaseRow,
+  type: PropertyType,
+): string | null {
+  switch (type) {
+    case "created_time":
+      return row.page.created_at ?? null;
+    case "updated_time":
+      return row.page.updated_at ?? null;
+    case "created_by":
+      return row.page.created_by ?? null;
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sort
+// ---------------------------------------------------------------------------
+
+/**
+ * Sort rows by multiple criteria. Null/empty values sort last regardless of
+ * direction. Returns a new array (does not mutate the input).
+ */
+export function sortRows(
+  rows: DatabaseRow[],
+  sorts: SortRule[],
+  properties: DatabaseProperty[],
+): DatabaseRow[] {
+  if (sorts.length === 0) return rows;
+
+  const propMap = new Map(properties.map((p) => [p.id, p]));
+
+  return [...rows].sort((a, b) => {
+    for (const sort of sorts) {
+      const prop = propMap.get(sort.property_id);
+      if (!prop) continue;
+
+      const result = compareForSort(a, b, prop, sort.direction);
+      if (result !== 0) return result;
+    }
+    return 0;
+  });
+}
+
+/**
+ * Compare two rows for sorting. Null/empty values always sort last,
+ * regardless of direction. Non-null values are compared normally and
+ * the direction is applied.
+ */
+function compareForSort(
+  a: DatabaseRow,
+  b: DatabaseRow,
+  prop: DatabaseProperty,
+  direction: "asc" | "desc",
+): number {
+  const aIsNull = isValueNull(a, prop);
+  const bIsNull = isValueNull(b, prop);
+
+  // Both null → equal
+  if (aIsNull && bIsNull) return 0;
+  // Null always sorts last regardless of direction
+  if (aIsNull) return 1;
+  if (bIsNull) return -1;
+
+  const cmp = compareValues(a, b, prop);
+  return direction === "asc" ? cmp : -cmp;
+}
+
+/**
+ * Check if a row's value for a property is null/empty.
+ */
+function isValueNull(row: DatabaseRow, prop: DatabaseProperty): boolean {
+  const isComputed =
+    prop.type === "created_time" ||
+    prop.type === "updated_time" ||
+    prop.type === "created_by";
+
+  if (isComputed) {
+    return getComputedValue(row, prop.type) === null;
+  }
+
+  const rv = row.values[prop.id];
+  if (!rv) return true;
+  const inner = rv.value?.value;
+  if (inner === undefined || inner === null || inner === "") return true;
+  if (Array.isArray(inner) && inner.length === 0) return true;
+  return false;
+}
+
+/**
+ * Compare two rows by a single property. Returns negative if a < b,
+ * positive if a > b, 0 if equal. Assumes both values are non-null.
+ */
+function compareValues(
+  a: DatabaseRow,
+  b: DatabaseRow,
+  prop: DatabaseProperty,
+): number {
+  const isComputed =
+    prop.type === "created_time" ||
+    prop.type === "updated_time" ||
+    prop.type === "created_by";
+
+  if (isComputed) {
+    const va = getComputedValue(a, prop.type);
+    const vb = getComputedValue(b, prop.type);
+    if (va === null || vb === null) return 0; // handled by compareForSort
+    if (prop.type === "created_by") {
+      return va.localeCompare(vb);
+    }
+    return va < vb ? -1 : va > vb ? 1 : 0;
+  }
+
+  const rvA = a.values[prop.id];
+  const rvB = b.values[prop.id];
+
+  switch (prop.type) {
+    case "text":
+    case "url":
+    case "email":
+    case "phone":
+    case "formula": {
+      const sa = extractString(rvA);
+      const sb = extractString(rvB);
+      return sa.localeCompare(sb);
+    }
+
+    case "number": {
+      const na = extractNumber(rvA) ?? 0;
+      const nb = extractNumber(rvB) ?? 0;
+      return na - nb;
+    }
+
+    case "select": {
+      const sa = extractString(rvA);
+      const sb = extractString(rvB);
+      return sa.localeCompare(sb);
+    }
+
+    case "multi_select": {
+      const msA = extractMultiSelectValues(rvA);
+      const msB = extractMultiSelectValues(rvB);
+      const firstA = msA[0] ?? "";
+      const firstB = msB[0] ?? "";
+      return firstA.localeCompare(firstB);
+    }
+
+    case "checkbox": {
+      const ca = extractPrimitive(rvA);
+      const cb = extractPrimitive(rvB);
+      const ba = ca === true ? 1 : 0;
+      const bb = cb === true ? 1 : 0;
+      return ba - bb;
+    }
+
+    case "date": {
+      const da = extractDate(rvA) ?? "";
+      const db = extractDate(rvB) ?? "";
+      return da < db ? -1 : da > db ? 1 : 0;
+    }
+
+    case "person": {
+      const pa = extractString(rvA);
+      const pb = extractString(rvB);
+      return pa.localeCompare(pb);
+    }
+
+    default:
+      return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Filter
+// ---------------------------------------------------------------------------
+
+/**
+ * Filter rows by multiple criteria (AND logic — all must match).
+ * Returns a new array.
+ */
+export function filterRows(
+  rows: DatabaseRow[],
+  filters: FilterRule[],
+  properties: DatabaseProperty[],
+): DatabaseRow[] {
+  if (filters.length === 0) return rows;
+
+  const propMap = new Map(properties.map((p) => [p.id, p]));
+
+  return rows.filter((row) =>
+    filters.every((filter) => {
+      const prop = propMap.get(filter.property_id);
+      if (!prop) return true; // unknown property — don't filter out
+      return matchesFilter(row, prop, filter);
+    }),
+  );
+}
+
+/**
+ * Check if a single row matches a single filter rule.
+ */
+function matchesFilter(
+  row: DatabaseRow,
+  prop: DatabaseProperty,
+  filter: FilterRule,
+): boolean {
+  const isComputed =
+    prop.type === "created_time" ||
+    prop.type === "updated_time" ||
+    prop.type === "created_by";
+
+  // Handle is_empty / is_not_empty for all types
+  if (filter.operator === "is_empty") {
+    if (isComputed) {
+      return getComputedValue(row, prop.type) === null;
+    }
+    return isEmpty(row.values[prop.id]);
+  }
+  if (filter.operator === "is_not_empty") {
+    if (isComputed) {
+      return getComputedValue(row, prop.type) !== null;
+    }
+    return !isEmpty(row.values[prop.id]);
+  }
+
+  // Computed properties
+  if (isComputed) {
+    const cv = getComputedValue(row, prop.type);
+    if (cv === null) return false;
+
+    if (prop.type === "created_by") {
+      return matchStringFilter(cv, filter);
+    }
+    // Date-based computed properties
+    return matchDateFilter(cv, filter);
+  }
+
+  const rv = row.values[prop.id];
+
+  switch (prop.type) {
+    case "text":
+    case "url":
+    case "email":
+    case "phone":
+    case "formula":
+      return matchStringFilter(extractString(rv), filter);
+
+    case "number":
+      return matchNumberFilter(extractNumber(rv), filter);
+
+    case "select":
+      return matchStringFilter(extractString(rv), filter);
+
+    case "multi_select":
+      return matchMultiSelectFilter(extractMultiSelectValues(rv), filter);
+
+    case "checkbox":
+      return matchCheckboxFilter(extractPrimitive(rv), filter);
+
+    case "date":
+      return matchDateFilter(extractDate(rv), filter);
+
+    case "person":
+      return matchStringFilter(extractString(rv), filter);
+
+    default:
+      return true;
+  }
+}
+
+function matchStringFilter(value: string, filter: FilterRule): boolean {
+  const filterVal = String(filter.value ?? "");
+  switch (filter.operator) {
+    case "contains":
+      return value.toLowerCase().includes(filterVal.toLowerCase());
+    case "equals":
+      return value.toLowerCase() === filterVal.toLowerCase();
+    default:
+      return true;
+  }
+}
+
+function matchNumberFilter(
+  value: number | null,
+  filter: FilterRule,
+): boolean {
+  if (value === null) return false;
+  const filterVal = Number(filter.value);
+  if (Number.isNaN(filterVal)) return false;
+
+  switch (filter.operator) {
+    case "equals":
+      return value === filterVal;
+    case "gt":
+      return value > filterVal;
+    case "lt":
+      return value < filterVal;
+    case "gte":
+      return value >= filterVal;
+    case "lte":
+      return value <= filterVal;
+    default:
+      return true;
+  }
+}
+
+function matchMultiSelectFilter(
+  values: string[],
+  filter: FilterRule,
+): boolean {
+  const filterVal = String(filter.value ?? "").toLowerCase();
+  switch (filter.operator) {
+    case "contains":
+      return values.some((v) => v.toLowerCase().includes(filterVal));
+    default:
+      return true;
+  }
+}
+
+function matchCheckboxFilter(
+  value: string | number | boolean | null,
+  filter: FilterRule,
+): boolean {
+  if (filter.operator !== "equals") return true;
+  // No value set → does not match either true or false
+  if (value === null) return false;
+  const expected =
+    filter.value === true ||
+    filter.value === "true" ||
+    filter.value === 1;
+  const actual = value === true;
+  return actual === expected;
+}
+
+function matchDateFilter(
+  value: string | null,
+  filter: FilterRule,
+): boolean {
+  if (value === null) return false;
+  const filterVal = String(filter.value ?? "");
+  if (!filterVal) return false;
+
+  switch (filter.operator) {
+    case "equals":
+      // Compare date portion only (YYYY-MM-DD)
+      return value.slice(0, 10) === filterVal.slice(0, 10);
+    case "before":
+      return value < filterVal;
+    case "after":
+      return value > filterVal;
+    default:
+      return true;
+  }
+}

--- a/src/lib/property-icons.ts
+++ b/src/lib/property-icons.ts
@@ -1,0 +1,40 @@
+// Shared mapping from PropertyType to lucide-react icon component.
+// Extracted so multiple database components can reuse it.
+
+import {
+  Calendar,
+  CheckSquare,
+  Clock,
+  FileText,
+  Hash,
+  Link as LinkIcon,
+  List,
+  Mail,
+  Phone,
+  Type,
+  User,
+  Users,
+} from "lucide-react";
+import type { PropertyType } from "@/lib/types";
+
+export const PROPERTY_TYPE_ICON: Record<
+  PropertyType,
+  React.ComponentType<{ className?: string }>
+> = {
+  text: Type,
+  number: Hash,
+  select: List,
+  multi_select: List,
+  checkbox: CheckSquare,
+  date: Calendar,
+  url: LinkIcon,
+  email: Mail,
+  phone: Phone,
+  person: User,
+  files: FileText,
+  relation: LinkIcon,
+  formula: Hash,
+  created_time: Clock,
+  updated_time: Clock,
+  created_by: Users,
+};


### PR DESCRIPTION
Closes #437

## What

Implements client-side sort and filter logic for database views, plus the filter bar UI and sort menu components. Sort and filter operate on loaded `DatabaseRow[]` as pure functions — no data fetching.

## How

### Sort engine (`src/lib/database-filters.ts`)
- `sortRows(rows, sorts, properties)` — sorts by multiple criteria in order
- Type-aware comparators: text (locale), number (numeric), select (alphabetical), multi-select (first option), checkbox (false < true), date (chronological), person (locale), computed properties (created_time, updated_time, created_by from page metadata)
- Null/empty values always sort last regardless of sort direction

### Filter engine (`src/lib/database-filters.ts`)
- `filterRows(rows, filters, properties)` — AND-combined filters
- Type-appropriate operators per property type (e.g., `gt`/`lt` only for numbers, `before`/`after` only for dates)
- `getOperatorsForType(type)` returns valid operators for a property type
- `operatorNeedsValue(op)` distinguishes `is_empty`/`is_not_empty` from value-requiring operators

### Filter bar UI (`src/components/database/filter-bar.tsx`)
- Active filters shown as `Badge` components with property name, operator, value
- Remove filter via X button on each badge
- Add filter flow: click `+ Add filter` → pick property → pick operator → enter value
- Positioned between view tabs and database grid per design spec

### Sort menu UI (`src/components/database/sort-menu.tsx`)
- Dropdown showing active sort rules with direction toggle and remove buttons
- Add sort by picking from available properties
- Sort count indicator on the button

### Table view integration
- Sort indicators (ArrowUp/ArrowDown) in column headers, visible on hover or when active
- `sorts` and `onSortToggle` props added to `TableViewProps`
- Extracted `PROPERTY_TYPE_ICON` to shared `src/lib/property-icons.ts` for reuse

## Testing

- 47 unit tests covering sort (12 tests) and filter (25 tests) logic plus utility functions (10 tests)
- All 600 existing tests pass
- Lint and typecheck clean (0 errors)
- Storybook stories for FilterBar (6 stories: empty, single filter, multiple filters, empty operators, many filters, interactive) and SortMenu (4 stories: no sorts, single, multiple, interactive)
- Visual regression baselines will be generated by CI (environment timeout prevented local generation)