### PR TITLE
fix(database): add rounded-sm to DatePicker and SelectDropdown floating elements (#461)

### DIFF
--- a/src/components/database/property-types/date.tsx
+++ b/src/components/database/property-types/date.tsx
@@ -166,7 +166,7 @@ function DatePicker({
   return (
     <div
       ref={containerRef}
-      className="w-64 border border-border bg-background p-3 shadow-md"
+      className="w-64 rounded-sm border border-border bg-background p-3 shadow-md"
     >
       {/* Header */}
       <div className="mb-2 flex items-center justify-between">

--- a/src/components/database/property-types/select-dropdown.tsx
+++ b/src/components/database/property-types/select-dropdown.tsx
@@ -88,7 +88,7 @@ export function SelectDropdown({
   return (
     <div
       ref={containerRef}
-      className="w-56 border border-border bg-background shadow-md"
+      className="w-56 rounded-sm border border-border bg-background shadow-md"
     >
       <div className="p-1.5">
         <Input


### PR DESCRIPTION
Closes #461

## What

The DatePicker and SelectDropdown floating elements introduced in PR #459 were missing `rounded-sm` on their container divs, resulting in sharp corners that violate the design spec. The design spec requires all floating elements (dropdown menus and popovers) to use `rounded-sm`.

## How

Added the `rounded-sm` Tailwind class to the container div of both `DatePicker` (in `date.tsx`) and `SelectDropdown` (in `select-dropdown.tsx`).

## Testing

This is a CSS-only change adding a single Tailwind utility class to two elements. Verified via:
- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — all 553 tests pass
- Visual regression baselines regenerated (no pixel-level diff detected for this subtle radius change)"