### PR TITLE
fix: update E2E tests for PropertyTypePicker dropdown and rename dialog (#553)

### DIFF
--- a/e2e/database-crud.spec.ts
+++ b/e2e/database-crud.spec.ts
@@ -123,10 +123,16 @@ test.describe("Database CRUD", () => {
       timeout: 10_000,
     });
 
-    // Click the "Add column" button (+ icon in the last column header)
+    // Click the "Add column" button (+ icon in the last column header).
+    // This opens a PropertyTypePicker dropdown — select "Text".
     const addColumnBtn = page.locator('button[aria-label="Add column"]');
     await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
     await addColumnBtn.click();
+
+    // Select "Text" from the property type dropdown
+    const textMenuItem = page.getByRole("menuitem", { name: "Text" });
+    await expect(textMenuItem).toBeVisible({ timeout: 5_000 });
+    await textMenuItem.click();
 
     // Wait for the new column header to appear
     await page.waitForTimeout(1_500);
@@ -153,10 +159,15 @@ test.describe("Database CRUD", () => {
       timeout: 10_000,
     });
 
-    // Add a text property column so we have an editable cell
+    // Add a text property column so we have an editable cell.
+    // This opens a PropertyTypePicker dropdown — select "Text".
     const addColumnBtn = page.locator('button[aria-label="Add column"]');
     await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
     await addColumnBtn.click();
+
+    const textMenuItem = page.getByRole("menuitem", { name: "Text" });
+    await expect(textMenuItem).toBeVisible({ timeout: 5_000 });
+    await textMenuItem.click();
     await page.waitForTimeout(1_500);
 
     // Click on the property cell to start editing.
@@ -230,25 +241,33 @@ test.describe("Database CRUD", () => {
       timeout: 10_000,
     });
 
+    // Add a column via the PropertyTypePicker dropdown — select "Text".
     const addColumnBtn = page.locator('button[aria-label="Add column"]');
     await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
     await addColumnBtn.click();
+
+    const textMenuItem = page.getByRole("menuitem", { name: "Text" });
+    await expect(textMenuItem).toBeVisible({ timeout: 5_000 });
+    await textMenuItem.click();
     await page.waitForTimeout(1_500);
 
-    // Set up dialog handler before clicking the header.
-    // The rename uses window.prompt — handle it with a dialog listener.
-    page.on("dialog", async (dialog) => {
-      if (dialog.type() === "prompt") {
-        await dialog.accept("Renamed Column");
-      }
-    });
-
-    // Click the property column header button to trigger rename.
+    // Click the property column header button to open the rename dialog.
     const propertyHeader = page
       .locator('[role="columnheader"]', { hasText: /property/i })
       .first();
     const headerButton = propertyHeader.locator("button").first();
     await headerButton.click();
+
+    // The RenamePropertyDialog should appear with an input field.
+    const renameInput = page.locator('input#property-name');
+    await expect(renameInput).toBeVisible({ timeout: 5_000 });
+
+    // Clear the input and type the new name
+    await renameInput.fill("Renamed Column");
+
+    // Click the "Rename" button to confirm
+    const renameBtn = page.getByRole("button", { name: "Rename" });
+    await renameBtn.click();
 
     // Wait for the rename to take effect
     await page.waitForTimeout(2_000);

--- a/e2e/page-crud.spec.ts
+++ b/e2e/page-crud.spec.ts
@@ -89,9 +89,11 @@ test.describe("Page CRUD", () => {
     const titleBtn = treeItem.locator("button.flex-1").first();
     await titleBtn.click();
 
-    // Editor should be visible on the page
+    // The page could be a regular page (contenteditable editor) or a
+    // database page (grid view). Accept either as a successful navigation.
     const editor = page.locator('[contenteditable="true"]');
-    await expect(editor).toBeVisible({ timeout: 10_000 });
+    const grid = page.locator('[role="grid"], :text("No rows yet")');
+    await expect(editor.or(grid).first()).toBeVisible({ timeout: 10_000 });
   });
 
   test("user can rename a page via inline title", async ({


### PR DESCRIPTION
Closes #553

## What

Three `database-crud.spec.ts` E2E tests were broken because PR #543 changed the "Add column" button from a direct action to a `PropertyTypePicker` dropdown, and changed the column rename from `window.prompt` to a `RenamePropertyDialog`. The tests were not updated to interact with these new UI elements, causing the dropdown's overlay to block all subsequent pointer events and tests to time out.

Additionally, `page-crud.spec.ts` "user can navigate to a page via sidebar" was flaky because it clicked the first sidebar tree item (which could be a database page with no `contenteditable` editor).

## How

- **database-crud.spec.ts**: After clicking the "Add column" button, the tests now select "Text" from the `PropertyTypePicker` dropdown menu before proceeding. The rename test now interacts with the `RenamePropertyDialog` (fills the input field and clicks "Rename") instead of using a `window.prompt` dialog handler.
- **page-crud.spec.ts**: The sidebar navigation test now accepts either a `contenteditable` editor or a database grid/empty-state as valid page content after navigation.

## Testing

All 11 tests in `database-crud.spec.ts` and `page-crud.spec.ts` pass against the live site:
```
BASE_URL=https://memo.software-factory.dev pnpm test:e2e -- e2e/database-crud.spec.ts e2e/page-crud.spec.ts
```
`pnpm lint && pnpm typecheck && pnpm test` all pass.