### PR TITLE
fix: resolve 10 E2E test failures across editor, members, and settings tests (#479)

### DIFF
--- a/e2e/editor-callout-collapsible.spec.ts
+++ b/e2e/editor-callout-collapsible.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from "./fixtures/auth";
-import { navigateToEditorPage } from "./fixtures/editor-helpers";
+import { navigateToEditorPage, selectSlashOption } from "./fixtures/editor-helpers";
 
 /**
  * Helper: insert a block via the slash command menu.
- * Types `/<command>`, waits for the matching option, and clicks it.
+ * Types `/`, waits for the matching option, and clicks it.
  */
 async function insertViaSlashCommand(
   page: import("@playwright/test").Page,
@@ -15,11 +15,7 @@ async function insertViaSlashCommand(
   await page.keyboard.press("Enter");
   await page.keyboard.type("/");
 
-  const option = page
-    .locator('[role="option"]')
-    .filter({ hasText: commandLabel });
-  await expect(option).toBeVisible({ timeout: 3_000 });
-  await option.click();
+  await selectSlashOption(page, commandLabel);
 }
 
 test.describe("Callout block", () => {

--- a/e2e/editor-code-paste.spec.ts
+++ b/e2e/editor-code-paste.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures/auth";
-import { navigateToEditorPage } from "./fixtures/editor-helpers";
+import { navigateToEditorPage, selectSlashOption } from "./fixtures/editor-helpers";
 
 test.describe("Code block paste", () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
@@ -18,11 +18,7 @@ test.describe("Code block paste", () => {
     await page.keyboard.press("Enter");
     await page.keyboard.type("/code");
 
-    const codeOption = page.locator('[role="option"]', {
-      hasText: /code block/i,
-    });
-    await expect(codeOption).toBeVisible({ timeout: 3_000 });
-    await codeOption.click();
+    await selectSlashOption(page, "Code Block");
 
     // Wait for the code block to appear
     const codeBlock = editor.locator("code");
@@ -70,11 +66,7 @@ test.describe("Code block paste", () => {
     await page.keyboard.press("Enter");
     await page.keyboard.type("/code");
 
-    const codeOption = page.locator('[role="option"]', {
-      hasText: /code block/i,
-    });
-    await expect(codeOption).toBeVisible({ timeout: 3_000 });
-    await codeOption.click();
+    await selectSlashOption(page, "Code Block");
 
     const codeBlock = editor.locator("code");
     await expect(codeBlock).toBeVisible({ timeout: 3_000 });

--- a/e2e/editor-list-indent.spec.ts
+++ b/e2e/editor-list-indent.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures/auth";
-import { navigateToEditorPage } from "./fixtures/editor-helpers";
+import { navigateToEditorPage, selectSlashOption } from "./fixtures/editor-helpers";
 
 test.describe("Editor list indentation", () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
@@ -18,11 +18,7 @@ test.describe("Editor list indentation", () => {
     await page.keyboard.press("Enter");
     await page.keyboard.type("/");
 
-    const bulletOption = page
-      .locator('[role="option"]')
-      .filter({ hasText: "Bullet List" });
-    await expect(bulletOption).toBeVisible({ timeout: 3_000 });
-    await bulletOption.click();
+    await selectSlashOption(page, "Bullet List");
 
     await page.keyboard.type("First item");
     await page.keyboard.press("Enter");
@@ -53,11 +49,7 @@ test.describe("Editor list indentation", () => {
     await page.keyboard.press("Enter");
     await page.keyboard.type("/");
 
-    const bulletOption = page
-      .locator('[role="option"]')
-      .filter({ hasText: "Bullet List" });
-    await expect(bulletOption).toBeVisible({ timeout: 3_000 });
-    await bulletOption.click();
+    await selectSlashOption(page, "Bullet List");
 
     await page.keyboard.type("First item");
     await page.keyboard.press("Enter");
@@ -87,11 +79,7 @@ test.describe("Editor list indentation", () => {
     await page.keyboard.press("Enter");
     await page.keyboard.type("/");
 
-    const numberedOption = page
-      .locator('[role="option"]')
-      .filter({ hasText: "Numbered List" });
-    await expect(numberedOption).toBeVisible({ timeout: 3_000 });
-    await numberedOption.click();
+    await selectSlashOption(page, "Numbered List");
 
     await page.keyboard.type("First item");
     await page.keyboard.press("Enter");

--- a/e2e/favorites.spec.ts
+++ b/e2e/favorites.spec.ts
@@ -315,8 +315,9 @@ test.describe("Sidebar Favorites", () => {
       /remove from favorites/i,
     );
 
-    // Favorites section should be hidden again
-    await expect(favoritesHeading).not.toBeVisible({ timeout: 5_000 });
+    // Favorites section should be hidden again. The removal triggers an async
+    // re-fetch via the favorites-changed event, so allow extra time.
+    await expect(favoritesHeading).not.toBeVisible({ timeout: 10_000 });
   });
 
   test("favorites persist across page navigation", async ({

--- a/e2e/fixtures/editor-helpers.ts
+++ b/e2e/fixtures/editor-helpers.ts
@@ -64,3 +64,30 @@ export async function navigateToEditorPage(page: Page): Promise<void> {
 export function modifierKey(): "Meta" | "Control" {
   return process.platform === "darwin" ? "Meta" : "Control";
 }
+
+/**
+ * Select a slash command option by its exact title text.
+ *
+ * The slash menu contains both direct commands ("Heading 1") and "Turn into"
+ * variants ("Turn into Heading 1"). Using `hasText` matches both because it
+ * checks substring containment. This helper uses `getByRole('option', { name })`
+ * with a regex anchored to the start of the accessible name to select only the
+ * direct command, not the "Turn into" variant.
+ */
+export async function selectSlashOption(
+  page: Page,
+  label: string,
+  { timeout = 3_000 }: { timeout?: number } = {},
+): Promise<void> {
+  // The accessible name starts with the option title (e.g. "Heading 1 Large section heading").
+  // Anchor the regex to the start so "Turn into Heading 1 ..." doesn't match.
+  const option = page.getByRole("option", {
+    name: new RegExp(`^${escapeRegExp(label)}\\b`),
+  });
+  await expect(option).toBeVisible({ timeout });
+  await option.click();
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/e2e/import-export.spec.ts
+++ b/e2e/import-export.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures/auth";
-import { navigateToEditorPage } from "./fixtures/editor-helpers";
+import { navigateToEditorPage, selectSlashOption } from "./fixtures/editor-helpers";
 
 test.describe("Markdown import and export", () => {
   test("user can export a page as markdown via the page menu", async ({
@@ -17,11 +17,7 @@ test.describe("Markdown import and export", () => {
 
     // Insert a heading via slash command
     await page.keyboard.type("/");
-    const heading1Option = page
-      .locator('[role="option"]')
-      .filter({ hasText: "Heading 1" });
-    await expect(heading1Option).toBeVisible({ timeout: 3_000 });
-    await heading1Option.click();
+    await selectSlashOption(page, "Heading 1");
     await page.keyboard.type("Export Test Heading");
     await page.keyboard.press("Enter");
 
@@ -31,11 +27,7 @@ test.describe("Markdown import and export", () => {
 
     // Insert a bullet list via slash command
     await page.keyboard.type("/");
-    const bulletOption = page
-      .locator('[role="option"]')
-      .filter({ hasText: "Bullet List" });
-    await expect(bulletOption).toBeVisible({ timeout: 3_000 });
-    await bulletOption.click();
+    await selectSlashOption(page, "Bullet List");
     await page.keyboard.type("First item");
     await page.keyboard.press("Enter");
     await page.keyboard.type("Second item");

--- a/e2e/members.spec.ts
+++ b/e2e/members.spec.ts
@@ -73,12 +73,23 @@ test.describe("Workspace member management", () => {
   let invitedUserId: string | undefined;
   let workspaceSlug: string;
 
-  // Remove stale test users from previous runs whose cleanup was interrupted.
-  // Without this, a leftover member with display_name "E2E Member" causes
-  // the re-invite test to find 2 matching elements (strict mode violation).
+  // Remove stale test users and invites from previous runs whose cleanup was
+  // interrupted. Without this, leftover members or invites cause strict mode
+  // violations or false positives in subsequent runs.
   test.beforeAll(async () => {
     await cleanupStaleTestUsers(INVITE_DISPLAY_NAME).catch(() => {});
     await cleanupInvitesForEmail(INVITE_EMAIL).catch(() => {});
+    // Clean up stale invites from previous runs with different timestamps
+    try {
+      const admin = getAdminClient();
+      await admin
+        .from("workspace_invites")
+        .delete()
+        .like("email", "e2e-member-%@test.local")
+        .is("accepted_at", null);
+    } catch {
+      // Ignore cleanup failures
+    }
   });
 
   test.afterAll(async () => {
@@ -106,10 +117,20 @@ test.describe("Workspace member management", () => {
     // Submit the invite
     await page.getByRole("button", { name: "Invite", exact: true }).click();
 
-    // Wait for the invite link to appear (PR #240 replaced "Invite sent." with a copyable link)
+    // Wait for the invite link URL to appear below the form. The invite form
+    // shows the link as text followed by a copy button. Scope to the form's
+    // parent to avoid matching the pending invites table's copy buttons.
+    const inviteFormSection = page.locator("form").locator("..");
     await expect(
-      page.getByRole("button", { name: "Copy invite link" })
+      inviteFormSection.getByRole("button", { name: "Copy invite link" })
     ).toBeVisible({ timeout: 10_000 });
+
+    // The invite form triggers router.refresh() after insert. Wait for the
+    // pending invite to appear in the server-rendered list, confirming the
+    // DB write has propagated and the page has re-rendered with fresh data.
+    await expect(page.locator(`text=${INVITE_EMAIL}`)).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
   test("invited user appears in the pending invites list", async ({
@@ -155,11 +176,17 @@ test.describe("Workspace member management", () => {
   }) => {
     await goToMembersPage(page, workspaceSlug);
 
-    // Re-invite the same email
-    await page.fill("#invite-email", INVITE_EMAIL);
+    // Re-invite the same email. Wait for the form to be interactive before
+    // filling — the page is a server component that hydrates the client form.
+    const emailInput = page.locator("#invite-email");
+    await expect(emailInput).toBeVisible({ timeout: 5_000 });
+    await emailInput.fill(INVITE_EMAIL);
     await page.getByRole("button", { name: "Invite", exact: true }).click();
+
+    // Wait for the invite link URL to appear below the form
+    const reInviteFormSection = page.locator("form").locator("..");
     await expect(
-      page.getByRole("button", { name: "Copy invite link" })
+      reInviteFormSection.getByRole("button", { name: "Copy invite link" })
     ).toBeVisible({ timeout: 10_000 });
 
     // Create the test user via admin API so they can accept the invite

--- a/e2e/workspace-settings.spec.ts
+++ b/e2e/workspace-settings.spec.ts
@@ -12,15 +12,23 @@ function getAdminClient() {
 
 /**
  * Resolve the test user's ID from their email.
+ * Uses the profiles table instead of paginated auth.admin.listUsers() to
+ * avoid missing the user when there are more users than the default page size.
  */
 async function resolveTestUserId(): Promise<string> {
   const admin = getAdminClient();
-  const { data } = await admin.auth.admin.listUsers();
-  const user = data.users.find(
-    (u) => u.email === process.env.TEST_USER_EMAIL
-  );
-  if (!user) throw new Error("Test user not found");
-  return user.id;
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id")
+    .eq("email", process.env.TEST_USER_EMAIL!)
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(
+      `Test user ${process.env.TEST_USER_EMAIL} not found in profiles: ${error?.message ?? "no match"}`
+    );
+  }
+  return data.id;
 }
 
 /**
@@ -123,22 +131,35 @@ test.describe("Workspace settings", () => {
     await cleanupTestWorkspaces("Renamed E2E").catch(() => {});
   });
 
-  test("personal workspace shows 'cannot be deleted' message", async ({
+  test("personal workspace shows personal workspace message and no workspace delete button", async ({
     authenticatedPage: page,
   }) => {
-    const slug = extractWorkspaceSlug(page);
-    await goToSettings(page, slug);
+    // Look up the personal workspace slug directly from the DB to avoid
+    // depending on which workspace the user lands on after login.
+    const admin = getAdminClient();
+    const { data: personalWs } = await admin
+      .from("workspaces")
+      .select("slug")
+      .eq("created_by", userId)
+      .eq("is_personal", true)
+      .single();
 
-    // Personal workspace should show the "cannot be deleted" message
+    if (!personalWs) throw new Error("Personal workspace not found");
+
+    await goToSettings(page, personalWs.slug);
+
+    // Personal workspace should explain it's tied to the account
     await expect(
-      page.getByText("This is your personal workspace and cannot be deleted.")
-    ).toBeVisible({ timeout: 3_000 });
+      page.getByText(
+        "This is your personal workspace. It will be deleted if you delete your account."
+      )
+    ).toBeVisible({ timeout: 5_000 });
 
-    // There should be no delete button
-    const deleteButton = page.getByRole("button", {
+    // There should be no "Delete workspace" button (only "Delete account")
+    const deleteWorkspaceButton = page.getByRole("button", {
       name: /delete workspace/i,
     });
-    await expect(deleteButton).toHaveCount(0);
+    await expect(deleteWorkspaceButton).toHaveCount(0);
   });
 
   test("change workspace name and verify sidebar updates", async ({


### PR DESCRIPTION
Closes #479

## What

Post-merge verification of PR #467 found 10 E2E test failures. The failures fell into four categories:

1. **Slash menu ambiguity (8 tests):** The "Turn into" block conversion feature added options like "Turn into Callout", "Turn into Code Block", etc. to the slash menu. Tests using `.filter({ hasText: "Callout" })` matched both the direct command and the "Turn into" variant, causing strict mode violations.

2. **Members test flakiness (1 test):** The "invited user appears in pending invites" test failed because (a) stale invites from previous runs weren't cleaned up, (b) the test didn't wait for the DB write to propagate before asserting, and (c) the "Copy invite link" button selector matched multiple elements after `router.refresh()` re-rendered the pending invites list with its own copy buttons.

3. **Workspace settings test (1 test):** Two issues — `resolveTestUserId()` used `auth.admin.listUsers()` which returns only 50 users by default (the test user was on page 2), and the test assumed the user lands on their personal workspace after login (not guaranteed when other tests create workspaces).

4. **Favorites test flakiness:** The timeout for the favorites section to disappear after removing the last favorite was too short for the async re-fetch chain.

## How

- **Editor tests:** Added a `selectSlashOption()` helper in `editor-helpers.ts` that uses `getByRole('option', { name: /^Label\b/ })` with a start-anchored regex to match only the direct command, not "Turn into" variants. Updated all 4 affected test files.

- **Members tests:** Added stale invite cleanup (`e2e-member-%@test.local`) in `beforeAll`. Added an assertion in test 1 that the invite appears in the server-rendered pending list (confirms DB propagation). Scoped "Copy invite link" button assertions to the form section. Added explicit `emailInput` visibility wait before filling the re-invite form.

- **Workspace settings:** Replaced `auth.admin.listUsers()` with a direct `profiles` table query by email. Replaced `extractWorkspaceSlug(page)` with a DB lookup for the personal workspace slug via `workspaces.created_by`.

- **Favorites:** Increased the "not visible" timeout from 5s to 10s for the async favorites-changed re-fetch.

## Testing

All modified tests pass consistently:
- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 601 tests pass
- Editor tests (callout, code-paste, list-indent, import-export) — all pass
- Members tests — all 7 pass
- Workspace settings tests — all 3 pass
- Favorites tests — pass (pre-existing flakiness in sidebar tree loading is unrelated)