### PR TITLE
fix(editor): restore immediate saving status indicator (#546)

### DIFF
--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -214,6 +214,10 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
       // to the debounced doSave to avoid JSON.stringify on every keystroke.
       pendingEditorStateRef.current = editorState;
 
+      // Show "Saving..." immediately so the user gets instant feedback.
+      // This is a cheap React state update — no serialization involved.
+      setSaveStatus("saving");
+
       if (saveTimerRef.current) {
         clearTimeout(saveTimerRef.current);
       }

--- a/src/components/editor/save-debounce.test.ts
+++ b/src/components/editor/save-debounce.test.ts
@@ -19,9 +19,9 @@ describe("editor save debounce", () => {
     expect(editorSource).toMatch(/const SAVE_DEBOUNCE_MS\s*=\s*\d+/);
   });
 
-  it("does not call setSaveStatus in the synchronous handleChange body", () => {
-    // Extract the handleChange callback body (between the useCallback and doSave)
-    // The synchronous part is from "editorState: EditorState" to "const doSave"
+  it("sets saving status synchronously for immediate user feedback", () => {
+    // The synchronous handleChange body should set "saving" status immediately
+    // (cheap state update) but must NOT do serialization — that stays in doSave.
     const handleChangeStart = editorSource.indexOf(
       "(editorState: EditorState) =>",
     );
@@ -30,7 +30,7 @@ describe("editor save debounce", () => {
     expect(doSaveStart).toBeGreaterThan(handleChangeStart);
 
     const synchronousBody = editorSource.slice(handleChangeStart, doSaveStart);
-    expect(synchronousBody).not.toContain("setSaveStatus");
+    expect(synchronousBody).toContain('setSaveStatus("saving")');
   });
 
   it("does not call toJSON() or JSON.stringify in the synchronous handleChange body", () => {


### PR DESCRIPTION
Closes #546

## What

PR #544 moved `setSaveStatus("saving")` into the debounced `doSave` function to avoid per-keystroke React state updates. This caused the "Saving..." indicator to no longer appear immediately after typing — it only showed when the 500ms debounce fired, making the transition too brief to observe. The E2E test `save status indicator shows Saving and Saved after editing` failed because "Saving" never appeared within the assertion window.

## How

Moved `setSaveStatus("saving")` back to the synchronous `onChange` handler. This is a cheap React state update (no serialization involved), so it doesn't regress the debounce optimization from #544. Serialization (`toJSON`, `JSON.stringify`) remains deferred to the debounced `doSave` function. Updated the static analysis test in `save-debounce.test.ts` to verify the saving status is set synchronously rather than forbidding it.

## Testing

- The E2E test `save status indicator shows Saving and Saved after editing` now passes — "Saving..." appears immediately after typing, then transitions to "Saved" after the debounced save completes.
- The static analysis test `save-debounce.test.ts` verifies `setSaveStatus("saving")` is in the synchronous body and serialization remains deferred.
- All 737 unit tests pass. Lint and typecheck clean.