### PR TITLE
fix: replace arbitrary spacing min-h-[60px] with min-h-16 in formula editor (#494)

### DIFF
--- a/src/components/database/property-types/formula-design-spec.test.ts
+++ b/src/components/database/property-types/formula-design-spec.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression test for issue #494: arbitrary spacing value min-h-[60px]
+ * used instead of the Tailwind spacing scale.
+ */
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(__dirname, relativePath), "utf-8");
+}
+
+describe("formula design spec compliance", () => {
+  const source = readSource("./formula.tsx");
+
+  it("does not use arbitrary spacing values", () => {
+    // Design spec: "Never use arbitrary spacing values (p-[13px]). Use the scale."
+    const arbitrarySpacing =
+      /(?:min-h|max-h|h|w|min-w|max-w|p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|space-x|space-y|inset|top|right|bottom|left)-\[\d+px\]/;
+    expect(source).not.toMatch(arbitrarySpacing);
+  });
+
+  it("does not use arbitrary font sizes", () => {
+    const arbitraryFontSize = /text-\[\d+px\]/;
+    expect(source).not.toMatch(arbitraryFontSize);
+  });
+});

--- a/src/components/database/property-types/formula.tsx
+++ b/src/components/database/property-types/formula.tsx
@@ -108,7 +108,7 @@ export function FormulaConfigEditor({
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
         placeholder='e.g. prop("Price") * prop("Quantity")'
-        className="min-h-[60px] font-mono text-xs"
+        className="min-h-16 font-mono text-xs"
         rows={2}
       />
       {preview && (


### PR DESCRIPTION
Closes #494

## What
The `FormulaConfigEditor` Textarea used `min-h-[60px]`, an arbitrary spacing value that violates the design spec rule: "Never use arbitrary spacing values. Use the scale."

## How
Replaced `min-h-[60px]` with `min-h-16` (64px), the nearest value on the Tailwind spacing scale.

## Testing
Added `formula-design-spec.test.ts` — a static analysis regression test that asserts the formula component source contains no arbitrary spacing or font-size values. This would have caught the original violation at CI time.