### PR TITLE
fix(editor): debounce save serialization and status updates (#539)

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -182,8 +182,11 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
     initialContent ? JSON.stringify(initialContent) : ""
   );
   const lastVersionSavedAtRef = useRef<number>(0);
-  // Track the latest pending state so we always save the most recent content
-  // and only show "Saved" when the persisted state matches the latest state.
+  // Track the latest pending editor state so we always save the most recent
+  // content. We store the EditorState object (immutable snapshot) and defer
+  // serialization to the debounced save — avoids JSON.stringify on every
+  // keystroke which was causing typing lag (#539).
+  const pendingEditorStateRef = useRef<EditorState | null>(null);
   const pendingJsonRef = useRef<SerializedEditorState | null>(null);
   const pendingSerializedRef = useRef<string | null>(null);
   const isSavingRef = useRef(false);
@@ -201,18 +204,15 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
   // is scheduled automatically once the current one completes. This prevents
   // an earlier save (e.g. empty table) from overwriting a later one (table
   // with cell text) — the root cause of #402.
+  //
+  // Serialization (toJSON + JSON.stringify) and the "saving" status update
+  // are deferred to the debounced save function so they don't run on every
+  // keystroke — the root cause of #539.
   const handleChange = useCallback(
     (editorState: EditorState) => {
-      const json = editorState.toJSON();
-      const serialized = JSON.stringify(json);
-
-      if (serialized === lastSavedRef.current) return;
-
-      // Always store the latest state so the save sends the newest content
-      pendingJsonRef.current = json;
-      pendingSerializedRef.current = serialized;
-
-      setSaveStatus("saving");
+      // Store the immutable EditorState snapshot — serialization is deferred
+      // to the debounced doSave to avoid JSON.stringify on every keystroke.
+      pendingEditorStateRef.current = editorState;
 
       if (saveTimerRef.current) {
         clearTimeout(saveTimerRef.current);
@@ -223,14 +223,31 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
       if (isSavingRef.current) return;
 
       const doSave = async () => {
-        const pendingJson = pendingJsonRef.current;
-        const pendingSerialized = pendingSerializedRef.current;
-        if (!pendingJson || !pendingSerialized) return;
+        // Serialize the latest pending editor state now (deferred from onChange)
+        const editorSnapshot = pendingEditorStateRef.current;
+        if (!editorSnapshot) return;
+
+        const json = editorSnapshot.toJSON();
+        const serialized = JSON.stringify(json);
+
+        // Skip save if content hasn't changed from last persisted state
+        if (serialized === lastSavedRef.current) {
+          pendingEditorStateRef.current = null;
+          return;
+        }
+
+        pendingJsonRef.current = json;
+        pendingSerializedRef.current = serialized;
 
         // Snapshot and clear so concurrent changes accumulate in a new pending slot
+        const pendingJson = pendingJsonRef.current;
+        const pendingSerialized = pendingSerializedRef.current;
         pendingJsonRef.current = null;
         pendingSerializedRef.current = null;
+        pendingEditorStateRef.current = null;
         isSavingRef.current = true;
+
+        setSaveStatus("saving");
 
         const supabase = await getClient();
         const { error } = await supabase
@@ -245,7 +262,7 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
 
           // If new changes arrived while this save was in-flight, re-save
           // instead of showing "Saved".
-          if (pendingSerializedRef.current !== null) {
+          if (pendingEditorStateRef.current !== null) {
             if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
             saveTimerRef.current = setTimeout(doSave, SAVE_DEBOUNCE_MS);
           } else {

--- a/src/components/editor/save-debounce.test.ts
+++ b/src/components/editor/save-debounce.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for #539: editor auto-save must not run expensive
+ * serialization or trigger React state updates on every keystroke.
+ * The handleChange callback should only store the EditorState ref and
+ * reset the debounce timer — all heavy work belongs in the debounced
+ * doSave function.
+ */
+describe("editor save debounce", () => {
+  const editorSource = readFileSync(
+    join(__dirname, "editor.tsx"),
+    "utf-8",
+  );
+
+  it("defines SAVE_DEBOUNCE_MS constant", () => {
+    expect(editorSource).toMatch(/const SAVE_DEBOUNCE_MS\s*=\s*\d+/);
+  });
+
+  it("does not call setSaveStatus in the synchronous handleChange body", () => {
+    // Extract the handleChange callback body (between the useCallback and doSave)
+    // The synchronous part is from "editorState: EditorState" to "const doSave"
+    const handleChangeStart = editorSource.indexOf(
+      "(editorState: EditorState) =>",
+    );
+    const doSaveStart = editorSource.indexOf("const doSave", handleChangeStart);
+    expect(handleChangeStart).toBeGreaterThan(-1);
+    expect(doSaveStart).toBeGreaterThan(handleChangeStart);
+
+    const synchronousBody = editorSource.slice(handleChangeStart, doSaveStart);
+    expect(synchronousBody).not.toContain("setSaveStatus");
+  });
+
+  it("does not call toJSON() or JSON.stringify in the synchronous handleChange body", () => {
+    const handleChangeStart = editorSource.indexOf(
+      "(editorState: EditorState) =>",
+    );
+    const doSaveStart = editorSource.indexOf("const doSave", handleChangeStart);
+    const synchronousBody = editorSource.slice(handleChangeStart, doSaveStart);
+
+    // Strip comments so we only check executable code
+    const codeOnly = synchronousBody
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("//"))
+      .join("\n");
+
+    expect(codeOnly).not.toContain(".toJSON()");
+    expect(codeOnly).not.toContain("JSON.stringify");
+  });
+
+  it("calls setSaveStatus inside the doSave function", () => {
+    const doSaveStart = editorSource.indexOf("const doSave");
+    expect(doSaveStart).toBeGreaterThan(-1);
+
+    const afterDoSave = editorSource.slice(doSaveStart);
+    expect(afterDoSave).toContain('setSaveStatus("saving")');
+    expect(afterDoSave).toContain('setSaveStatus("saved")');
+    expect(afterDoSave).toContain('setSaveStatus("error")');
+  });
+
+  it("stores EditorState ref for deferred serialization", () => {
+    // The handleChange should store the editor state in a ref, not serialize it
+    const handleChangeStart = editorSource.indexOf(
+      "(editorState: EditorState) =>",
+    );
+    const doSaveStart = editorSource.indexOf("const doSave", handleChangeStart);
+    const synchronousBody = editorSource.slice(handleChangeStart, doSaveStart);
+
+    expect(synchronousBody).toContain("pendingEditorStateRef.current");
+  });
+
+  it("uses setTimeout with SAVE_DEBOUNCE_MS for the save timer", () => {
+    expect(editorSource).toContain("setTimeout(doSave, SAVE_DEBOUNCE_MS)");
+  });
+});


### PR DESCRIPTION
Closes #539

## What

Every keystroke in the editor triggered `editorState.toJSON()`, `JSON.stringify()`, and `setSaveStatus("saving")` synchronously inside the `OnChangePlugin` onChange handler. While the actual Supabase save was properly debounced at 500ms, the expensive serialization and React state update ran on every keypress, causing re-renders and lag that interrupted the typing flow.

## How

Deferred all heavy work into the debounced `doSave` function:
- Store the immutable `EditorState` snapshot in a ref (cheap — just a pointer assignment)
- Only call `toJSON()` + `JSON.stringify()` when the debounce timer fires
- Only call `setSaveStatus("saving")` when the save actually starts executing

The save-coalescing logic (preventing earlier saves from overwriting later ones, re-scheduling on in-flight changes) is preserved — the check now uses `pendingEditorStateRef` instead of `pendingSerializedRef` to detect pending changes.

## Testing

Added `save-debounce.test.ts` — static analysis regression test that verifies:
- `setSaveStatus` is not called in the synchronous handleChange body
- `toJSON()` and `JSON.stringify` are not called in the synchronous handleChange body
- The `EditorState` ref is stored for deferred serialization
- All status updates happen inside the debounced `doSave` function

All 732 unit tests pass. Lint and typecheck clean.