### PR TITLE
test: add E2E tests for database CRUD and table view (#502)

### DIFF
--- a/e2e/database-crud.spec.ts
+++ b/e2e/database-crud.spec.ts
@@ -1,0 +1,284 @@
+import { test, expect } from "./fixtures/auth";
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Admin client for cleanup
+// ---------------------------------------------------------------------------
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+// Track database page IDs created during tests for cleanup
+const createdDatabaseIds: string[] = [];
+
+test.afterAll(async () => {
+  if (createdDatabaseIds.length === 0) return;
+  const admin = getAdminClient();
+  for (const id of createdDatabaseIds) {
+    // Hard-delete child pages (rows) first, then the database page
+    await admin.from("pages").delete().eq("parent_id", id);
+    await admin.from("pages").delete().eq("id", id);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Wait for the sidebar page tree to finish loading.
+ * Returns the sidebar locator.
+ */
+async function waitForSidebarTree(page: import("@playwright/test").Page) {
+  const sidebar = page.getByRole("complementary");
+  const treeLoaded = sidebar
+    .locator('[role="treeitem"], :text("No pages yet")')
+    .first();
+  await expect(treeLoaded).toBeVisible({ timeout: 15_000 });
+  return sidebar;
+}
+
+/**
+ * Create a new database via the sidebar button and wait for the database
+ * page to load. Returns the database page ID extracted from the URL.
+ */
+async function createDatabaseFromSidebar(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  const sidebar = await waitForSidebarTree(page);
+
+  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
+  await newDbBtn.click();
+
+  // Wait for navigation to the database page
+  await page.waitForURL(
+    (url) => url.pathname.split("/").filter(Boolean).length >= 2,
+    { timeout: 15_000 },
+  );
+
+  // Wait for the database view to load — the empty state shows "No rows yet",
+  // the populated state shows a grid with role="grid".
+  const dbLoaded = page
+    .locator('[role="grid"], :text("No rows yet")')
+    .first();
+  await expect(dbLoaded).toBeVisible({ timeout: 15_000 });
+
+  // Extract page ID from URL: /<workspaceSlug>/<pageId>
+  const pathParts = new URL(page.url()).pathname.split("/").filter(Boolean);
+  const pageId = pathParts[pathParts.length - 1];
+  createdDatabaseIds.push(pageId);
+  return pageId;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Database CRUD", () => {
+  test("user can create a new database from the sidebar", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+
+    // The breadcrumb should show "Untitled Database"
+    const breadcrumb = page.locator(':text("Untitled Database")').first();
+    await expect(breadcrumb).toBeVisible({ timeout: 10_000 });
+
+    // The table view empty state should show the "TITLE" column header
+    // (rendered as uppercase text in a .bg-muted container)
+    const titleHeader = page.locator(".bg-muted").filter({
+      hasText: /title/i,
+    }).first();
+    await expect(titleHeader).toBeVisible({ timeout: 10_000 });
+
+    // The empty state should show "No rows yet"
+    await expect(page.locator(':text("No rows yet")')).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // The "+ New" button should be visible (onAddRow is now wired up)
+    const addRowBtn = page.locator("button", { hasText: "+ New" });
+    await expect(addRowBtn).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("user can add a text property column to a database", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+
+    // The empty state doesn't render the "Add column" button with
+    // aria-label. Add a row first so the full grid renders.
+    const addRowBtn = page.locator("button", { hasText: "+ New" });
+    await expect(addRowBtn).toBeVisible({ timeout: 10_000 });
+    await addRowBtn.click();
+
+    // Wait for the grid to appear (row added → non-empty state)
+    await expect(page.locator('[role="grid"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Click the "Add column" button (+ icon in the last column header)
+    const addColumnBtn = page.locator('button[aria-label="Add column"]');
+    await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
+    await addColumnBtn.click();
+
+    // Wait for the new column header to appear
+    await page.waitForTimeout(1_500);
+
+    // The new column should contain "Property" in its name
+    const newHeader = page.locator('[role="columnheader"]', {
+      hasText: /property/i,
+    });
+    await expect(newHeader.first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("user can add a row and edit cell values inline in table view", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+
+    // Add a row to get the full grid
+    const addRowBtn = page.locator("button", { hasText: "+ New" });
+    await expect(addRowBtn).toBeVisible({ timeout: 10_000 });
+    await addRowBtn.click();
+
+    // Wait for the grid
+    await expect(page.locator('[role="grid"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Add a text property column so we have an editable cell
+    const addColumnBtn = page.locator('button[aria-label="Add column"]');
+    await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
+    await addColumnBtn.click();
+    await page.waitForTimeout(1_500);
+
+    // Click on the property cell to start editing.
+    // Editable cells have tabindex="0" and cursor-text styling.
+    const editableCells = page.locator(
+      '[role="gridcell"][tabindex="0"]',
+    );
+    await expect(editableCells.first()).toBeVisible({ timeout: 5_000 });
+    await editableCells.first().click();
+
+    // An input should appear for inline editing
+    const cellInput = page.locator(
+      '[role="gridcell"] input[type="text"], [role="gridcell"] input[type="number"]',
+    );
+    await expect(cellInput).toBeVisible({ timeout: 5_000 });
+
+    // Type a value and click outside to blur and save
+    await cellInput.fill("Test Value");
+    // Click the page title area to blur the cell input
+    await page.locator("h1, input[aria-label]").first().click();
+    await page.waitForTimeout(1_500);
+
+    // The cell should now display the value
+    const cellText = page.locator('[role="gridcell"]', {
+      hasText: "Test Value",
+    });
+    await expect(cellText.first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("user can delete a row from the table view", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+
+    // Add a row first
+    const addRowBtn = page.locator("button", { hasText: "+ New" });
+    await expect(addRowBtn).toBeVisible({ timeout: 10_000 });
+    await addRowBtn.click();
+
+    // Wait for the grid to appear
+    await expect(page.locator('[role="grid"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Hover over the title cell to reveal the delete button
+    const titleCell = page.locator('[role="gridcell"]').first();
+    await titleCell.hover();
+    await page.waitForTimeout(500);
+
+    // Click the delete button
+    const deleteBtn = page.locator('button[aria-label="Delete row"]').first();
+    await expect(deleteBtn).toBeVisible({ timeout: 5_000 });
+    await deleteBtn.click();
+
+    // Wait for the row to be removed — "No rows yet" should appear
+    await expect(page.locator(':text("No rows yet")')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test("user can rename a database property (column header)", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+
+    // Add a row to get the full grid, then add a column
+    const addRowBtn = page.locator("button", { hasText: "+ New" });
+    await expect(addRowBtn).toBeVisible({ timeout: 10_000 });
+    await addRowBtn.click();
+    await expect(page.locator('[role="grid"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const addColumnBtn = page.locator('button[aria-label="Add column"]');
+    await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
+    await addColumnBtn.click();
+    await page.waitForTimeout(1_500);
+
+    // Set up dialog handler before clicking the header.
+    // The rename uses window.prompt — handle it with a dialog listener.
+    page.on("dialog", async (dialog) => {
+      if (dialog.type() === "prompt") {
+        await dialog.accept("Renamed Column");
+      }
+    });
+
+    // Click the property column header button to trigger rename.
+    const propertyHeader = page
+      .locator('[role="columnheader"]', { hasText: /property/i })
+      .first();
+    const headerButton = propertyHeader.locator("button").first();
+    await headerButton.click();
+
+    // Wait for the rename to take effect
+    await page.waitForTimeout(2_000);
+
+    // The column header should now show the new name
+    const renamedHeader = page.locator('[role="columnheader"]', {
+      hasText: "Renamed Column",
+    });
+    await expect(renamedHeader.first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("database page shows grid icon in sidebar", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+
+    const sidebar = page.getByRole("complementary");
+
+    // The sidebar tree should have loaded with the new database page.
+    // Database pages render a Table2 SVG icon (class "lucide-table-2")
+    // instead of the FileText SVG icon used for regular pages.
+    const treeItems = sidebar.locator('[role="treeitem"]');
+    await expect(treeItems.first()).toBeVisible({ timeout: 10_000 });
+
+    // lucide-react adds class "lucide-table-2" to the Table2 SVG.
+    // Check that at least one tree item contains this icon.
+    const gridIconItems = treeItems.filter({
+      has: page.locator("svg.lucide-table-2"),
+    });
+    const gridCount = await gridIconItems.count();
+    expect(gridCount).toBeGreaterThan(0);
+  });
+});

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -10,13 +10,22 @@ import { PageIcon } from "@/components/page-icon";
 import { PageCover } from "@/components/page-cover";
 import { ViewTabs, VIEW_TYPE_LABELS } from "@/components/database/view-tabs";
 import {
+  addProperty,
+  addRow,
   addView,
   deleteView,
   loadDatabase,
   loadWorkspaceMembers,
   reorderViews,
+  updateProperty,
+  updateRowValue,
   updateView,
 } from "@/lib/database";
+import { createClient } from "@/lib/supabase/client";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+} from "@/lib/sentry";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -145,6 +154,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     initialContent,
     workspaceId,
     workspaceSlug,
+    userId,
   } = props;
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -329,6 +339,114 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     [pageId],
   );
 
+  // -----------------------------------------------------------------------
+  // Row / column / cell CRUD
+  // -----------------------------------------------------------------------
+
+  const handleAddRow = useCallback(async () => {
+    const { data: rowPage, error } = await addRow(pageId, userId);
+    if (error || !rowPage) {
+      toast.error("Failed to add row", { duration: 8000 });
+      return;
+    }
+    // Append the new row optimistically
+    setRows((prev) => [
+      ...prev,
+      { page: rowPage as DatabaseRow["page"], values: {} },
+    ]);
+  }, [pageId, userId]);
+
+  const handleCellUpdate = useCallback(
+    async (rowId: string, propertyId: string, value: Record<string, unknown>) => {
+      // Optimistic update
+      setRows((prev) =>
+        prev.map((r) => {
+          if (r.page.id !== rowId) return r;
+          return {
+            ...r,
+            values: {
+              ...r.values,
+              [propertyId]: {
+                ...(r.values[propertyId] ?? {
+                  id: "",
+                  row_id: rowId,
+                  property_id: propertyId,
+                  created_at: new Date().toISOString(),
+                  updated_at: new Date().toISOString(),
+                }),
+                value,
+                updated_at: new Date().toISOString(),
+              },
+            },
+          };
+        }),
+      );
+
+      const { error } = await updateRowValue(rowId, propertyId, value);
+      if (error) {
+        toast.error("Failed to update cell", { duration: 8000 });
+      }
+    },
+    [],
+  );
+
+  const handleAddColumn = useCallback(async () => {
+    const name = `Property ${properties.length + 1}`;
+    const { data: newProp, error } = await addProperty(pageId, name, "text");
+    if (error || !newProp) {
+      toast.error("Failed to add column", { duration: 8000 });
+      return;
+    }
+    setProperties((prev) => [...prev, newProp]);
+  }, [pageId, properties.length]);
+
+  const handleColumnHeaderClick = useCallback(
+    async (propertyId: string) => {
+      const prop = properties.find((p) => p.id === propertyId);
+      if (!prop) return;
+
+      const newName = window.prompt("Rename property", prop.name);
+      if (newName === null || newName.trim() === "" || newName === prop.name) return;
+
+      // Optimistic update
+      setProperties((prev) =>
+        prev.map((p) => (p.id === propertyId ? { ...p, name: newName.trim() } : p)),
+      );
+
+      const { error } = await updateProperty(propertyId, { name: newName.trim() });
+      if (error) {
+        toast.error("Failed to rename property", { duration: 8000 });
+        // Revert
+        setProperties((prev) =>
+          prev.map((p) => (p.id === propertyId ? { ...p, name: prop.name } : p)),
+        );
+      }
+    },
+    [properties],
+  );
+
+  const handleDeleteRow = useCallback(
+    async (rowId: string) => {
+      // Optimistic removal
+      setRows((prev) => prev.filter((r) => r.page.id !== rowId));
+
+      const supabase = createClient();
+      const { error } = await supabase.rpc("soft_delete_page", {
+        page_id: rowId,
+      });
+      if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-view:delete-row");
+        }
+        toast.error("Failed to delete row", { duration: 8000 });
+        // Reload to restore
+        const { data } = await loadDatabase(pageId);
+        if (data) setRows(data.rows);
+      }
+    },
+    [pageId],
+  );
+
   // Check if there's Lexical content to render above the database
   const hasContent =
     initialContent !== null &&
@@ -394,6 +512,11 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
                   properties={properties}
                   viewConfig={activeView.config}
                   workspaceSlug={workspaceSlug}
+                  onAddRow={handleAddRow}
+                  onCellUpdate={handleCellUpdate}
+                  onAddColumn={handleAddColumn}
+                  onColumnHeaderClick={handleColumnHeaderClick}
+                  onDeleteRow={handleDeleteRow}
                 />
               ) : activeView?.type === "board" ? (
                 <BoardView

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -13,6 +13,7 @@ import {
   ArrowUp,
   FileText,
   Plus,
+  Trash2,
 } from "lucide-react";
 import { PROPERTY_TYPE_ICON } from "@/lib/property-icons";
 import type { SortRule } from "@/lib/database-filters";
@@ -68,6 +69,8 @@ export interface TableViewProps {
   sorts?: SortRule[];
   /** Called when a column header sort indicator is clicked. Cycles: unsorted → asc → desc → unsorted. */
   onSortToggle?: (propertyId: string) => void;
+  /** Called when a row should be deleted. */
+  onDeleteRow?: (rowId: string) => void;
   /** Loading state — shows skeleton. */
   loading?: boolean;
 }
@@ -95,6 +98,7 @@ export function TableView({
   onAddColumn,
   onColumnWidthsChange,
   onColumnHeaderClick,
+  onDeleteRow,
   sorts = [],
   onSortToggle,
   loading = false,
@@ -407,6 +411,7 @@ export function TableView({
             onStartEditing={startEditing}
             onCellKeyDown={handleCellKeyDown}
             onCellBlur={handleCellBlur}
+            onDeleteRow={onDeleteRow}
           />
         ))}
       </div>
@@ -440,6 +445,7 @@ interface TableRowProps {
   onStartEditing: (rowId: string, propertyId: string) => void;
   onCellKeyDown: (e: React.KeyboardEvent, rowIndex: number, colIndex: number) => void;
   onCellBlur: (rowId: string, propertyId: string, newValue: Record<string, unknown>) => void;
+  onDeleteRow?: (rowId: string) => void;
 }
 
 function TableRow({
@@ -453,24 +459,35 @@ function TableRow({
   onStartEditing,
   onCellKeyDown,
   onCellBlur,
+  onDeleteRow,
 }: TableRowProps) {
   return (
     <>
       {/* Title cell */}
       <div
         className={cn(
-          "flex items-center border-b border-white/[0.06] p-2 hover:bg-white/[0.02]",
+          "group/row flex items-center border-b border-white/[0.06] p-2 hover:bg-white/[0.02]",
           rowHeightClass,
         )}
         role="gridcell"
       >
         <Link
           href={`/${workspaceSlug}/${row.page.id}`}
-          className="truncate text-sm text-foreground hover:underline"
+          className="min-w-0 flex-1 truncate text-sm text-foreground hover:underline"
         >
           {row.page.icon && <span className="mr-1.5">{row.page.icon}</span>}
           {row.page.title || "Untitled"}
         </Link>
+        {onDeleteRow && (
+          <button
+            type="button"
+            onClick={() => onDeleteRow(row.page.id)}
+            className="ml-1 shrink-0 text-muted-foreground opacity-0 hover:text-destructive group-hover/row:opacity-100"
+            aria-label="Delete row"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        )}
       </div>
 
       {/* Property cells */}


### PR DESCRIPTION
Closes #502

## What

Add E2E test coverage for the foundational database CRUD flows: creating a database, adding properties, adding/editing/deleting rows in table view, and verifying the sidebar grid icon.

## How

**Wire up CRUD handlers in `database-view-client.tsx`:**
The table view component already accepted `onAddRow`, `onCellUpdate`, `onAddColumn`, `onColumnHeaderClick`, but the parent `DatabaseViewClient` didn't pass them. This PR wires up:
- `handleAddRow` — creates a new row page via `addRow()` and appends it optimistically
- `handleCellUpdate` — updates cell values via `updateRowValue()` with optimistic state
- `handleAddColumn` — adds a text property via `addProperty()`
- `handleColumnHeaderClick` — renames a property via `window.prompt` + `updateProperty()`
- `handleDeleteRow` — soft-deletes a row page via `soft_delete_page` RPC with optimistic removal

**Add `onDeleteRow` prop to `table-view.tsx`:**
Renders a trash icon button on row hover in the title cell.

**New E2E tests in `e2e/database-crud.spec.ts`:**
1. Create a new database from the sidebar "New Database" button
2. Add a text property column via the "+" button
3. Add a row and edit cell values inline (click-to-edit, blur-to-save)
4. Delete a row from the table view via the hover trash button
5. Rename a database property via column header click
6. Verify database page shows grid icon (`lucide-table-2`) in sidebar

## Testing

- `pnpm lint` — 0 errors (23 pre-existing warnings)
- `pnpm typecheck` — passes
- `pnpm test` — 711/711 pass
- `pnpm test:e2e` — all 6 new tests pass; 4 pre-existing failures in unrelated specs (favorites, members, version-history, editor-slash-commands)
- Cleanup: test databases are hard-deleted in `afterAll` via admin client