### PR TITLE
fix: use shadcn ContextMenu and rounded-sm in view tabs (#483)

### DIFF
--- a/src/components/database/view-tabs.tsx
+++ b/src/components/database/view-tabs.tsx
@@ -27,6 +27,13 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -114,15 +121,6 @@ export function ViewTabs({
   const [dragViewId, setDragViewId] = useState<string | null>(null);
   const [dropTargetIndex, setDropTargetIndex] = useState<number | null>(null);
 
-  // Context menu state (right-click positioned menu)
-  const [contextMenuViewId, setContextMenuViewId] = useState<string | null>(null);
-  const [contextMenuOpen, setContextMenuOpen] = useState(false);
-  const [contextMenuPosition, setContextMenuPosition] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
-  const contextMenuRef = useRef<HTMLDivElement>(null);
-
   // Focus rename input when entering rename mode
   useEffect(() => {
     if (renamingViewId && renameInputRef.current) {
@@ -130,23 +128,6 @@ export function ViewTabs({
       renameInputRef.current.select();
     }
   }, [renamingViewId]);
-
-  // Close context menu on outside click
-  useEffect(() => {
-    if (!contextMenuOpen) return;
-
-    function handleClick(e: MouseEvent) {
-      if (
-        contextMenuRef.current &&
-        e.target instanceof Node &&
-        !contextMenuRef.current.contains(e.target)
-      ) {
-        setContextMenuOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [contextMenuOpen]);
 
   // ---------------------------------------------------------------------------
   // Tab click
@@ -171,7 +152,6 @@ export function ViewTabs({
       if (!view) return;
       setRenamingViewId(viewId);
       setRenameValue(view.name);
-      setContextMenuOpen(false);
     },
     [views],
   );
@@ -215,37 +195,24 @@ export function ViewTabs({
   );
 
   // ---------------------------------------------------------------------------
-  // Context menu (right-click)
+  // Context menu actions
   // ---------------------------------------------------------------------------
 
-  const handleContextMenu = useCallback(
-    (e: React.MouseEvent, viewId: string) => {
-      e.preventDefault();
-      setContextMenuViewId(viewId);
-      setContextMenuPosition({ x: e.clientX, y: e.clientY });
-      setContextMenuOpen(true);
-    },
-    [],
-  );
-
   const handleContextMenuAction = useCallback(
-    (action: "rename" | "duplicate" | "delete") => {
-      if (!contextMenuViewId) return;
-      setContextMenuOpen(false);
-
+    (viewId: string, action: "rename" | "duplicate" | "delete") => {
       switch (action) {
         case "rename":
-          startRename(contextMenuViewId);
+          startRename(viewId);
           break;
         case "duplicate":
-          onDuplicateView?.(contextMenuViewId);
+          onDuplicateView?.(viewId);
           break;
         case "delete":
-          setDeleteViewId(contextMenuViewId);
+          setDeleteViewId(viewId);
           break;
       }
     },
-    [contextMenuViewId, startRename, onDuplicateView],
+    [startRename, onDuplicateView],
   );
 
   // ---------------------------------------------------------------------------
@@ -340,56 +307,94 @@ export function ViewTabs({
               dropTargetIndex === index && dragViewId !== null;
 
             return (
-              <div
-                key={view.id}
-                className="relative flex items-center"
-                draggable={
-                  onReorderViews !== undefined && renamingViewId === null
-                }
-                onDragStart={(e) => handleDragStart(e, view.id)}
-                onDragOver={(e) => handleDragOver(e, index)}
-                onDragLeave={handleDragLeave}
-                onDrop={(e) => handleDrop(e, index)}
-                onDragEnd={handleDragEnd}
-              >
-                {/* Drop indicator — left edge */}
-                {showDropIndicator && (
-                  <div className="absolute left-0 top-1 bottom-1 z-10 w-0.5 bg-accent" />
-                )}
-
-                <button
-                  type="button"
-                  onClick={() => handleTabClick(view.id)}
-                  onDoubleClick={() => handleDoubleClick(view.id)}
-                  onContextMenu={(e) => handleContextMenu(e, view.id)}
-                  className={cn(
-                    "group/tab flex shrink-0 items-center gap-1.5 px-3 py-2 text-sm transition-colors",
-                    isActive
-                      ? "border-b-2 border-accent text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                    isDragging && "opacity-50",
-                  )}
+              <ContextMenu key={view.id}>
+                <ContextMenuTrigger
+                  className="relative flex items-center"
+                  draggable={
+                    onReorderViews !== undefined && renamingViewId === null
+                  }
+                  onDragStart={(e) => handleDragStart(e, view.id)}
+                  onDragOver={(e) => handleDragOver(e, index)}
+                  onDragLeave={handleDragLeave}
+                  onDrop={(e) => handleDrop(e, index)}
+                  onDragEnd={handleDragEnd}
                 >
-                  {onReorderViews && (
-                    <GripVertical className="h-3 w-3 shrink-0 cursor-grab opacity-0 transition-opacity group-hover/tab:opacity-50" />
-                  )}
-                  <Icon className="h-3.5 w-3.5 shrink-0" />
-                  {renamingViewId === view.id ? (
-                    <input
-                      ref={renameInputRef}
-                      type="text"
-                      value={renameValue}
-                      onChange={(e) => setRenameValue(e.target.value)}
-                      onKeyDown={handleRenameKeyDown}
-                      onBlur={confirmRename}
-                      className="w-24 bg-transparent text-sm outline-none border-b border-accent"
-                      aria-label="Rename view"
-                    />
+                    {/* Drop indicator — left edge */}
+                    {showDropIndicator && (
+                      <div className="absolute left-0 top-1 bottom-1 z-10 w-0.5 bg-accent" />
+                    )}
+
+                    <button
+                      type="button"
+                      onClick={() => handleTabClick(view.id)}
+                      onDoubleClick={() => handleDoubleClick(view.id)}
+                      className={cn(
+                        "group/tab flex shrink-0 items-center gap-1.5 px-3 py-2 text-sm transition-colors",
+                        isActive
+                          ? "border-b-2 border-accent text-foreground"
+                          : "text-muted-foreground hover:text-foreground",
+                        isDragging && "opacity-50",
+                      )}
+                    >
+                      {onReorderViews && (
+                        <GripVertical className="h-3 w-3 shrink-0 cursor-grab opacity-0 transition-opacity group-hover/tab:opacity-50" />
+                      )}
+                      <Icon className="h-3.5 w-3.5 shrink-0" />
+                      {renamingViewId === view.id ? (
+                        <input
+                          ref={renameInputRef}
+                          type="text"
+                          value={renameValue}
+                          onChange={(e) => setRenameValue(e.target.value)}
+                          onKeyDown={handleRenameKeyDown}
+                          onBlur={confirmRename}
+                          className="w-24 bg-transparent text-sm outline-none border-b border-accent"
+                          aria-label="Rename view"
+                        />
+                      ) : (
+                        <span>{view.name}</span>
+                      )}
+                    </button>
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem
+                    onSelect={() =>
+                      handleContextMenuAction(view.id, "rename")
+                    }
+                  >
+                    <Pencil className="h-4 w-4" />
+                    <span>Rename</span>
+                  </ContextMenuItem>
+                  <ContextMenuItem
+                    onSelect={() =>
+                      handleContextMenuAction(view.id, "duplicate")
+                    }
+                  >
+                    <Copy className="h-4 w-4" />
+                    <span>Duplicate</span>
+                  </ContextMenuItem>
+                  <ContextMenuSeparator />
+                  {isLastView ? (
+                    <ContextMenuItem
+                      disabled
+                      variant="destructive"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span>Delete view</span>
+                    </ContextMenuItem>
                   ) : (
-                    <span>{view.name}</span>
+                    <ContextMenuItem
+                      variant="destructive"
+                      onSelect={() =>
+                        handleContextMenuAction(view.id, "delete")
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      <span>Delete view</span>
+                    </ContextMenuItem>
                   )}
-                </button>
-              </div>
+                </ContextMenuContent>
+              </ContextMenu>
             );
           })}
 
@@ -437,56 +442,6 @@ export function ViewTabs({
           </DropdownMenu>
         )}
       </div>
-
-      {/* Right-click context menu — positioned absolutely */}
-      {contextMenuOpen && contextMenuPosition && contextMenuViewId && (
-        <div
-          ref={contextMenuRef}
-          className="fixed z-50 min-w-32 rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10"
-          style={{
-            left: contextMenuPosition.x,
-            top: contextMenuPosition.y,
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => handleContextMenuAction("rename")}
-            className="flex w-full cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground"
-          >
-            <Pencil className="h-4 w-4" />
-            <span>Rename</span>
-          </button>
-          <button
-            type="button"
-            onClick={() => handleContextMenuAction("duplicate")}
-            className="flex w-full cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground"
-          >
-            <Copy className="h-4 w-4" />
-            <span>Duplicate</span>
-          </button>
-          <div className="-mx-1 my-1 h-px bg-border" />
-          {isLastView ? (
-            <button
-              type="button"
-              disabled
-              title="Cannot delete the last view"
-              className="flex w-full cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none opacity-50 text-destructive"
-            >
-              <Trash2 className="h-4 w-4" />
-              <span>Delete view</span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => handleContextMenuAction("delete")}
-              className="flex w-full cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none text-destructive hover:bg-destructive/10"
-            >
-              <Trash2 className="h-4 w-4" />
-              <span>Delete view</span>
-            </button>
-          )}
-        </div>
-      )}
 
       {/* Delete confirmation dialog */}
       <AlertDialog

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,271 @@
+"use client"
+
+import * as React from "react"
+import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
+
+function ContextMenuPortal({ ...props }: ContextMenuPrimitive.Portal.Props) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  )
+}
+
+function ContextMenuTrigger({
+  className,
+  ...props
+}: ContextMenuPrimitive.Trigger.Props) {
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      className={cn("select-none", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuContent({
+  className,
+  align = "start",
+  alignOffset = 4,
+  side = "right",
+  sideOffset = 0,
+  ...props
+}: ContextMenuPrimitive.Popup.Props &
+  Pick<
+    ContextMenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <ContextMenuPrimitive.Popup
+          data-slot="context-menu-content"
+          className={cn("z-50 max-h-(--available-height) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-sm bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </ContextMenuPrimitive.Positioner>
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuGroup({ ...props }: ContextMenuPrimitive.Group.Props) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  )
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: ContextMenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.GroupLabel
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: ContextMenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/context-menu-item relative flex cursor-default items-center gap-1.5 rounded-sm px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuSub({ ...props }: ContextMenuPrimitive.SubmenuRoot.Props) {
+  return (
+    <ContextMenuPrimitive.SubmenuRoot data-slot="context-menu-sub" {...props} />
+  )
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: ContextMenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.SubmenuTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-sm px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function ContextMenuSubContent({
+  ...props
+}: React.ComponentProps<typeof ContextMenuContent>) {
+  return (
+    <ContextMenuContent
+      data-slot="context-menu-sub-content"
+      className="shadow-lg"
+      side="right"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: ContextMenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-sm py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </ContextMenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  )
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: ContextMenuPrimitive.RadioGroup.Props) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: ContextMenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-sm py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </ContextMenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  )
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: ContextMenuPrimitive.Separator.Props) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}


### PR DESCRIPTION
Closes #483

## What

The view tabs context menu (right-click on a tab) was built as a custom positioned `<div>` with manual outside-click handling, manual positioning, and custom button elements. It also used `rounded-lg` on the container and `rounded-md` on menu items, violating the design spec which requires `rounded-sm` for floating elements.

## How

- Installed the shadcn `ContextMenu` component (`@base-ui/react` context menu primitive).
- Replaced the custom context menu implementation in `view-tabs.tsx` with shadcn `ContextMenu`, `ContextMenuTrigger`, `ContextMenuContent`, `ContextMenuItem`, and `ContextMenuSeparator`. This provides proper positioning, keyboard navigation, focus management, and outside-click dismissal automatically.
- Fixed all border-radius values in the new `context-menu.tsx` component from `rounded-lg`/`rounded-md` to `rounded-sm` to match the design spec's floating element exception.
- Removed ~60 lines of manual state management (context menu position, open state, outside-click effect, ref).

## Testing

- `pnpm typecheck` — passes
- `pnpm lint` — no new warnings
- `pnpm test` — all 607 tests pass across 63 test files
- Existing Storybook stories unaffected (context menu is interactive, not rendered in static screenshots)