### PR TITLE
fix: filter Supabase auth lock contention errors from Sentry

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1238,6 +1238,44 @@ This applies to any client-side mutation where the RLS rejection is an expected
 authorization boundary (workspace limits, non-member access) and the user is
 already notified via toast.
 
+### Supabase auth lock contention errors
+
+The Supabase client uses the Web Lock API to serialize auth token refresh.
+When multiple concurrent requests race for the lock (e.g. parallel
+`favorites:check` calls on page load), the loser gets an `AbortError: Lock
+broken by another request with the 'steal' option.` This is expected behavior,
+not a bug.
+
+Two error shapes exist:
+1. **PostgrestError-like** — `details` contains the AbortError message. Passes
+   through `captureSupabaseError` which downgrades to warning level via
+   `isSupabaseAuthLockError`.
+2. **Unhandled rejection** — Supabase auth internals throw `Lock "lock:sb-..."
+   was released because another request stole it`. Dropped by `beforeSend` in
+   `instrumentation-client.ts` via `isSupabaseAuthLockContention`.
+
+For client-side code that checks errors before calling `captureSupabaseError`,
+also skip `isSupabaseAuthLockError`:
+
+```typescript
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+  isSupabaseAuthLockError,
+} from "@/lib/sentry";
+
+if (error) {
+  if (
+    !isSchemaNotFoundError(error) &&
+    !isInsufficientPrivilegeError(error) &&
+    !isSupabaseAuthLockError(error)
+  ) {
+    captureSupabaseError(error, "feature:operation");
+  }
+}
+```
+
 ## Usage Event Tracking
 
 Product analytics events are recorded via two modules — `src/lib/track-event-server.ts`

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -8,9 +8,11 @@ import("@sentry/nextjs").then(async (Sentry) => {
   // Dynamic import keeps sentry.ts out of the shared framework chunk.
   // The filter functions only inspect the event object — they have no
   // Sentry runtime dependency.
-  const { isNextjsInternalNoise, isReactLexicalDomConflict } = await import(
-    "@/lib/sentry"
-  );
+  const {
+    isNextjsInternalNoise,
+    isReactLexicalDomConflict,
+    isSupabaseAuthLockContention,
+  } = await import("@/lib/sentry");
 
   Sentry.init({
     dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -31,6 +33,7 @@ import("@sentry/nextjs").then(async (Sentry) => {
     beforeSend(event) {
       if (isNextjsInternalNoise(event)) return null;
       if (isReactLexicalDomConflict(event)) return null;
+      if (isSupabaseAuthLockContention(event)) return null;
       return event;
     },
   });

--- a/src/components/sidebar/favorites-section.tsx
+++ b/src/components/sidebar/favorites-section.tsx
@@ -9,6 +9,7 @@ import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
   isSchemaNotFoundError,
+  isSupabaseAuthLockError,
 } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import type { FavoriteWithPage } from "@/lib/types";
@@ -228,7 +229,8 @@ export function useFavorite({
       if (error) {
         if (
           !isSchemaNotFoundError(error) &&
-          !isInsufficientPrivilegeError(error)
+          !isInsufficientPrivilegeError(error) &&
+          !isSupabaseAuthLockError(error)
         ) {
           captureSupabaseError(error, "favorites:check");
         }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -147,6 +147,51 @@ const NODE_FETCH_CAUSE_PATTERNS = [
 ];
 
 /**
+ * True when the error originates from Supabase auth lock contention. The
+ * Supabase client uses the Web Lock API to serialize token refresh. When
+ * multiple concurrent requests race for the lock, the loser gets an
+ * `AbortError: Lock broken by another request with the 'steal' option.`
+ * This is expected behavior during concurrent page loads — not a bug.
+ *
+ * Matches two shapes:
+ * 1. PostgrestError-like objects where `details` or `message` contains the
+ *    lock-stolen AbortError (from `captureSupabaseError` path — MEMO-16/17/19)
+ * 2. Plain Error with the lock-released message thrown as an unhandled
+ *    rejection by the Supabase auth internals (MEMO-18)
+ */
+export function isSupabaseAuthLockError(error: Error): boolean {
+  const msg = error.message;
+  const details = isPostgrestError(error) ? error.details : "";
+
+  return (
+    msg.includes("Lock broken by another request") ||
+    msg.includes("was released because another request stole it") ||
+    details.includes("Lock broken by another request") ||
+    details.includes("was released because another request stole it")
+  );
+}
+
+/**
+ * Returns true when the Sentry event is a Supabase auth lock contention
+ * error. These are unhandled promise rejections from the Supabase client's
+ * internal `_acquireLock` when concurrent requests steal each other's
+ * Web Lock API locks. They are harmless and not actionable.
+ */
+export function isSupabaseAuthLockContention(event: ErrorEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) return false;
+
+  return values.some(
+    (ex) =>
+      typeof ex.value === "string" &&
+      (ex.value.includes("Lock broken by another request") ||
+        ex.value.includes(
+          "was released because another request stole it",
+        )),
+  );
+}
+
+/**
  * True when the error is a transient network failure (e.g. offline, DNS
  * timeout, connection reset). These are not application bugs and should be
  * reported at warning level so they don't trigger error-level alerts.
@@ -235,7 +280,8 @@ export function captureSupabaseError(
   if (
     isTransientNetworkError(error) ||
     isSchemaNotFoundError(error) ||
-    isInsufficientPrivilegeError(error)
+    isInsufficientPrivilegeError(error) ||
+    isSupabaseAuthLockError(error)
   ) {
     lazyCaptureException(error, { extra, level: "warning" });
     return;

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -12,6 +12,8 @@ import {
   isTransientNetworkError,
   isSchemaNotFoundError,
   isInsufficientPrivilegeError,
+  isSupabaseAuthLockError,
+  isSupabaseAuthLockContention,
   captureSupabaseError,
   isNextjsInternalNoise,
   isReactLexicalDomConflict,
@@ -268,6 +270,50 @@ describe("isInsufficientPrivilegeError", () => {
   });
 });
 
+describe("isSupabaseAuthLockError", () => {
+  it("detects AbortError in PostgrestError details (MEMO-16/17/19)", () => {
+    const error = makePostgrestError({
+      message: "AbortError: Lock broken by another request with the 'steal' option.",
+      code: "",
+      details: "AbortError: Lock broken by another request with the 'steal' option.",
+      hint: "Request was aborted (timeout or manual cancellation)",
+    });
+    expect(isSupabaseAuthLockError(error)).toBe(true);
+  });
+
+  it("detects lock-released message from Supabase auth internals (MEMO-18)", () => {
+    const error = new Error(
+      'Lock "lock:sb-yoipusltrtbvneuywzkj-auth-token" was released because another request stole it',
+    );
+    expect(isSupabaseAuthLockError(error)).toBe(true);
+  });
+
+  it("detects lock-broken message in plain Error", () => {
+    const error = new Error(
+      "AbortError: Lock broken by another request with the 'steal' option.",
+    );
+    expect(isSupabaseAuthLockError(error)).toBe(true);
+  });
+
+  it("returns false for transient network errors", () => {
+    const error = new Error("Failed to fetch");
+    expect(isSupabaseAuthLockError(error)).toBe(false);
+  });
+
+  it("returns false for generic application errors", () => {
+    const error = new Error("Something went wrong");
+    expect(isSupabaseAuthLockError(error)).toBe(false);
+  });
+
+  it("returns false for RLS violations", () => {
+    const error = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    expect(isSupabaseAuthLockError(error)).toBe(false);
+  });
+});
+
 describe("captureSupabaseError", () => {
   beforeEach(() => {
     captureExceptionMock.mockClear();
@@ -345,6 +391,22 @@ describe("captureSupabaseError", () => {
     const [, opts] = captureExceptionMock.mock.calls[0];
     expect(opts.level).toBe("warning");
     expect(opts.extra.operation).toBe("usage-events:track");
+  });
+
+  it("captures Supabase auth lock errors at warning level (MEMO-16/17/19)", async () => {
+    const error = makePostgrestError({
+      message: "AbortError: Lock broken by another request with the 'steal' option.",
+      code: "",
+      details: "AbortError: Lock broken by another request with the 'steal' option.",
+      hint: "Request was aborted (timeout or manual cancellation)",
+    });
+    captureSupabaseError(error, "favorites:check");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("favorites:check");
   });
 
   it("captures non-network, non-RLS errors at default (error) level", async () => {
@@ -623,5 +685,58 @@ describe("isReactLexicalDomConflict", () => {
       },
     ]);
     expect(isReactLexicalDomConflict(event)).toBe(true);
+  });
+});
+
+describe("isSupabaseAuthLockContention", () => {
+  it("detects lock-released unhandled rejection (MEMO-18)", () => {
+    const event = makeSentryEvent([
+      {
+        type: "Error",
+        value:
+          'Lock "lock:sb-yoipusltrtbvneuywzkj-auth-token" was released because another request stole it',
+      },
+    ]);
+    expect(isSupabaseAuthLockContention(event)).toBe(true);
+  });
+
+  it("detects lock-broken AbortError in event value", () => {
+    const event = makeSentryEvent([
+      {
+        type: "Error",
+        value:
+          "AbortError: Lock broken by another request with the 'steal' option.",
+      },
+    ]);
+    expect(isSupabaseAuthLockContention(event)).toBe(true);
+  });
+
+  it("detects the error in chained exceptions", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Some wrapper error" },
+      {
+        type: "Error",
+        value:
+          'Lock "lock:sb-abc123-auth-token" was released because another request stole it',
+      },
+    ]);
+    expect(isSupabaseAuthLockContention(event)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    const event = makeSentryEvent([
+      { type: "TypeError", value: "Cannot read properties of undefined" },
+    ]);
+    expect(isSupabaseAuthLockContention(event)).toBe(false);
+  });
+
+  it("returns false when exception values are empty", () => {
+    const event = makeSentryEvent([]);
+    expect(isSupabaseAuthLockContention(event)).toBe(false);
+  });
+
+  it("returns false when exception is missing", () => {
+    const event = { type: undefined } as ErrorEvent;
+    expect(isSupabaseAuthLockContention(event)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Supabase auth lock contention errors were flooding Sentry at error level. The Supabase client uses the Web Lock API to serialize auth token refresh — when concurrent requests race for the lock, the loser gets an AbortError. This is expected behavior, not a bug.

Closes #496

## Sentry Issues

- [MEMO-16](https://ona-2j.sentry.io/issues/MEMO-16), [MEMO-17](https://ona-2j.sentry.io/issues/MEMO-17), [MEMO-19](https://ona-2j.sentry.io/issues/MEMO-19): `favorites:check` AbortError reported at error level (handled)
- [MEMO-18](https://ona-2j.sentry.io/issues/MEMO-18): Unhandled rejection from Supabase auth `_acquireLock` (6 events, 5 users)

## Root Cause

The Supabase JS client's `_acquireLock` uses `navigator.locks.request` with `{ steal: true }`. When request B steals the lock from request A, request A receives `AbortError: Lock broken by another request with the 'steal' option.` Two error shapes exist:

1. **PostgrestError-like** — `details` contains the AbortError message, passes through `captureSupabaseError` at error level (no existing filter matched)
2. **Unhandled rejection** — `Lock \"lock:sb-...-auth-token\" was released because another request stole it` — bypasses all filters and hits Sentry's global handler

## Changes

- **`src/lib/sentry.ts`**: Add `isSupabaseAuthLockError` (detects auth lock errors in Error/PostgrestError objects) and `isSupabaseAuthLockContention` (detects auth lock errors in Sentry ErrorEvent). Add `isSupabaseAuthLockError` to `captureSupabaseError` warning-level downgrade.
- **`instrumentation-client.ts`**: Add `isSupabaseAuthLockContention` to `beforeSend` to drop unhandled auth lock rejections.
- **`src/components/sidebar/favorites-section.tsx`**: Add `isSupabaseAuthLockError` to the skip guard in `favorites:check` (alongside existing `isSchemaNotFoundError` and `isInsufficientPrivilegeError` checks).
- **`src/lib/sentry.unit.test.ts`**: 13 new test cases covering both error shapes, the warning-level downgrade, and the `beforeSend` filter.
- **`.agents/conventions.md`**: Document the Supabase auth lock contention pattern.

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 708 tests pass (13 new)