### PR TITLE
fix: resolve E2E test failures from PropertyTypePicker overlay and test setup issues (#559)

### DIFF
--- a/e2e/database-list.spec.ts
+++ b/e2e/database-list.spec.ts
@@ -373,9 +373,11 @@ test.describe("Database list view", () => {
       { timeout: 15_000 },
     );
 
-    // The page should show the row title in the heading area
+    // The page should show the row title in the heading area.
+    // Use .first() because the title may appear in multiple places
+    // (page heading, sidebar tree item, breadcrumb).
     await expect(
-      page.getByRole("button", { name: "Item Alpha" }),
+      page.getByRole("button", { name: "Item Alpha" }).first(),
     ).toBeVisible({ timeout: 10_000 });
   });
 

--- a/e2e/database-row-page.spec.ts
+++ b/e2e/database-row-page.spec.ts
@@ -111,10 +111,15 @@ test.describe("Database Row Page", () => {
   }) => {
     await createDatabaseWithRow(page);
 
-    // Add a text property column so the row page has a property to display
+    // Add a text property column so the row page has a property to display.
+    // Select "Text" from the PropertyTypePicker dropdown to dismiss the overlay.
     const addColumnBtn = page.locator('button[aria-label="Add column"]');
     await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
     await addColumnBtn.click();
+
+    const textMenuItem = page.getByRole("menuitem", { name: "Text" });
+    await expect(textMenuItem).toBeVisible({ timeout: 5_000 });
+    await textMenuItem.click();
     await page.waitForTimeout(1_500);
 
     // Navigate to the row page

--- a/e2e/database-views.spec.ts
+++ b/e2e/database-views.spec.ts
@@ -73,6 +73,11 @@ async function addColumn(page: import("@playwright/test").Page) {
   const addColumnBtn = page.locator('button[aria-label="Add column"]');
   await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
   await addColumnBtn.click();
+
+  // Select "Text" from the PropertyTypePicker dropdown to dismiss the overlay
+  const textMenuItem = page.getByRole("menuitem", { name: "Text" });
+  await expect(textMenuItem).toBeVisible({ timeout: 5_000 });
+  await textMenuItem.click();
   await page.waitForTimeout(1_500);
 }
 

--- a/e2e/workspace-limit.spec.ts
+++ b/e2e/workspace-limit.spec.ts
@@ -14,21 +14,39 @@ function getAdminClient() {
 
 async function resolveTestUserId(): Promise<string> {
   const admin = getAdminClient();
-  const { data } = await admin.auth.admin.listUsers({ perPage: 1000 });
-  const user = data.users.find(
-    (u) => u.email === process.env.TEST_USER_EMAIL
-  );
-  if (!user) throw new Error("Test user not found");
-  return user.id;
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id")
+    .eq("email", process.env.TEST_USER_EMAIL!)
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(
+      `Test user ${process.env.TEST_USER_EMAIL} not found in profiles: ${error?.message ?? "no match"}`
+    );
+  }
+  return data.id;
 }
 
-async function cleanupTestWorkspaces(): Promise<void> {
+async function cleanupTestWorkspaces(userId?: string): Promise<void> {
   const admin = getAdminClient();
+
+  // Delete workspaces matching the test prefix
   await admin
     .from("workspaces")
     .delete()
     .eq("is_personal", false)
     .like("name", `${WS_PREFIX}%`);
+
+  // Also delete all non-personal workspaces created by the test user
+  // to handle stale data from crashed test runs
+  if (userId) {
+    await admin
+      .from("workspaces")
+      .delete()
+      .eq("is_personal", false)
+      .eq("created_by", userId);
+  }
 }
 
 /**
@@ -57,11 +75,11 @@ test.describe("Workspace creation limit", () => {
 
   test.beforeAll(async () => {
     userId = await resolveTestUserId();
-    await cleanupTestWorkspaces();
+    await cleanupTestWorkspaces(userId);
   });
 
   test.afterAll(async () => {
-    await cleanupTestWorkspaces();
+    await cleanupTestWorkspaces(userId);
   });
 
   test("enforces workspace creation limit end-to-end", async ({
@@ -97,6 +115,11 @@ test.describe("Workspace creation limit", () => {
     await nameInput.fill(ws2Name);
     await dialog.getByRole("button", { name: /create workspace/i }).click();
 
+    // Wait for navigation after second workspace creation
+    await page.waitForURL(
+      (url) => !url.pathname.includes("/sign-in"),
+      { timeout: 15_000 }
+    );
     await page.waitForLoadState("networkidle");
 
     // Reload to ensure the WorkspaceSwitcher has fresh data
@@ -115,7 +138,9 @@ test.describe("Workspace creation limit", () => {
       name: /create workspace/i,
     });
     await expect(createItem).toBeVisible({ timeout: 3_000 });
-    await expect(createItem.getByText("Limit reached")).toBeVisible();
+    await expect(createItem.getByText("Limit reached")).toBeVisible({
+      timeout: 5_000,
+    });
 
     // ── Step 3: Verify the dialog shows the limit message ──
 

--- a/e2e/workspace-settings.spec.ts
+++ b/e2e/workspace-settings.spec.ts
@@ -85,16 +85,41 @@ async function deleteTestWorkspace(workspaceId: string): Promise<void> {
  * Delete all non-personal workspaces owned by the given user.
  * Called in beforeAll to guarantee a clean slate regardless of what
  * previous (possibly crashed) test runs left behind.
+ *
+ * Also cleans up workspaces where the user is a member but not the
+ * creator (e.g. workspaces created via UI by other test files).
  */
 async function cleanupAllNonPersonalWorkspaces(
   userId: string
 ): Promise<void> {
   const admin = getAdminClient();
+
+  // Delete workspaces created by this user
   await admin
     .from("workspaces")
     .delete()
     .eq("is_personal", false)
     .eq("created_by", userId);
+
+  // Also delete any non-personal workspaces where the user is a member
+  // but not the creator (handles workspaces created via RPC where
+  // created_by might differ from expectations)
+  const { data: memberships } = await admin
+    .from("members")
+    .select("workspace_id, workspaces(id, is_personal)")
+    .eq("user_id", userId);
+
+  if (memberships) {
+    for (const m of memberships) {
+      const ws = m.workspaces as unknown as {
+        id: string;
+        is_personal: boolean;
+      };
+      if (ws && !ws.is_personal) {
+        await admin.from("workspaces").delete().eq("id", ws.id);
+      }
+    }
+  }
 }
 
 /**
@@ -130,7 +155,7 @@ test.describe("Workspace settings", () => {
     // Remove all non-personal workspaces for the test user to guarantee
     // we stay under the 3-workspace limit, even if a previous run crashed
     // and afterAll never ran.
-    await cleanupAllNonPersonalWorkspaces(userId).catch(() => {});
+    await cleanupAllNonPersonalWorkspaces(userId);
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
Closes #559

## What

Eight E2E tests were failing across five test files. Five tests in `database-views.spec.ts`, `database-row-page.spec.ts` failed because the `PropertyTypePicker` dropdown overlay (`data-base-ui-inert`) blocked pointer events on underlying elements after clicking "Add column". One test in `database-list.spec.ts` hit a Playwright strict mode violation because `getByRole('button', { name: 'Item Alpha' })` matched 3 elements. Two workspace tests failed due to workspace limit collisions between test files and insufficient wait times.

## How

- **database-views.spec.ts**: Updated the shared `addColumn` helper to select "Text" from the `PropertyTypePicker` dropdown after clicking "Add column", dismissing the overlay before subsequent interactions. This fixes all 5 overlay-blocked tests.
- **database-row-page.spec.ts**: Applied the same fix — select "Text" from the dropdown after clicking "Add column" to dismiss the overlay.
- **database-list.spec.ts**: Added `.first()` to the `getByRole('button', { name: 'Item Alpha' })` assertion to avoid strict mode violation when the title appears in multiple places (heading, sidebar, breadcrumb).
- **workspace-settings.spec.ts**: Made `cleanupAllNonPersonalWorkspaces` more thorough — it now also cleans up workspaces where the test user is a member (not just creator), handling stale data from other test files. Removed `.catch(() => {})` from `beforeAll` so cleanup failures surface instead of silently proceeding into a limit-exceeded state.
- **workspace-limit.spec.ts**: Added `waitForURL` after second workspace creation to ensure navigation completes before reload. Added timeout to "Limit reached" assertion. Made cleanup more robust by also deleting all non-personal workspaces by `created_by`. Switched `resolveTestUserId` from paginated `auth.admin.listUsers` to direct `profiles` table query (matching the pattern in `workspace-settings.spec.ts`).

## Testing

- `pnpm lint` — passes (0 errors)
- `pnpm typecheck` — passes
- `pnpm test` — all 738 unit tests pass
- All fixes follow the exact pattern proven in PR #556 for the overlay issue