### PR TITLE
fix(sentry): use startsWith for hostname-suffixed transient network errors

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -201,6 +201,9 @@ Transient network errors are automatically captured at `warning` level instead o
 Browser-style messages: `TypeError: Failed to fetch`, `Failed to fetch`,
 `Load failed`, `NetworkError when attempting to fetch resource.`,
 `The Internet connection appears to be offline.`, `Network request failed`.
+The Supabase client may append the hostname in parentheses, e.g.
+`TypeError: Failed to fetch (example.supabase.co)` — use `startsWith` matching,
+not exact equality, for the `TypeError: Failed to fetch` pattern.
 
 Node.js native fetch (undici) messages: `fetch failed` or `TypeError: fetch failed`
 (top-level), with the real cause wrapped in `error.cause` — look for `ECONNRESET`,

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -208,16 +208,24 @@ export function isTransientNetworkError(error: Error): boolean {
   const msg = error.message;
   const details = isPostgrestError(error) ? error.details : "";
 
-  // Browser-style fetch errors
+  // Browser-style fetch errors.
+  // The Supabase client may append the hostname in parentheses, e.g.
+  // "TypeError: Failed to fetch (example.supabase.co)" — use startsWith
+  // for patterns that have known suffixes, exact match for the rest.
   if (
-    msg === "TypeError: Failed to fetch" ||
-    details === "TypeError: Failed to fetch" ||
+    msg.startsWith("TypeError: Failed to fetch") ||
     msg === "Failed to fetch" ||
     msg === "Load failed" ||
     msg === "NetworkError when attempting to fetch resource." ||
     msg === "The Internet connection appears to be offline." ||
     msg === "Network request failed"
   ) {
+    return true;
+  }
+
+  // Supabase may embed "TypeError: Failed to fetch" in the details field,
+  // sometimes with a full stack trace appended.
+  if (details.startsWith("TypeError: Failed to fetch")) {
     return true;
   }
 

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -158,6 +158,22 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("detects 'TypeError: Failed to fetch' with Supabase hostname suffix (MEMO-1A regression)", () => {
+    const error = new Error(
+      "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+    );
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
+  it("detects 'TypeError: Failed to fetch' with stack trace in PostgrestError details (MEMO-1A regression)", () => {
+    const error = makePostgrestError({
+      message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+      details:
+        "TypeError: Failed to fetch\n    at https://memo.software-factory.dev/_next/static/chunks/0vbg59c79mvs4.js:20:1653",
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns false when cause is not an Error instance", () => {
     const error = new Error("some error", { cause: "string cause" });
     expect(isTransientNetworkError(error)).toBe(false);
@@ -407,6 +423,21 @@ describe("captureSupabaseError", () => {
     const [, opts] = captureExceptionMock.mock.calls[0];
     expect(opts.level).toBe("warning");
     expect(opts.extra.operation).toBe("favorites:check");
+  });
+
+  it("captures hostname-suffixed transient network errors at warning level (MEMO-1A)", async () => {
+    const error = makePostgrestError({
+      message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+      details:
+        "TypeError: Failed to fetch\n    at https://memo.software-factory.dev/_next/static/chunks/0vbg59c79mvs4.js:20:1653",
+    });
+    captureSupabaseError(error, "create-workspace-dialog:create");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("create-workspace-dialog:create");
   });
 
   it("captures non-network, non-RLS errors at default (error) level", async () => {


### PR DESCRIPTION
## Summary

The Supabase client appends the hostname in parentheses to `TypeError: Failed to fetch` messages — e.g. `TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)`. The exact equality check in `isTransientNetworkError` missed these, causing transient network errors to be reported at error level instead of warning level.

Sentry issue: https://ona-2j.sentry.io/issues/MEMO-1A

## Root Cause

Two exact-equality checks in `isTransientNetworkError` fail when the Supabase client appends context:
1. `msg === "TypeError: Failed to fetch"` misses `"TypeError: Failed to fetch (hostname.supabase.co)"`
2. `details === "TypeError: Failed to fetch"` misses details containing a full stack trace starting with `"TypeError: Failed to fetch\n    at ..."`

## Changes

- **`src/lib/sentry.ts`**: Replace `===` with `startsWith()` for the `"TypeError: Failed to fetch"` pattern in both message and details checks. Extracted the details check into its own block with a comment.
- **`src/lib/sentry.unit.test.ts`**: Added 3 regression tests — `isTransientNetworkError` with hostname suffix, with stack-trace details, and `captureSupabaseError` end-to-end at warning level.
- **`.agents/conventions.md`**: Documented the hostname suffix pattern and the `startsWith` matching requirement.

## Test Results

All 714 tests pass. Lint and typecheck clean.

Closes #508