### PR TITLE
fix(sentry): detect Supabase-wrapped "TypeError: fetch failed" in isTransientNetworkError

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -202,10 +202,13 @@ Browser-style messages: `TypeError: Failed to fetch`, `Failed to fetch`,
 `Load failed`, `NetworkError when attempting to fetch resource.`,
 `The Internet connection appears to be offline.`, `Network request failed`.
 
-Node.js native fetch (undici) messages: `fetch failed` (top-level), with the real
-cause wrapped in `error.cause` — look for `ECONNRESET`, `ENOTFOUND`, `ETIMEDOUT`,
-`UND_ERR_SOCKET` in the cause message. Always check the `cause` chain for
-server-side fetch errors, not just the top-level message.
+Node.js native fetch (undici) messages: `fetch failed` or `TypeError: fetch failed`
+(top-level), with the real cause wrapped in `error.cause` — look for `ECONNRESET`,
+`ENOTFOUND`, `ETIMEDOUT`, `UND_ERR_SOCKET` in the cause message. When Supabase
+wraps a Node.js fetch error as a PostgrestError, the message becomes
+`"TypeError: fetch failed"` and the cause chain (ECONNRESET etc.) is embedded in
+the `details` string rather than `error.cause`. Always check both `error.cause`
+and `details` for server-side fetch errors, not just the top-level message.
 
 ### Always use `captureSupabaseError` for Supabase errors
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -154,6 +154,10 @@ const NODE_FETCH_CAUSE_PATTERNS = [
  * Checks both browser-style fetch errors (top-level message) and Node.js
  * native fetch errors (undici), which use `"fetch failed"` as the message
  * and wrap the real cause (ECONNRESET, ENOTFOUND, etc.) in `error.cause`.
+ *
+ * When Supabase wraps a Node.js fetch error as a PostgrestError, the message
+ * becomes `"TypeError: fetch failed"` and the cause chain (ECONNRESET etc.)
+ * is embedded in the `details` string rather than `error.cause`.
  */
 export function isTransientNetworkError(error: Error): boolean {
   const msg = error.message;
@@ -172,8 +176,14 @@ export function isTransientNetworkError(error: Error): boolean {
     return true;
   }
 
-  // Node.js native fetch (undici): top-level message is "fetch failed"
-  if (msg === "fetch failed") {
+  // Node.js native fetch (undici): message is "fetch failed" or
+  // "TypeError: fetch failed" (when Supabase wraps the error)
+  if (msg === "fetch failed" || msg === "TypeError: fetch failed") {
+    return true;
+  }
+
+  // Supabase may embed "TypeError: fetch failed" in the details field
+  if (details.includes("TypeError: fetch failed")) {
     return true;
   }
 
@@ -182,6 +192,14 @@ export function isTransientNetworkError(error: Error): boolean {
   if (
     causeMsg &&
     NODE_FETCH_CAUSE_PATTERNS.some((pattern) => causeMsg.includes(pattern))
+  ) {
+    return true;
+  }
+
+  // Supabase PostgrestErrors embed the cause chain in the details string
+  if (
+    details &&
+    NODE_FETCH_CAUSE_PATTERNS.some((pattern) => details.includes(pattern))
   ) {
     return true;
   }

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -117,6 +117,45 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("detects 'TypeError: fetch failed' message (Supabase-wrapped Node.js fetch)", () => {
+    const error = new Error("TypeError: fetch failed");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'TypeError: fetch failed' in PostgrestError message", () => {
+    const error = makePostgrestError({
+      message: "TypeError: fetch failed",
+      details:
+        "TypeError: fetch failed\n\nCaused by: Error: Client network socket disconnected before secure TLS connection was established (ECONNRESET)",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects ECONNRESET in PostgrestError details (Supabase cause chain)", () => {
+    const error = makePostgrestError({
+      message: "some wrapper message",
+      details:
+        "TypeError: fetch failed\n\nCaused by: Error: connect ECONNRESET 10.0.0.1:443",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects ENOTFOUND in PostgrestError details", () => {
+    const error = makePostgrestError({
+      message: "some wrapper message",
+      details: "getaddrinfo ENOTFOUND db.example.com",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects ETIMEDOUT in PostgrestError details", () => {
+    const error = makePostgrestError({
+      message: "some wrapper message",
+      details: "connect ETIMEDOUT 10.0.0.1:443",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns false when cause is not an Error instance", () => {
     const error = new Error("some error", { cause: "string cause" });
     expect(isTransientNetworkError(error)).toBe(false);


### PR DESCRIPTION
## Summary

Fixes a regression in MEMO-15 where Supabase-wrapped Node.js fetch errors bypass `isTransientNetworkError` and are reported at error level instead of warning level.

Sentry issue: https://ona-2j.sentry.io/issues/MEMO-15 (regressed, 2 events, 2 users)

Closes #489

## Root Cause

The previous fix (#430) added `msg === \"fetch failed\"` for Node.js native fetch errors and `error.cause` inspection for the underlying network error. However, when Supabase wraps a Node.js fetch error as a PostgrestError, two things differ:

1. **Message**: becomes `\"TypeError: fetch failed\"` (with `TypeError:` prefix), not `\"fetch failed\"`
2. **Cause chain**: embedded in the `details` string (e.g. `\"TypeError: fetch failed\\n\\nCaused by: Error: ...ECONNRESET...\"`), not in `error.cause`

Production error shape:
```json
{
  \"message\": \"TypeError: fetch failed\",
  \"code\": \"\",
  \"details\": \"TypeError: fetch failed\\n\\nCaused by: Error: Client network socket disconnected before secure TLS connection was established (ECONNRESET)\",
  \"hint\": \"\"
}
```

## Changes

- **`src/lib/sentry.ts`**: Add `\"TypeError: fetch failed\"` to message checks, check `details` for both `\"TypeError: fetch failed\"` substring and `NODE_FETCH_CAUSE_PATTERNS` (ECONNRESET, ENOTFOUND, ETIMEDOUT, UND_ERR_SOCKET)
- **`src/lib/sentry.unit.test.ts`**: 5 new regression tests covering the exact error shapes from production (Supabase-wrapped message, PostgrestError with cause in details)
- **`.agents/conventions.md`**: Document that Supabase wraps Node.js fetch errors differently — check both `error.cause` and `details`

## Verification

- `pnpm lint` ✅ (0 errors)
- `pnpm typecheck` ✅
- `pnpm test` ✅ (612 tests, 63 files, including 61 sentry unit tests)"}
</invoke>