### PR TITLE
fix: prevent duplicate key error on rapid addProperty double-click (#562)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1273,6 +1273,36 @@ if (error) {
 }
 ```
 
+### Duplicate key violations on concurrent mutations (PostgreSQL 23505)
+
+When a user rapidly triggers the same mutation (e.g. double-clicking "add
+property"), two identical inserts can race against a unique constraint before
+React state updates. PostgreSQL returns error code `23505`
+(`unique_violation`). This is an expected race condition, not an application
+bug.
+
+**Prevention:** Use a `useRef` boolean guard to prevent concurrent calls in
+event handlers that trigger inserts with auto-generated names:
+
+```typescript
+const isAdding = useRef(false);
+
+const handleAdd = useCallback(async () => {
+  if (isAdding.current) return;
+  isAdding.current = true;
+  try {
+    // ... insert logic
+  } finally {
+    isAdding.current = false;
+  }
+}, [deps]);
+```
+
+**Safety net:** `captureSupabaseError` automatically downgrades `23505` to
+warning level via `isDuplicateKeyError`. Client-side code that guards before
+calling `captureSupabaseError` can also skip `isDuplicateKeyError` to avoid
+reporting entirely.
+
 ### Supabase auth lock contention errors
 
 The Supabase client uses the Web Lock API to serialize auth token refresh.

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { toast } from "sonner";
@@ -182,6 +182,9 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     id: string;
     name: string;
   } | null>(null);
+
+  // Guard against concurrent addProperty calls (e.g. rapid double-click)
+  const isAddingColumn = useRef(false);
 
   // Active view: from URL ?view= param, or first view by position
   const viewIdFromUrl = searchParams.get("view");
@@ -552,13 +555,19 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
 
   const handleAddColumn = useCallback(
     async (type: PropertyType) => {
-      const name = `Property ${properties.length + 1}`;
-      const { data: newProp, error } = await addProperty(pageId, name, type);
-      if (error || !newProp) {
-        toast.error("Failed to add column", { duration: 8000 });
-        return;
+      if (isAddingColumn.current) return;
+      isAddingColumn.current = true;
+      try {
+        const name = `Property ${properties.length + 1}`;
+        const { data: newProp, error } = await addProperty(pageId, name, type);
+        if (error || !newProp) {
+          toast.error("Failed to add column", { duration: 8000 });
+          return;
+        }
+        setProperties((prev) => [...prev, newProp]);
+      } finally {
+        isAddingColumn.current = false;
       }
-      setProperties((prev) => [...prev, newProp]);
     },
     [pageId, properties.length],
   );

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -157,6 +157,27 @@ export function isForeignKeyViolationError(error: Error): boolean {
 }
 
 /**
+ * True when PostgreSQL raises `unique_violation` (23505). This occurs when a
+ * concurrent insert races against the same unique constraint — e.g. rapid
+ * double-click on "add property" generates the same auto-incremented name
+ * before state updates. This is an expected race condition, not an application
+ * bug, so it should be reported at warning level.
+ *
+ * Matches two shapes:
+ * 1. PostgrestError objects with `code: "23505"` (from `{ data, error }` path)
+ * 2. Generic Error with a `code` property set to `"23505"` (thrown path)
+ */
+export function isDuplicateKeyError(error: Error): boolean {
+  if (isPostgrestError(error)) {
+    return error.code === "23505";
+  }
+  return (
+    "code" in error &&
+    (error as Record<string, unknown>).code === "23505"
+  );
+}
+
+/**
  * Node.js native fetch (undici) wraps the real network error in the `cause`
  * property. These substrings in the cause message indicate transient failures.
  */
@@ -311,6 +332,7 @@ export function captureSupabaseError(
     isSchemaNotFoundError(error) ||
     isInsufficientPrivilegeError(error) ||
     isForeignKeyViolationError(error) ||
+    isDuplicateKeyError(error) ||
     isSupabaseAuthLockError(error)
   ) {
     lazyCaptureException(error, { extra, level: "warning" });

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -13,6 +13,7 @@ import {
   isSchemaNotFoundError,
   isInsufficientPrivilegeError,
   isForeignKeyViolationError,
+  isDuplicateKeyError,
   isSupabaseAuthLockError,
   isSupabaseAuthLockContention,
   captureSupabaseError,
@@ -334,6 +335,53 @@ describe("isForeignKeyViolationError", () => {
   });
 });
 
+describe("isDuplicateKeyError", () => {
+  it("detects PostgreSQL 23505 (unique_violation) from PostgrestError", () => {
+    const error = makePostgrestError({
+      message: 'duplicate key value violates unique constraint "database_properties_db_name"',
+      code: "23505",
+    });
+    expect(isDuplicateKeyError(error)).toBe(true);
+  });
+
+  it("detects 23505 from generic Error with code property (thrown path)", () => {
+    const error = Object.assign(
+      new Error('duplicate key value violates unique constraint "database_properties_db_name"'),
+      { code: "23505" },
+    );
+    expect(isDuplicateKeyError(error)).toBe(true);
+  });
+
+  it("returns false for other PostgrestError codes", () => {
+    const error = makePostgrestError({
+      message: "foreign key violation",
+      code: "23503",
+    });
+    expect(isDuplicateKeyError(error)).toBe(false);
+  });
+
+  it("returns false for RLS violations (42501)", () => {
+    const error = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    expect(isDuplicateKeyError(error)).toBe(false);
+  });
+
+  it("returns false for generic errors without code", () => {
+    const error = new Error("Something went wrong");
+    expect(isDuplicateKeyError(error)).toBe(false);
+  });
+
+  it("returns false for generic Error with non-23505 code property", () => {
+    const error = Object.assign(
+      new Error("foreign key violation"),
+      { code: "23503" },
+    );
+    expect(isDuplicateKeyError(error)).toBe(false);
+  });
+});
+
 describe("isSupabaseAuthLockError", () => {
   it("detects AbortError in PostgrestError details (MEMO-16/17/19)", () => {
     const error = makePostgrestError({
@@ -503,18 +551,18 @@ describe("captureSupabaseError", () => {
     expect(opts.extra.operation).toBe("create-workspace-dialog:create");
   });
 
-  it("captures non-network, non-RLS errors at default (error) level", async () => {
+  it("captures duplicate key violations (23505) at warning level (MEMO-1G)", async () => {
     const error = makePostgrestError({
       message: "duplicate key value violates unique constraint",
       code: "23505",
     });
-    captureSupabaseError(error, "pages.insert");
+    captureSupabaseError(error, "database.addProperty");
     await flush();
 
     expect(captureExceptionMock).toHaveBeenCalledOnce();
     const [, opts] = captureExceptionMock.mock.calls[0];
-    expect(opts.level).toBeUndefined();
-    expect(opts.extra.operation).toBe("pages.insert");
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("database.addProperty");
     expect(opts.extra.code).toBe("23505");
   });
 


### PR DESCRIPTION
Closes #562

## What

Rapidly clicking "add property" in database view triggers a duplicate key violation (`23505`) on the `database_properties_db_name` unique constraint. Both clicks compute the same auto-generated name (`Property N`) from `properties.length` before `setProperties` updates state, causing the second insert to fail. The error was captured at error level in Sentry (MEMO-1G).

## How

1. Added an `isAddingColumn` ref guard in `handleAddColumn` to prevent concurrent calls — the second click is silently ignored while the first is in-flight.
2. Added `isDuplicateKeyError` helper to `src/lib/sentry.ts` that detects PostgreSQL error code `23505` (both PostgrestError and generic Error shapes).
3. Added `isDuplicateKeyError` to the warning-level classification in `captureSupabaseError` as a safety net — any 23505 that slips past the UI guard is downgraded to warning instead of flooding Sentry at error level.
4. Documented the duplicate key race condition pattern in `.agents/conventions.md`.

## Testing

- Updated existing test that asserted 23505 was captured at error level — now asserts warning level.
- Added 6 new tests for `isDuplicateKeyError`: PostgrestError detection, generic Error with code property, and negative cases for other error codes.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (744 tests, 0 failures).