### PR TITLE
fix: remove rounded border-radius from PersonEditor skeleton bars (#476)

### DIFF
--- a/src/components/database/property-types/person-skeleton-design-spec.test.ts
+++ b/src/components/database/property-types/person-skeleton-design-spec.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression test for issue #476: skeleton text bars in PersonEditor
+ * used `rounded` (4px border-radius) instead of sharp corners.
+ *
+ * Design spec: sharp corners by default. Only dropdown menus/popovers,
+ * toasts, and code blocks may use `rounded-sm`. Skeleton bars are not
+ * in the exception list.
+ */
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+describe("PersonEditor skeleton design spec compliance", () => {
+  const source = readSource("./person.tsx");
+
+  it("skeleton text bars do not use border-radius", () => {
+    // Extract lines that are skeleton text bars (animate-pulse bg-muted,
+    // but NOT rounded-full which is correct for avatar circles).
+    const skeletonLines = source
+      .split("\n")
+      .filter(
+        (line) =>
+          line.includes("animate-pulse") &&
+          line.includes("bg-muted") &&
+          !line.includes("rounded-full"),
+      );
+
+    for (const line of skeletonLines) {
+      // Should not contain `rounded` (standalone class, not rounded-full or rounded-sm on exceptions)
+      expect(line).not.toMatch(/\brounded\b(?!-)/);
+    }
+  });
+});

--- a/src/components/database/property-types/person.tsx
+++ b/src/components/database/property-types/person.tsx
@@ -287,8 +287,8 @@ export function PersonEditor({
             <div key={i} className="flex items-center gap-2 px-2 py-1.5">
               <span className="size-5 shrink-0 animate-pulse rounded-full bg-muted" />
               <div className="flex min-w-0 flex-1 flex-col gap-1">
-                <span className="h-3 w-24 animate-pulse rounded bg-muted" />
-                <span className="h-2.5 w-32 animate-pulse rounded bg-muted" />
+                <span className="h-3 w-24 animate-pulse bg-muted" />
+                <span className="h-2.5 w-32 animate-pulse bg-muted" />
               </div>
             </div>
           ))}


### PR DESCRIPTION
Closes #476

## What
The skeleton text bars in the `PersonEditor` loading state used the `rounded` class (4px border-radius), violating the design spec which requires sharp corners by default. Skeleton bars are not in the exception list for rounded corners.

## How
Removed the `rounded` class from the two skeleton `<span>` elements on lines 290–291 of `person.tsx`. The circular avatar skeleton (`rounded-full`) is correct and was left unchanged.

## Testing
Added a static analysis regression test (`person-skeleton-design-spec.test.ts`) that scans the source for skeleton text bars using `animate-pulse bg-muted` (excluding `rounded-full` avatar skeletons) and asserts none use the standalone `rounded` class. All 602 tests pass.