### PR TITLE
fix: clean up all non-personal workspaces in E2E beforeAll to prevent workspace limit errors (#500)

### DIFF
--- a/e2e/workspace-settings.spec.ts
+++ b/e2e/workspace-settings.spec.ts
@@ -82,15 +82,19 @@ async function deleteTestWorkspace(workspaceId: string): Promise<void> {
 }
 
 /**
- * Clean up any non-personal workspaces whose name starts with a given prefix.
+ * Delete all non-personal workspaces owned by the given user.
+ * Called in beforeAll to guarantee a clean slate regardless of what
+ * previous (possibly crashed) test runs left behind.
  */
-async function cleanupTestWorkspaces(prefix: string): Promise<void> {
+async function cleanupAllNonPersonalWorkspaces(
+  userId: string
+): Promise<void> {
   const admin = getAdminClient();
   await admin
     .from("workspaces")
     .delete()
     .eq("is_personal", false)
-    .like("name", `${prefix}%`);
+    .eq("created_by", userId);
 }
 
 /**
@@ -123,12 +127,14 @@ test.describe("Workspace settings", () => {
 
   test.beforeAll(async () => {
     userId = await resolveTestUserId();
-    await cleanupTestWorkspaces("E2E WS").catch(() => {});
+    // Remove all non-personal workspaces for the test user to guarantee
+    // we stay under the 3-workspace limit, even if a previous run crashed
+    // and afterAll never ran.
+    await cleanupAllNonPersonalWorkspaces(userId).catch(() => {});
   });
 
   test.afterAll(async () => {
-    await cleanupTestWorkspaces("E2E WS").catch(() => {});
-    await cleanupTestWorkspaces("Renamed E2E").catch(() => {});
+    await cleanupAllNonPersonalWorkspaces(userId).catch(() => {});
   });
 
   test("personal workspace shows personal workspace message and no workspace delete button", async ({


### PR DESCRIPTION
Closes #500

## What

The `workspace-settings.spec.ts` E2E test fails with "Workspace limit reached: users can create at most 3 workspaces" after repeated runs. The previous cleanup in `beforeAll` only deleted workspaces matching the `"E2E WS"` name prefix, missing workspaces that were renamed (to `"Renamed E2E ..."`) or left behind by crashed runs. Once the test user accumulated 3 workspaces, all subsequent runs failed.

## How

Replaced the prefix-based `cleanupTestWorkspaces` with `cleanupAllNonPersonalWorkspaces` that deletes **all** non-personal workspaces owned by the test user (`created_by = userId`). This runs in both `beforeAll` (guaranteeing a clean slate) and `afterAll` (best-effort cleanup). The per-test `finally` block for immediate cleanup is preserved.

## Testing

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — passes
- `pnpm test` — all 708 unit tests pass
- The fix ensures `beforeAll` removes all stale non-personal workspaces regardless of name, so the 3-workspace limit is never hit by leftover test data