### PR TITLE
fix: add rounded-sm to calendar overflow popover (#488)

### DIFF
--- a/src/components/database/views/calendar-view-design-spec.test.ts
+++ b/src/components/database/views/calendar-view-design-spec.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for issue #488: the overflow popover in the calendar view
+ * must use `rounded-sm` per the design spec for floating elements.
+ */
+describe("calendar-view design spec compliance", () => {
+  const source = readFileSync(join(__dirname, "calendar-view.tsx"), "utf-8");
+
+  it("overflow popover uses rounded-sm", () => {
+    // Design spec Corners section:
+    // "Exceptions (use rounded-sm only): Dropdown menus and popovers
+    //  (floating elements need a slight radius to feel intentional)."
+    const lines = source.split("\n");
+    const popoverLines = lines.filter(
+      (line) =>
+        line.includes("z-50") &&
+        line.includes("shadow-md") &&
+        line.includes("bg-background"),
+    );
+
+    expect(popoverLines.length).toBeGreaterThan(0);
+    for (const line of popoverLines) {
+      expect(line).toContain("rounded-sm");
+    }
+  });
+});

--- a/src/components/database/views/calendar-view.tsx
+++ b/src/components/database/views/calendar-view.tsx
@@ -461,7 +461,7 @@ function CalendarDayCell({ cell, workspaceSlug, onClick }: CalendarDayCellProps)
             {showAll && (
               <div
                 ref={popoverRef}
-                className="absolute left-0 top-full z-50 w-56 border border-border bg-background p-2 shadow-md"
+                className="absolute left-0 top-full z-50 w-56 rounded-sm border border-border bg-background p-2 shadow-md"
               >
                 <div className="mb-1 text-xs font-medium text-muted-foreground">
                   {cell.date}


### PR DESCRIPTION
Closes #488

## What
The calendar view's overflow popover ("+N more" dropdown) was missing `rounded-sm`, violating the design spec rule that floating elements (dropdown menus and popovers) must use `rounded-sm` for a slight radius.

## How
Added `rounded-sm` to the overflow popover's className in `calendar-view.tsx`.

## Testing
Added a static analysis regression test (`calendar-view-design-spec.test.ts`) that reads the source file and verifies all floating popover elements include `rounded-sm`. This test would have caught the original violation.