### PR TITLE
fix(database): wrap DropdownMenuLabel inside DropdownMenuGroup

### DIFF
--- a/src/components/database/property-type-picker.test.ts
+++ b/src/components/database/property-type-picker.test.ts
@@ -24,6 +24,13 @@ function readTableView(): string {
   );
 }
 
+function readPropertyTypePicker(): string {
+  return readFileSync(
+    resolve(__dirname, "./property-type-picker.tsx"),
+    "utf-8",
+  );
+}
+
 describe("property type selector regression (#538)", () => {
   const viewClient = readViewClient();
 
@@ -51,5 +58,39 @@ describe("property type selector regression (#538)", () => {
   it("table view onAddColumn accepts a PropertyType parameter", () => {
     const tableView = readTableView();
     expect(tableView).toMatch(/onAddColumn\?\s*:\s*\(\s*type\s*:\s*PropertyType\s*\)/);
+  });
+});
+
+/**
+ * Regression test for issue #547 / Sentry MEMO-1E: DropdownMenuLabel must be
+ * inside DropdownMenuGroup.
+ *
+ * DropdownMenuLabel renders Base UI's Menu.GroupLabel, which requires a
+ * Menu.Group ancestor. When placed outside, Base UI throws error #31
+ * ("MenuGroupRootContext is missing").
+ */
+describe("DropdownMenuLabel inside DropdownMenuGroup (#547)", () => {
+  const source = readPropertyTypePicker();
+
+  it("every DropdownMenuLabel is preceded by a DropdownMenuGroup open tag (not a close tag)", () => {
+    // Find every <DropdownMenuLabel and check that the closest preceding
+    // DropdownMenuGroup tag is an opening tag, not a closing tag.
+    const labelPattern = /<DropdownMenuLabel/g;
+    let match: RegExpExecArray | null;
+    let count = 0;
+
+    while ((match = labelPattern.exec(source)) !== null) {
+      count++;
+      const before = source.slice(0, match.index);
+      const lastOpen = before.lastIndexOf("<DropdownMenuGroup");
+      const lastClose = before.lastIndexOf("</DropdownMenuGroup");
+
+      expect(lastOpen).toBeGreaterThan(
+        lastClose,
+      );
+    }
+
+    // Sanity: we found at least one label
+    expect(count).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/components/database/property-type-picker.tsx
+++ b/src/components/database/property-type-picker.tsx
@@ -32,9 +32,9 @@ export function PropertyTypePicker({ onSelect }: PropertyTypePickerProps) {
         <Plus className="h-3.5 w-3.5" />
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" align="start" className="w-48">
-        <DropdownMenuLabel>Property type</DropdownMenuLabel>
-        <DropdownMenuSeparator />
         <DropdownMenuGroup>
+          <DropdownMenuLabel>Property type</DropdownMenuLabel>
+          <DropdownMenuSeparator />
           {STANDARD_PROPERTY_TYPES.map((type) => {
             const Icon = PROPERTY_TYPE_ICON[type];
             return (
@@ -46,8 +46,8 @@ export function PropertyTypePicker({ onSelect }: PropertyTypePickerProps) {
           })}
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-        <DropdownMenuLabel>Advanced</DropdownMenuLabel>
         <DropdownMenuGroup>
+          <DropdownMenuLabel>Advanced</DropdownMenuLabel>
           {ADVANCED_PROPERTY_TYPES.map((type) => {
             const Icon = PROPERTY_TYPE_ICON[type];
             return (


### PR DESCRIPTION
## Summary

Fixes Base UI error #31 ("MenuGroupRootContext is missing") in the database property type picker dropdown.

**Sentry issue:** https://ona-2j.sentry.io/issues/MEMO-1E — 15 events, 10 users, escalating.

## Root Cause

`DropdownMenuLabel` renders Base UI's `Menu.GroupLabel`, which requires a `<Menu.Group>` ancestor context. In `property-type-picker.tsx`, both `<DropdownMenuLabel>` elements ("Property type" and "Advanced") were placed as siblings of `<DropdownMenuGroup>` instead of inside them. Every time a user opened the "Add column" dropdown on a database page, Base UI threw error #31.

## Changes

- **`src/components/database/property-type-picker.tsx`** — Moved each `DropdownMenuLabel` inside its corresponding `DropdownMenuGroup`
- **`src/components/database/property-type-picker.test.ts`** — Added static analysis regression test verifying every `DropdownMenuLabel` is nested inside a `DropdownMenuGroup`

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 738 tests pass (70 files)

Closes #547