### PR TITLE
fix: default column name matches selected type and use registry editors in table view (#563)

### DIFF
--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -36,6 +36,7 @@ import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
+import { PROPERTY_TYPE_LABEL } from "@/lib/property-icons";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -558,7 +559,14 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       if (isAddingColumn.current) return;
       isAddingColumn.current = true;
       try {
-        const name = `Property ${properties.length + 1}`;
+        const baseLabel = PROPERTY_TYPE_LABEL[type];
+        const existingNames = new Set(properties.map((p) => p.name));
+        let name = baseLabel;
+        let suffix = 2;
+        while (existingNames.has(name)) {
+          name = `${baseLabel} ${suffix}`;
+          suffix++;
+        }
         const { data: newProp, error } = await addProperty(pageId, name, type);
         if (error || !newProp) {
           toast.error("Failed to add column", { duration: 8000 });
@@ -569,7 +577,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         isAddingColumn.current = false;
       }
     },
-    [pageId, properties.length],
+    [pageId, properties],
   );
 
   const handleColumnHeaderClick = useCallback(

--- a/src/components/database/property-type-picker.test.ts
+++ b/src/components/database/property-type-picker.test.ts
@@ -62,6 +62,71 @@ describe("property type selector regression (#538)", () => {
 });
 
 /**
+ * Regression test for issue #563: default column name should match the selected
+ * property type instead of using a generic "Property N" name.
+ */
+describe("default column name matches property type (#563)", () => {
+  const viewClient = readViewClient();
+
+  it("imports PROPERTY_TYPE_LABEL from property-icons", () => {
+    expect(viewClient).toContain("PROPERTY_TYPE_LABEL");
+    expect(viewClient).toMatch(
+      /import\s*\{[^}]*PROPERTY_TYPE_LABEL[^}]*\}\s*from\s*["']@\/lib\/property-icons["']/,
+    );
+  });
+
+  it("does not use the generic 'Property N' naming pattern", () => {
+    // The old pattern: `Property ${properties.length + 1}`
+    expect(viewClient).not.toMatch(/`Property \$\{properties\.length/);
+  });
+
+  it("generates a name from PROPERTY_TYPE_LABEL[type]", () => {
+    expect(viewClient).toMatch(/PROPERTY_TYPE_LABEL\[type\]/);
+  });
+
+  it("handles name collisions by appending a number suffix", () => {
+    // Must check existing names and append a suffix when there's a collision
+    expect(viewClient).toMatch(/existingNames\.has\(name\)/);
+    expect(viewClient).toMatch(/`\$\{baseLabel\} \$\{suffix\}`/);
+  });
+});
+
+/**
+ * Regression test for issue #563: date cells in table view should use the
+ * DateEditor (calendar picker) instead of a plain text input.
+ */
+describe("table view uses registry editors for specialized types (#563)", () => {
+  const tableView = readTableView();
+
+  it("uses getPropertyTypeConfig to look up editors in the editing path", () => {
+    // The editing branch must call getPropertyTypeConfig to get the Editor
+    expect(tableView).toMatch(/getPropertyTypeConfig\(propertyType\)/);
+  });
+
+  it("renders a RegistryEditorCell for non-text-input types", () => {
+    expect(tableView).toContain("RegistryEditorCell");
+  });
+
+  it("does not use plain input for date type editing", () => {
+    // The plain-input exclusion list only includes text, number, url, email, phone.
+    // Date is NOT excluded, so it uses the registry editor (DateEditor / calendar picker).
+    const plainInputTypes = tableView.match(
+      /hasRegistryEditor\s*=[\s\S]+?;/,
+    )?.[0];
+    expect(plainInputTypes).toBeDefined();
+    // date should NOT be in the plain-input exclusion list
+    expect(plainInputTypes).not.toContain('"date"');
+  });
+
+  it("RegistryEditorCell passes value, property, onChange, and onBlur to Editor", () => {
+    expect(tableView).toMatch(/<Editor[\s\S]*?value=\{/);
+    expect(tableView).toMatch(/<Editor[\s\S]*?property=\{property\}/);
+    expect(tableView).toMatch(/<Editor[\s\S]*?onChange=\{/);
+    expect(tableView).toMatch(/<Editor[\s\S]*?onBlur=\{/);
+  });
+});
+
+/**
  * Regression test for issue #547 / Sentry MEMO-1E: DropdownMenuLabel must be
  * inside DropdownMenuGroup.
  *

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -722,6 +722,31 @@ function TableCell({
     propertyType === "created_by";
 
   if (isEditing && !isReadOnly) {
+    // Types with specialized editors use the registry Editor component.
+    // Simple text-input types (text, number, url, email, phone) use a plain <input>.
+    const config = getPropertyTypeConfig(propertyType);
+    const hasRegistryEditor =
+      config?.Editor &&
+      propertyType !== "text" &&
+      propertyType !== "number" &&
+      propertyType !== "url" &&
+      propertyType !== "email" &&
+      propertyType !== "phone";
+
+    if (hasRegistryEditor) {
+      return (
+        <RegistryEditorCell
+          rowId={rowId}
+          propertyId={propertyId}
+          property={property}
+          propertyType={propertyType}
+          value={value}
+          rowHeightClass={rowHeightClass}
+          onBlur={onBlur}
+        />
+      );
+    }
+
     return (
       <div
         className={cn(
@@ -825,6 +850,64 @@ function TableCell({
         value={value}
         propertyType={propertyType}
         displayValue={displayValue}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RegistryEditorCell — wraps a registry Editor, tracks value changes via ref,
+// and commits the latest value on blur so onChange→onBlur sequences work.
+// ---------------------------------------------------------------------------
+
+interface RegistryEditorCellProps {
+  rowId: string;
+  propertyId: string;
+  property: DatabaseProperty;
+  propertyType: PropertyType;
+  value: RowValue | undefined;
+  rowHeightClass: string;
+  onBlur: (rowId: string, propertyId: string, newValue: Record<string, unknown>) => void;
+}
+
+function RegistryEditorCell({
+  rowId,
+  propertyId,
+  property,
+  propertyType,
+  value,
+  rowHeightClass,
+  onBlur,
+}: RegistryEditorCellProps) {
+  const config = getPropertyTypeConfig(propertyType);
+  const Editor = config!.Editor!;
+  const latestValue = useRef<Record<string, unknown>>(value?.value ?? {});
+
+  const handleChange = useCallback(
+    (newValue: Record<string, unknown>) => {
+      latestValue.current = newValue;
+      onBlur(rowId, propertyId, newValue);
+    },
+    [rowId, propertyId, onBlur],
+  );
+
+  const handleBlur = useCallback(() => {
+    onBlur(rowId, propertyId, latestValue.current);
+  }, [rowId, propertyId, onBlur]);
+
+  return (
+    <div
+      className={cn(
+        "relative border-b border-white/[0.06]",
+        rowHeightClass,
+      )}
+      role="gridcell"
+    >
+      <Editor
+        value={value?.value ?? {}}
+        property={property}
+        onChange={handleChange}
+        onBlur={handleBlur}
       />
     </div>
   );


### PR DESCRIPTION
Closes #563

## What

Two bugs in the database table view:

1. Adding a new column via "Add column" named it `Property N` regardless of the selected type. Users expected the column name to match the type (e.g., "Date", "Number", "Select").

2. Editing a date cell rendered a plain text input instead of the `DateEditor` calendar picker. The registry had the correct `DateEditor` component, but the `TableCell` editing path always fell through to a generic `<input>`.

## How

1. **Column naming** — `handleAddColumn` in `database-view-client.tsx` now uses `PROPERTY_TYPE_LABEL[type]` (the existing label map) as the default name. If a column with that name already exists, it appends a numeric suffix (e.g., "Date 2").

2. **Registry editors** — The `TableCell` editing branch in `table-view.tsx` now checks `getPropertyTypeConfig()` for types that have specialized editors (`date`, `select`, `multi_select`, `checkbox`, `person`, `files`, `relation`). These types render through a new `RegistryEditorCell` wrapper that manages value tracking via a ref so the onChange→onBlur sequence from editors like `DatePicker` works correctly. Simple text-input types (`text`, `number`, `url`, `email`, `phone`) continue using the plain `<input>`.

## Testing

- Added static analysis regression tests in `property-type-picker.test.ts`:
  - Verifies `PROPERTY_TYPE_LABEL` is imported and used for column naming
  - Verifies the generic `Property N` pattern is no longer present
  - Verifies name collision handling with suffix logic
  - Verifies `getPropertyTypeConfig` is used in the editing path
  - Verifies `RegistryEditorCell` exists and passes correct props to Editor
  - Verifies `date` is not in the plain-input exclusion list
- `pnpm lint && pnpm typecheck && pnpm test` all pass (0 errors, 752 tests)