### PR TITLE
fix: toggle block Enter key does not create a new line (#540)

### DIFF
--- a/src/components/editor/collapsible-node.tsx
+++ b/src/components/editor/collapsible-node.tsx
@@ -4,12 +4,14 @@ import type {
   DOMExportOutput,
   LexicalNode,
   NodeKey,
+  RangeSelection,
   SerializedElementNode,
   Spread,
 } from "lexical";
 import {
   $applyNodeReplacement,
   $createParagraphNode,
+  $isElementNode,
   ElementNode,
 } from "lexical";
 
@@ -152,6 +154,34 @@ export class CollapsibleTitleNode extends ElementNode {
 
   isInline(): boolean {
     return false;
+  }
+
+  insertNewAfter(_selection: RangeSelection): LexicalNode | null {
+    // Enter in the title: move cursor into the content area.
+    const container = this.getParent();
+    if (container instanceof CollapsibleContainerNode) {
+      const contentNode = this.getNextSibling();
+      if (contentNode instanceof CollapsibleContentNode) {
+        const firstChild = contentNode.getFirstChild();
+        if ($isElementNode(firstChild)) {
+          firstChild.selectStart();
+        } else {
+          // Content is empty — insert a paragraph and select it
+          const paragraph = $createParagraphNode();
+          contentNode.append(paragraph);
+          paragraph.selectStart();
+        }
+        // Ensure the toggle is open so the user can see the content
+        if (!container.getOpen()) {
+          container.setOpen(true);
+        }
+        return null;
+      }
+    }
+    // Fallback: create a paragraph after the title
+    const paragraph = $createParagraphNode();
+    this.insertAfter(paragraph);
+    return paragraph;
   }
 
   collapseAtStart(): boolean {

--- a/src/components/editor/collapsible-plugin.tsx
+++ b/src/components/editor/collapsible-plugin.tsx
@@ -8,8 +8,11 @@ import {
   $getNodeByKey,
   $getSelection,
   $insertNodes,
+  $isParagraphNode,
   $isRangeSelection,
   COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_LOW,
+  KEY_ENTER_COMMAND,
   createCommand,
   type LexicalCommand,
 } from "lexical";
@@ -17,6 +20,8 @@ import {
   $createCollapsibleContainerNode,
   $createCollapsibleContentNode,
   $createCollapsibleTitleNode,
+  $isCollapsibleContainerNode,
+  $isCollapsibleContentNode,
   CollapsibleContainerNode,
   CollapsibleContentNode,
   CollapsibleTitleNode,
@@ -42,7 +47,7 @@ export function CollapsiblePlugin(): null {
       );
     }
 
-    return editor.registerCommand(
+    const unregisterInsert = editor.registerCommand(
       INSERT_COLLAPSIBLE_COMMAND,
       () => {
         editor.update(() => {
@@ -75,6 +80,65 @@ export function CollapsiblePlugin(): null {
       },
       COMMAND_PRIORITY_EDITOR
     );
+
+    // When Enter is pressed on an empty last paragraph inside collapsible
+    // content, escape the collapsible by moving the paragraph after the
+    // container. This mirrors the behavior of lists and block quotes.
+    const unregisterEnter = editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (event) => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          return false;
+        }
+
+        const anchorNode = selection.anchor.getNode();
+        const parentBlock =
+          $isParagraphNode(anchorNode)
+            ? anchorNode
+            : anchorNode.getParent();
+
+        if (
+          !$isParagraphNode(parentBlock) ||
+          parentBlock.getTextContentSize() !== 0
+        ) {
+          return false;
+        }
+
+        const contentNode = parentBlock.getParent();
+        if (!$isCollapsibleContentNode(contentNode)) {
+          return false;
+        }
+
+        // Only escape when the empty paragraph is the last child
+        if (contentNode.getLastChild()?.getKey() !== parentBlock.getKey()) {
+          return false;
+        }
+
+        const container = contentNode.getParent();
+        if (!$isCollapsibleContainerNode(container)) {
+          return false;
+        }
+
+        if (event) {
+          event.preventDefault();
+        }
+
+        // Move the empty paragraph out of the collapsible
+        parentBlock.remove();
+        const newParagraph = $createParagraphNode();
+        container.insertAfter(newParagraph);
+        newParagraph.selectStart();
+
+        return true;
+      },
+      COMMAND_PRIORITY_LOW
+    );
+
+    return () => {
+      unregisterInsert();
+      unregisterEnter();
+    };
   }, [editor]);
 
   // Handle toggle open/close via the chevron button.

--- a/src/components/editor/collapsible-toggle.test.ts
+++ b/src/components/editor/collapsible-toggle.test.ts
@@ -87,3 +87,51 @@ describe("collapsible chevron CSS rotation", () => {
     expect(css).toContain("rotate(90deg)");
   });
 });
+
+/**
+ * Regression tests for issue #540: Enter key does not create a new line
+ * after toggle blocks.
+ *
+ * Root cause: CollapsibleTitleNode did not implement insertNewAfter, so
+ * Lexical's insertParagraph received null and did nothing. Additionally,
+ * there was no KEY_ENTER_COMMAND handler to let users escape the content
+ * area by pressing Enter on an empty trailing paragraph.
+ */
+describe("collapsible Enter key handling (#540)", () => {
+  const nodeSource = readSource("./collapsible-node.tsx");
+  const pluginSource = readSource("./collapsible-plugin.tsx");
+
+  it("CollapsibleTitleNode implements insertNewAfter", () => {
+    // Without insertNewAfter, pressing Enter in the title does nothing
+    // because ElementNode.insertNewAfter returns null by default.
+    expect(nodeSource).toContain("insertNewAfter(");
+    // Must reference CollapsibleContentNode to move cursor into content
+    expect(nodeSource).toMatch(
+      /insertNewAfter[\s\S]*CollapsibleContentNode/
+    );
+  });
+
+  it("CollapsibleTitleNode opens the container when entering content", () => {
+    // If the toggle is closed, entering the content area must open it
+    // so the user can see where the cursor moved.
+    expect(nodeSource).toMatch(
+      /insertNewAfter[\s\S]*setOpen\(true\)/
+    );
+  });
+
+  it("plugin registers KEY_ENTER_COMMAND for escaping content", () => {
+    // A KEY_ENTER_COMMAND handler must exist to let users break out of
+    // the collapsible content by pressing Enter on an empty last paragraph.
+    expect(pluginSource).toContain("KEY_ENTER_COMMAND");
+    expect(pluginSource).toContain("$isCollapsibleContentNode");
+    expect(pluginSource).toContain("$isCollapsibleContainerNode");
+  });
+
+  it("escape handler only triggers on empty last paragraph", () => {
+    // The handler must check that the paragraph is empty and is the
+    // last child of the content node to avoid interfering with normal
+    // paragraph creation inside the content area.
+    expect(pluginSource).toContain("getTextContentSize() !== 0");
+    expect(pluginSource).toContain("getLastChild()");
+  });
+});


### PR DESCRIPTION
Closes #540

## What

Pressing Enter inside a toggle (collapsible) block did nothing — the cursor stayed in place and no new block was created. This blocked basic content creation after inserting a toggle.

The root cause was twofold:
1. `CollapsibleTitleNode` did not implement `insertNewAfter`, so Lexical's `insertParagraph` received `null` and silently did nothing when Enter was pressed in the title.
2. There was no `KEY_ENTER_COMMAND` handler to let users escape the collapsible content area by pressing Enter on an empty trailing paragraph.

## How

- Added `insertNewAfter` to `CollapsibleTitleNode` that moves the cursor into the content area's first paragraph (creating one if needed) and ensures the toggle is open.
- Added a `KEY_ENTER_COMMAND` handler in `CollapsiblePlugin` that detects Enter on an empty last paragraph inside `CollapsibleContentNode`, removes it, and creates a new paragraph after the container — escaping the collapsible. This mirrors the escape behavior of lists and block quotes.

## Testing

Added 4 static analysis regression tests in `collapsible-toggle.test.ts` verifying:
- `CollapsibleTitleNode` implements `insertNewAfter` and references `CollapsibleContentNode`
- The title handler opens the container when entering content
- The plugin registers `KEY_ENTER_COMMAND` with proper content/container node checks
- The escape handler only triggers on empty last paragraphs