### PR TITLE
fix(editor): use captureSupabaseError for save errors to classify transient network failures

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -207,6 +207,25 @@ cause wrapped in `error.cause` — look for `ECONNRESET`, `ENOTFOUND`, `ETIMEDOU
 `UND_ERR_SOCKET` in the cause message. Always check the `cause` chain for
 server-side fetch errors, not just the top-level message.
 
+### Always use `captureSupabaseError` for Supabase errors
+
+Never call `lazyCaptureException` or `Sentry.captureException` directly for errors
+originating from Supabase queries or mutations. Always use `captureSupabaseError`
+which classifies transient network errors, schema-not-found errors, and RLS
+violations at warning level. Direct capture bypasses this classification and floods
+Sentry with error-level noise for non-application-bugs.
+
+```typescript
+// ✅ Correct — uses captureSupabaseError
+captureSupabaseError(error, "editor:save");
+
+// ❌ Wrong — bypasses error classification
+lazyCaptureException(error);
+```
+
+Reserve `lazyCaptureException` for non-Supabase errors (e.g. Lexical editor
+framework errors, unexpected runtime exceptions).
+
 ### Retrying transient network errors
 
 Client-side Supabase queries that run on page load (e.g. workspace lookup, page

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -32,6 +32,7 @@ import type {
   SerializedEditorState,
 } from "lexical";
 import { lazyCaptureException } from "@/lib/capture";
+import { captureSupabaseError, isInsufficientPrivilegeError } from "@/lib/sentry";
 import { editorTheme } from "@/components/editor/theme";
 import { SlashCommandPlugin } from "@/components/editor/slash-command-plugin";
 import { FloatingToolbarPlugin } from "@/components/editor/floating-toolbar-plugin";
@@ -252,7 +253,7 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
           // Sync page_links in the background after successful save
           const linkedPageIds = extractPageLinkIds(pendingJson);
           syncPageLinks(pageId, workspaceId, linkedPageIds).catch((err) =>
-            lazyCaptureException(err),
+            captureSupabaseError(err, "editor:sync-page-links"),
           );
 
           // Save a version snapshot at intervals (every 5 minutes).
@@ -273,7 +274,9 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
             });
           }
         } else {
-          lazyCaptureException(error);
+          if (!isInsufficientPrivilegeError(error)) {
+            captureSupabaseError(error, "editor:save");
+          }
           setSaveStatus("error");
         }
       };

--- a/src/components/editor/save-error-handling.test.ts
+++ b/src/components/editor/save-error-handling.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for #485 / Sentry MEMO-E: editor save errors must use
+ * captureSupabaseError (not lazyCaptureException) so transient network
+ * errors are classified at warning level instead of error level.
+ */
+describe("editor save error handling", () => {
+  const editorSource = readFileSync(
+    join(__dirname, "editor.tsx"),
+    "utf-8",
+  );
+
+  it("imports captureSupabaseError and isInsufficientPrivilegeError from @/lib/sentry", () => {
+    expect(editorSource).toContain("captureSupabaseError");
+    expect(editorSource).toContain("isInsufficientPrivilegeError");
+    expect(editorSource).toMatch(
+      /import\s*\{[^}]*captureSupabaseError[^}]*\}\s*from\s*["']@\/lib\/sentry["']/,
+    );
+  });
+
+  it("uses captureSupabaseError for the page save error path", () => {
+    // The save error path should call captureSupabaseError with "editor:save"
+    expect(editorSource).toContain(
+      'captureSupabaseError(error, "editor:save")',
+    );
+  });
+
+  it("uses captureSupabaseError for the syncPageLinks error path", () => {
+    // The page links sync catch should use captureSupabaseError
+    expect(editorSource).toContain(
+      'captureSupabaseError(err, "editor:sync-page-links")',
+    );
+  });
+
+  it("guards RLS violations before captureSupabaseError in the save path", () => {
+    // The save error path should check isInsufficientPrivilegeError before
+    // calling captureSupabaseError, so expected RLS rejections are not reported.
+    expect(editorSource).toContain("isInsufficientPrivilegeError(error)");
+  });
+
+  it("does not use lazyCaptureException for Supabase errors", () => {
+    // lazyCaptureException should only appear for the Lexical onError handler,
+    // not for any Supabase error path. Extract all lazyCaptureException calls
+    // and verify none are in Supabase error contexts.
+    const lines = editorSource.split("\n");
+    const lazyCalls = lines
+      .map((line, i) => ({ line: line.trim(), lineNum: i + 1 }))
+      .filter(
+        ({ line }) =>
+          line.includes("lazyCaptureException(") &&
+          !line.startsWith("import") &&
+          !line.startsWith("//"),
+      );
+
+    // Only the Lexical onError handler should use lazyCaptureException
+    for (const { line } of lazyCalls) {
+      expect(line).not.toContain("editor:save");
+      expect(line).not.toContain("editor:sync");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Editor save errors were reported to Sentry at error level instead of warning level for transient network failures, flooding Sentry with 1841 events from 25 users.

**Sentry issue:** https://ona-2j.sentry.io/issues/MEMO-E

Closes #485

## Root Cause

The editor's `doSave` error path and `syncPageLinks` catch handler called `lazyCaptureException(error)` directly, bypassing `captureSupabaseError` which classifies transient network errors (`TypeError: Failed to fetch`), schema-not-found errors, and RLS violations at warning level.

When a Supabase PATCH to the `pages` table failed with a transient network error, the error object (with `details: "TypeError: Failed to fetch"`) was sent to Sentry at error level because `lazyCaptureException` has no error classification logic.

## Changes

- **`src/components/editor/editor.tsx`**: Replace `lazyCaptureException` with `captureSupabaseError` for the save error path (`"editor:save"`) and syncPageLinks catch (`"editor:sync-page-links"`). Add `isInsufficientPrivilegeError` guard so expected RLS rejections on save are not reported to Sentry at all.
- **`src/components/editor/save-error-handling.test.ts`**: Regression test verifying the correct error handling functions are used (static source analysis, consistent with existing `version-save-error-handling.test.ts`).
- **`.agents/conventions.md`**: Document convention that all Supabase error paths must use `captureSupabaseError`, never `lazyCaptureException` directly.

## Verification

- `pnpm lint` — 0 errors (22 pre-existing warnings)
- `pnpm typecheck` — clean
- `pnpm test` — 63 files, 607 tests pass