### PR TITLE
fix: downgrade foreign key violation (23503) to warning in Sentry (#512)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1241,6 +1241,38 @@ This applies to any client-side mutation where the RLS rejection is an expected
 authorization boundary (workspace limits, non-member access) and the user is
 already notified via toast.
 
+### Foreign key violations on deleted parent rows (PostgreSQL 23503)
+
+When a client inserts a row referencing a parent that was deleted between page
+load and the mutation (e.g. creating a page in a workspace that was deleted
+during E2E test teardown), PostgreSQL returns error code `23503`
+(`foreign_key_violation`). This is an expected race condition, not an
+application bug — the user already sees a toast error.
+
+`captureSupabaseError` automatically downgrades `23503` to warning level.
+Client-side code that guards before calling `captureSupabaseError` should also
+skip `isForeignKeyViolationError` to avoid reporting entirely:
+
+```typescript
+import {
+  captureSupabaseError,
+  isForeignKeyViolationError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
+
+if (error) {
+  if (
+    !isSchemaNotFoundError(error) &&
+    !isInsufficientPrivilegeError(error) &&
+    !isForeignKeyViolationError(error)
+  ) {
+    captureSupabaseError(error, "feature:operation");
+  }
+  toast.error("Failed to do thing", { duration: 8000 });
+}
+```
+
 ### Supabase auth lock contention errors
 
 The Supabase client uses the Web Lock API to serialize auth token refresh.

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -18,6 +18,7 @@ import { toast } from "@/lib/toast";
 import { getClient } from "@/lib/supabase/lazy-client";
 import {
   captureSupabaseError,
+  isForeignKeyViolationError,
   isInsufficientPrivilegeError,
   isSchemaNotFoundError,
 } from "@/lib/sentry";
@@ -307,7 +308,8 @@ export function PageTree({ userId }: PageTreeProps) {
       if (error) {
         if (
           !isSchemaNotFoundError(error) &&
-          !isInsufficientPrivilegeError(error)
+          !isInsufficientPrivilegeError(error) &&
+          !isForeignKeyViolationError(error)
         ) {
           captureSupabaseError(error, "page-tree:create-page");
         }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -136,6 +136,27 @@ export function isInsufficientPrivilegeError(error: Error): boolean {
 }
 
 /**
+ * True when PostgreSQL raises `foreign_key_violation` (23503). This occurs
+ * when an insert references a row that no longer exists — e.g. creating a
+ * page in a workspace that was deleted between page load and the insert.
+ * This is an expected race condition during E2E test teardown and concurrent
+ * user sessions, not an application bug.
+ *
+ * Matches two shapes:
+ * 1. PostgrestError objects with `code: "23503"` (from `{ data, error }` path)
+ * 2. Generic Error with a `code` property set to `"23503"` (thrown path)
+ */
+export function isForeignKeyViolationError(error: Error): boolean {
+  if (isPostgrestError(error)) {
+    return error.code === "23503";
+  }
+  return (
+    "code" in error &&
+    (error as Record<string, unknown>).code === "23503"
+  );
+}
+
+/**
  * Node.js native fetch (undici) wraps the real network error in the `cause`
  * property. These substrings in the cause message indicate transient failures.
  */
@@ -289,6 +310,7 @@ export function captureSupabaseError(
     isTransientNetworkError(error) ||
     isSchemaNotFoundError(error) ||
     isInsufficientPrivilegeError(error) ||
+    isForeignKeyViolationError(error) ||
     isSupabaseAuthLockError(error)
   ) {
     lazyCaptureException(error, { extra, level: "warning" });

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -12,6 +12,7 @@ import {
   isTransientNetworkError,
   isSchemaNotFoundError,
   isInsufficientPrivilegeError,
+  isForeignKeyViolationError,
   isSupabaseAuthLockError,
   isSupabaseAuthLockContention,
   captureSupabaseError,
@@ -286,6 +287,53 @@ describe("isInsufficientPrivilegeError", () => {
   });
 });
 
+describe("isForeignKeyViolationError", () => {
+  it("detects PostgreSQL 23503 (foreign_key_violation) from PostgrestError", () => {
+    const error = makePostgrestError({
+      message: 'insert or update on table "pages" violates foreign key constraint "pages_workspace_id_fkey"',
+      code: "23503",
+    });
+    expect(isForeignKeyViolationError(error)).toBe(true);
+  });
+
+  it("detects 23503 from generic Error with code property (thrown path)", () => {
+    const error = Object.assign(
+      new Error('insert or update on table "pages" violates foreign key constraint "pages_workspace_id_fkey"'),
+      { code: "23503" },
+    );
+    expect(isForeignKeyViolationError(error)).toBe(true);
+  });
+
+  it("returns false for other PostgrestError codes", () => {
+    const error = makePostgrestError({
+      message: "duplicate key value violates unique constraint",
+      code: "23505",
+    });
+    expect(isForeignKeyViolationError(error)).toBe(false);
+  });
+
+  it("returns false for RLS violations (42501)", () => {
+    const error = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    expect(isForeignKeyViolationError(error)).toBe(false);
+  });
+
+  it("returns false for generic errors without code", () => {
+    const error = new Error("Something went wrong");
+    expect(isForeignKeyViolationError(error)).toBe(false);
+  });
+
+  it("returns false for generic Error with non-23503 code property", () => {
+    const error = Object.assign(
+      new Error("duplicate key"),
+      { code: "23505" },
+    );
+    expect(isForeignKeyViolationError(error)).toBe(false);
+  });
+});
+
 describe("isSupabaseAuthLockError", () => {
   it("detects AbortError in PostgrestError details (MEMO-16/17/19)", () => {
     const error = makePostgrestError({
@@ -393,6 +441,21 @@ describe("captureSupabaseError", () => {
     expect(opts.level).toBe("warning");
     expect(opts.extra.operation).toBe("page-tree:create-page");
     expect(opts.extra.code).toBe("42501");
+  });
+
+  it("captures foreign key violations (23503) at warning level (MEMO-1B)", async () => {
+    const error = makePostgrestError({
+      message: 'insert or update on table "pages" violates foreign key constraint "pages_workspace_id_fkey"',
+      code: "23503",
+    });
+    captureSupabaseError(error, "page-tree:create-page");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("page-tree:create-page");
+    expect(opts.extra.code).toBe("23503");
   });
 
   it("captures Node.js native fetch errors at warning level (MEMO-15)", async () => {


### PR DESCRIPTION
Closes #512

## What

Foreign key violations (PostgreSQL code `23503`) on `page-tree:create-page` were being reported to Sentry at error level. This happens when a user creates a page in a workspace that was deleted between page load and the insert — an expected race condition during E2E test teardown and concurrent sessions. The user already sees a toast error, so the Sentry noise is not actionable.

## How

Added `isForeignKeyViolationError` helper to `src/lib/sentry.ts` that detects PostgreSQL code `23503` from both PostgrestError objects and generic Error with a `code` property. Added it to the warning-level downgrade list in `captureSupabaseError`, and added it to the skip guard in `page-tree.tsx` alongside `isSchemaNotFoundError` and `isInsufficientPrivilegeError`. Documented the convention in `.agents/conventions.md`.

## Testing

- 7 new unit tests in `sentry.unit.test.ts`: 6 for `isForeignKeyViolationError` (PostgrestError, thrown Error, negative cases for other codes) and 1 for `captureSupabaseError` verifying FK violations are captured at warning level.
- All 723 existing tests pass. Lint and typecheck clean.