### PR TITLE
fix(database): prevent MouseEvent leak into addRow initialValues

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1423,6 +1423,33 @@ if (config) {
 }
 ```
 
+## Event Handler Argument Leaks
+
+Never pass a callback that accepts optional business arguments directly to `onClick`.
+The browser forwards the `MouseEvent` as the first argument, which gets misinterpreted
+as the optional parameter.
+
+```typescript
+// ❌ BAD — MouseEvent leaks as initialValues
+<button onClick={onAddRow}>+ New</button>
+
+// ✅ GOOD — arrow function discards the event
+<button onClick={() => onAddRow()}>+ New</button>
+```
+
+When a callback accepts optional structured data (e.g. `initialValues?: Record<…>`),
+the receiving function should also guard against non-plain objects as defense-in-depth:
+
+```typescript
+const safeValues =
+  initialValues &&
+  typeof initialValues === "object" &&
+  !Array.isArray(initialValues) &&
+  Object.getPrototypeOf(initialValues) === Object.prototype
+    ? initialValues
+    : undefined;
+```
+
 ## This file evolves
 
 When you discover a new pattern that should be replicated, or an anti-pattern that

--- a/src/components/database/views/list-view.tsx
+++ b/src/components/database/views/list-view.tsx
@@ -65,7 +65,7 @@ export function ListView({
         {onAddRow && (
           <button
             type="button"
-            onClick={onAddRow}
+            onClick={() => onAddRow()}
             className="flex w-full items-center gap-1.5 border-t border-white/[0.06] px-3 py-2 text-sm text-muted-foreground hover:bg-white/[0.04]"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -90,7 +90,7 @@ export function ListView({
       {onAddRow && (
         <button
           type="button"
-          onClick={onAddRow}
+          onClick={() => onAddRow()}
           className="flex w-full items-center gap-1.5 border-t border-white/[0.06] px-3 py-2 text-sm text-muted-foreground hover:bg-white/[0.04]"
         >
           <Plus className="h-3.5 w-3.5" />

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -300,7 +300,7 @@ export function TableView({
         {onAddRow && (
           <button
             type="button"
-            onClick={onAddRow}
+            onClick={() => onAddRow()}
             className="w-full border-t border-white/[0.06] p-2 text-left text-sm text-muted-foreground hover:bg-white/[0.02]"
           >
             + New
@@ -420,7 +420,7 @@ export function TableView({
       {onAddRow && (
         <button
           type="button"
-          onClick={onAddRow}
+          onClick={() => onAddRow()}
           className="w-full border-t border-white/[0.06] p-2 text-left text-sm text-muted-foreground hover:bg-white/[0.02]"
         >
           + New

--- a/src/lib/database.test.ts
+++ b/src/lib/database.test.ts
@@ -418,6 +418,37 @@ describe("addRow", () => {
       "database.addRow:lookup",
     );
   });
+
+  it("ignores non-plain-object initialValues (e.g. MouseEvent leaked from onClick)", async () => {
+    mockTable("pages", {
+      data: {
+        ...FAKE_PAGE,
+        id: "row-1",
+        is_database: false,
+        parent_id: "page-1",
+        workspace_id: "ws-1",
+      },
+      error: null,
+    });
+
+    // Simulate a MouseEvent being passed as initialValues — this happens when
+    // onClick={onAddRow} forwards the event as the first argument.
+    const fakeEvent = Object.create(MouseEvent.prototype, {
+      target: { value: {}, enumerable: true },
+      type: { value: "click", enumerable: true },
+    });
+
+    const result = await addRow(
+      "page-1",
+      "user-1",
+      fakeEvent as unknown as Record<string, Record<string, unknown>>,
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+    // row_values insert should NOT have been called
+    expect(tableMocks["row_values"]).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -325,9 +325,18 @@ export async function addRow(
     return { data: null, error: rowError };
   }
 
-  // Insert initial values if provided
-  if (initialValues && Object.keys(initialValues).length > 0) {
-    const rows = Object.entries(initialValues).map(
+  // Insert initial values if provided.
+  // Guard: reject non-plain objects (e.g. a MouseEvent leaked from an onClick handler).
+  const safeValues =
+    initialValues &&
+    typeof initialValues === "object" &&
+    !Array.isArray(initialValues) &&
+    Object.getPrototypeOf(initialValues) === Object.prototype
+      ? initialValues
+      : undefined;
+
+  if (safeValues && Object.keys(safeValues).length > 0) {
+    const rows = Object.entries(safeValues).map(
       ([propertyId, value]) => ({
         row_id: rowPage.id,
         property_id: propertyId,


### PR DESCRIPTION
## Summary

`onClick={onAddRow}` in table-view and list-view forwarded the browser `MouseEvent` as the `initialValues` parameter to `addRow()`. The event contains circular references (`HTMLButtonElement` → React fiber → `stateNode`), causing `JSON.stringify` to throw when inserting into `row_values`.

**Sentry issues:** [MEMO-E](https://ona-2j.sentry.io/issues/MEMO-E) (1844 events, 25 users), [MEMO-G](https://ona-2j.sentry.io/issues/MEMO-G) (6 events, 3 users)

Closes #522

## Root Cause

`handleAddRow` accepts `initialValues?: Record<string, Record<string, unknown>>`. When passed directly to `onClick`, the `MouseEvent` becomes the first argument. It passes the truthy check and `Object.keys()` length check, so the code attempts to serialize event properties as row values — hitting the circular reference through the button's React fiber.

## Changes

- **table-view.tsx / list-view.tsx**: Wrap `onClick` handlers in arrow functions (`onClick={() => onAddRow()}`) to discard the event — 4 call sites fixed
- **database.ts**: Add plain-object prototype guard in `addRow` as defense-in-depth — rejects non-plain objects (MouseEvent, Array, etc.) before attempting insert
- **database.test.ts**: Regression test verifying `addRow` ignores a MouseEvent passed as `initialValues`
- **conventions.md**: Document the event handler argument leak anti-pattern

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 724 tests pass (including new regression test)