### PR TITLE
feat(database): relation property type — link rows across databases (#445)

### DIFF
--- a/src/components/database/property-types/index.ts
+++ b/src/components/database/property-types/index.ts
@@ -17,6 +17,7 @@ import {
   UpdatedTimeRenderer,
   CreatedByRenderer,
 } from "./computed";
+import { RelationRenderer, RelationEditor } from "./relation";
 
 // ---------------------------------------------------------------------------
 // Shared prop interfaces
@@ -96,11 +97,12 @@ const registry: Partial<Record<PropertyType, PropertyTypeConfig>> = {
   created_time: { Renderer: CreatedTimeRenderer, Editor: null },
   updated_time: { Renderer: UpdatedTimeRenderer, Editor: null },
   created_by: { Renderer: CreatedByRenderer, Editor: null },
+  relation: { Renderer: RelationRenderer, Editor: RelationEditor },
 };
 
 /**
  * Look up the renderer and editor for a property type.
- * Returns undefined for types not yet implemented (files, relation, formula).
+ * Returns undefined for types not yet implemented (files, formula).
  * Computed types (created_time, updated_time, created_by) have Editor: null.
  */
 export function getPropertyTypeConfig(

--- a/src/components/database/property-types/relation.stories.tsx
+++ b/src/components/database/property-types/relation.stories.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import type { DatabaseProperty } from "@/lib/types";
+import { RelationRenderer, RelationEditor } from "./relation";
+
+// ---------------------------------------------------------------------------
+// Mock property
+// ---------------------------------------------------------------------------
+
+const mockProperty: DatabaseProperty = {
+  id: "prop-relation-1",
+  database_id: "db-1",
+  name: "Related Tasks",
+  type: "relation",
+  config: { database_id: "target-db-1" },
+  position: 0,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const mockPropertyNoTarget: DatabaseProperty = {
+  ...mockProperty,
+  id: "prop-relation-no-target",
+  name: "Unconfigured Relation",
+  config: {},
+};
+
+// ---------------------------------------------------------------------------
+// Renderer stories
+// ---------------------------------------------------------------------------
+
+const rendererMeta: Meta<typeof RelationRenderer> = {
+  title: "Database/PropertyTypes/Relation/Renderer",
+  component: RelationRenderer,
+  decorators: [
+    (Story) => (
+      <div className="w-64 bg-background p-2">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Renders linked page pills for relation property values. " +
+          "In Storybook, pills show loading skeletons since Supabase is unavailable.",
+      },
+    },
+  },
+};
+
+export { rendererMeta as default };
+type RendererStory = StoryObj<typeof RelationRenderer>;
+
+export const SingleRelation: RendererStory = {
+  args: {
+    value: { page_ids: ["page-1"] },
+    property: mockProperty,
+  },
+};
+
+export const MultipleRelations: RendererStory = {
+  args: {
+    value: { page_ids: ["page-1", "page-2", "page-3"] },
+    property: mockProperty,
+  },
+};
+
+export const Empty: RendererStory = {
+  args: {
+    value: {},
+    property: mockProperty,
+  },
+};
+
+export const EmptyArray: RendererStory = {
+  args: {
+    value: { page_ids: [] },
+    property: mockProperty,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Editor stories
+// ---------------------------------------------------------------------------
+
+function EditorDemo() {
+  const [value, setValue] = useState<Record<string, unknown>>({
+    page_ids: ["page-1"],
+  });
+  return (
+    <div className="w-64 bg-background p-2">
+      <RelationEditor
+        value={value}
+        property={mockProperty}
+        onChange={setValue}
+        onBlur={fn()}
+      />
+    </div>
+  );
+}
+
+export const Editor: RendererStory = {
+  render: () => <EditorDemo />,
+};
+
+function EditorEmptyDemo() {
+  const [value, setValue] = useState<Record<string, unknown>>({});
+  return (
+    <div className="w-64 bg-background p-2">
+      <RelationEditor
+        value={value}
+        property={mockProperty}
+        onChange={setValue}
+        onBlur={fn()}
+      />
+    </div>
+  );
+}
+
+export const EditorEmpty: RendererStory = {
+  render: () => <EditorEmptyDemo />,
+};
+
+function EditorNoTargetDemo() {
+  const [value, setValue] = useState<Record<string, unknown>>({});
+  return (
+    <div className="w-64 bg-background p-2">
+      <RelationEditor
+        value={value}
+        property={mockPropertyNoTarget}
+        onChange={setValue}
+        onBlur={fn()}
+      />
+    </div>
+  );
+}
+
+export const EditorNoTarget: RendererStory = {
+  render: () => <EditorNoTargetDemo />,
+};

--- a/src/components/database/property-types/relation.tsx
+++ b/src/components/database/property-types/relation.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Check, FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import { getClient } from "@/lib/supabase/lazy-client";
+import type { RendererProps, EditorProps } from "./index";
+
+// ---------------------------------------------------------------------------
+// Value helpers
+// ---------------------------------------------------------------------------
+
+function getPageIds(value: Record<string, unknown>): string[] {
+  if (Array.isArray(value.page_ids)) {
+    return value.page_ids.filter(
+      (id): id is string => typeof id === "string",
+    );
+  }
+  return [];
+}
+
+function getTargetDatabaseId(
+  config: Record<string, unknown>,
+): string | null {
+  return typeof config.database_id === "string" ? config.database_id : null;
+}
+
+// ---------------------------------------------------------------------------
+// Linked page data
+// ---------------------------------------------------------------------------
+
+interface LinkedPage {
+  id: string;
+  title: string;
+  icon: string | null;
+  deleted?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// RelationPill — a single linked page pill (matches PageLinkNode styling)
+// ---------------------------------------------------------------------------
+
+function RelationPill({
+  page,
+  onClick,
+}: {
+  page: LinkedPage;
+  onClick?: (e: React.MouseEvent) => void;
+}) {
+  if (page.deleted) {
+    return (
+      <span className="inline-flex items-center gap-1 bg-muted px-2 py-0.5 text-xs text-muted-foreground line-through">
+        <FileText className="h-3 w-3 shrink-0" />
+        Deleted page
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex max-w-[160px] items-center gap-1 bg-muted px-2 py-0.5 text-xs text-foreground hover:bg-white/[0.08] cursor-pointer"
+      title={page.title}
+    >
+      {page.icon ? (
+        <span className="shrink-0 text-xs">{page.icon}</span>
+      ) : (
+        <FileText className="h-3 w-3 shrink-0 text-muted-foreground" />
+      )}
+      <span className="truncate underline decoration-muted-foreground/50 underline-offset-2">
+        {page.title || "Untitled"}
+      </span>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// useLinkedPages — resolve page IDs to page data
+// ---------------------------------------------------------------------------
+
+function useLinkedPages(pageIds: string[]): {
+  pages: LinkedPage[];
+  loading: boolean;
+} {
+  const idsKey = pageIds.join(",");
+  const hasIds = idsKey !== "";
+
+  // Start loading when there are IDs to resolve; avoids synchronous
+  // setState inside the effect body (react-hooks/set-state-in-effect).
+  const [pages, setPages] = useState<LinkedPage[]>([]);
+  const [loading, setLoading] = useState(hasIds);
+
+  useEffect(() => {
+    if (!hasIds) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const ids = idsKey.split(",");
+
+    async function resolve() {
+      const supabase = await getClient();
+      const { data, error } = await supabase
+        .from("pages")
+        .select("id, title, icon")
+        .in("id", ids);
+
+      if (cancelled) return;
+
+      if (error || !data) {
+        setPages(
+          ids.map((id) => ({ id, title: "", icon: null, deleted: true })),
+        );
+      } else {
+        const resolved = new Map(
+          data.map((p: { id: string; title: string; icon: string | null }) => [
+            p.id,
+            { id: p.id, title: p.title || "Untitled", icon: p.icon },
+          ]),
+        );
+        setPages(
+          ids.map(
+            (id) =>
+              resolved.get(id) ?? {
+                id,
+                title: "",
+                icon: null,
+                deleted: true,
+              },
+          ),
+        );
+      }
+      setLoading(false);
+    }
+
+    void resolve();
+    return () => {
+      cancelled = true;
+    };
+  }, [hasIds, idsKey]);
+
+  return { pages, loading };
+}
+
+// ---------------------------------------------------------------------------
+// RelationRenderer
+// ---------------------------------------------------------------------------
+
+export function RelationRenderer({ value }: RendererProps) {
+  const router = useRouter();
+  const params = useParams<{ workspaceSlug?: string }>();
+  const pageIds = getPageIds(value);
+  const { pages, loading } = useLinkedPages(pageIds);
+
+  if (pageIds.length === 0) return null;
+
+  if (loading) {
+    return (
+      <div className="flex flex-wrap gap-1">
+        {pageIds.map((id) => (
+          <span
+            key={id}
+            className="inline-flex items-center gap-1 bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+          >
+            <span className="inline-block h-3 w-12 animate-pulse bg-white/[0.08]" />
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  const handlePillClick = (pageId: string) => (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const slug = params.workspaceSlug ?? "";
+    router.push(`/${slug}/${pageId}`);
+  };
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {pages.map((page) => (
+        <RelationPill
+          key={page.id}
+          page={page}
+          onClick={page.deleted ? undefined : handlePillClick(page.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Target database row for the search dropdown
+// ---------------------------------------------------------------------------
+
+interface TargetRow {
+  id: string;
+  title: string;
+  icon: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// RelationEditor
+// ---------------------------------------------------------------------------
+
+export function RelationEditor({
+  value,
+  property,
+  onChange,
+  onBlur,
+}: EditorProps) {
+  const [query, setQuery] = useState("");
+  const [targetRows, setTargetRows] = useState<TargetRow[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedIds = getPageIds(value);
+  const targetDatabaseId = getTargetDatabaseId(property.config);
+
+  const hasTarget = targetDatabaseId !== null;
+
+  // Start loading when a target database is configured; avoids synchronous
+  // setState inside the effect body (react-hooks/set-state-in-effect).
+  const [loadingRows, setLoadingRows] = useState(hasTarget);
+
+  // Load rows from the target database
+  useEffect(() => {
+    if (!hasTarget || !targetDatabaseId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadTargetRows() {
+      const supabase = await getClient();
+      const { data, error } = await supabase
+        .from("pages")
+        .select("id, title, icon")
+        .eq("parent_id", targetDatabaseId)
+        .is("deleted_at", null)
+        .order("position");
+
+      if (cancelled) return;
+
+      if (error || !data) {
+        setTargetRows([]);
+      } else {
+        setTargetRows(
+          data.map(
+            (r: { id: string; title: string; icon: string | null }) => ({
+              id: r.id,
+              title: r.title || "Untitled",
+              icon: r.icon,
+            }),
+          ),
+        );
+      }
+      setLoadingRows(false);
+    }
+
+    void loadTargetRows();
+    return () => {
+      cancelled = true;
+    };
+  }, [hasTarget, targetDatabaseId]);
+
+  // Auto-focus the search input
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Close on click outside
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      const target = e.target;
+      if (
+        containerRef.current &&
+        target instanceof Node &&
+        !containerRef.current.contains(target)
+      ) {
+        onBlur();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [onBlur]);
+
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const trimmed = query.trim().toLowerCase();
+  const filtered = targetRows.filter((row) =>
+    row.title.toLowerCase().includes(trimmed),
+  );
+
+  const handleToggle = useCallback(
+    (rowId: string) => {
+      let newIds: string[];
+      if (selectedSet.has(rowId)) {
+        newIds = selectedIds.filter((id) => id !== rowId);
+      } else {
+        newIds = [...selectedIds, rowId];
+      }
+      onChange({ page_ids: newIds });
+    },
+    [selectedIds, selectedSet, onChange],
+  );
+
+  if (!targetDatabaseId) {
+    return (
+      <div className="w-56 border border-border bg-background p-3 shadow-md">
+        <p className="text-xs text-muted-foreground">
+          No target database configured for this relation property.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="w-56 border border-border bg-background shadow-md"
+    >
+      <div className="p-1.5">
+        <Input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              onBlur();
+            }
+          }}
+          placeholder="Search pages…"
+          className="h-7 text-xs"
+        />
+      </div>
+      <div className="max-h-48 overflow-y-auto px-1 pb-1">
+        {loadingRows ? (
+          <div className="space-y-1 px-2 py-1">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-5 animate-pulse bg-white/[0.06]"
+              />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <p className="px-2 py-1.5 text-xs text-muted-foreground">
+            {trimmed ? "No matching pages" : "No rows in target database"}
+          </p>
+        ) : (
+          filtered.map((row) => {
+            const isSelected = selectedSet.has(row.id);
+            return (
+              <button
+                key={row.id}
+                type="button"
+                onClick={() => handleToggle(row.id)}
+                className={cn(
+                  "flex w-full items-center gap-2 px-2 py-1 text-sm",
+                  "hover:bg-white/[0.04]",
+                )}
+              >
+                {row.icon ? (
+                  <span className="shrink-0 text-sm">{row.icon}</span>
+                ) : (
+                  <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                )}
+                <span className="flex-1 truncate text-left text-sm">
+                  {row.title}
+                </span>
+                {isSelected && (
+                  <Check className="ml-auto h-3.5 w-3.5 shrink-0 text-accent" />
+                )}
+              </button>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/database/property-types/relation.tsx
+++ b/src/components/database/property-types/relation.tsx
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Check, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+} from "@/lib/sentry";
 import { Input } from "@/components/ui/input";
 import { getClient } from "@/lib/supabase/lazy-client";
 import type { RendererProps, EditorProps } from "./index";
@@ -112,6 +116,9 @@ function useLinkedPages(pageIds: string[]): {
       if (cancelled) return;
 
       if (error || !data) {
+        if (error && !isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "relation-renderer:resolve-pages");
+        }
         setPages(
           ids.map((id) => ({ id, title: "", icon: null, deleted: true })),
         );
@@ -246,6 +253,9 @@ export function RelationEditor({
       if (cancelled) return;
 
       if (error || !data) {
+        if (error && !isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "relation-editor:load-target-rows");
+        }
         setTargetRows([]);
       } else {
         setTargetRows(


### PR DESCRIPTION
Closes #445

## What

Implements the relation property type that links rows in one database to rows in another database. The renderer shows linked page pills (matching `PageLinkNode` styling), and the editor provides a searchable dropdown of rows in the target database.

## How

**New files:**
- `src/components/database/property-types/relation.tsx` — `RelationRenderer` and `RelationEditor` components
- `src/components/database/property-types/relation.stories.tsx` — Storybook stories covering single, multiple, empty, editor, and unconfigured states

**Modified files:**
- `src/components/database/property-types/index.ts` — registered `relation` in the property type registry

**Renderer (`RelationRenderer`):**
- Resolves page IDs to page data (title, icon) via `useLinkedPages` hook using the lazy Supabase client
- Renders clickable pills with page icon + truncated title, matching `PageLinkNode` styling
- Deleted/orphaned pages render with strikethrough "Deleted page" styling
- Loading state shows animated pulse skeletons
- Clicking a pill navigates to `/${workspaceSlug}/${pageId}`

**Editor (`RelationEditor`):**
- Loads all rows from the target database (configured via `config.database_id`)
- Searchable dropdown filters by row title
- Click to toggle add/remove relations (checkmark indicates selected)
- Shows page icon + title for each option
- Handles unconfigured state with a message prompt
- Closes on Escape or click outside

**Value schema:** `{ page_ids: ["uuid1", "uuid2"] }`
**Config schema:** `{ database_id: "uuid" }` — the target database page ID

## Testing

- ✅ `pnpm lint` — 0 errors (17 pre-existing warnings)
- ✅ `pnpm typecheck` — passes
- ✅ `pnpm test` — all 553 tests pass
- Storybook stories render correctly (7 stories covering renderer and editor states)
- Visual regression baselines for new stories will be generated on first CI run with `--update-snapshots`
- E2E tests not added — this is a property type component without new pages or interactive flows requiring browser-level testing