### PR TITLE
fix: database view uses full page width instead of editor max-width (#569)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/[pageId]/database-width.test.ts
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/database-width.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression test for issue #569: database view should use full page width.
+ *
+ * Database pages must not be constrained by max-w-3xl. The page layout
+ * conditionally applies the max-width based on the isDatabase flag.
+ */
+
+const PAGE_DIR = resolve(__dirname);
+
+describe("database page width (#569)", () => {
+  it("page layout conditionally applies max-w-3xl based on isDatabase", () => {
+    const page = readFileSync(resolve(PAGE_DIR, "page.tsx"), "utf-8");
+    // The outer container must use a conditional class that omits max-w-3xl for databases
+    expect(page).toContain("isDatabase");
+    expect(page).toMatch(/isDatabase\s*\?\s*""\s*:\s*"max-w-3xl"/);
+  });
+
+  it("non-database pages still get max-w-3xl constraint", () => {
+    const page = readFileSync(resolve(PAGE_DIR, "page.tsx"), "utf-8");
+    // The conditional must include max-w-3xl for the non-database branch
+    expect(page).toContain('max-w-3xl');
+  });
+
+  it("database pages get full width (no max-w-3xl)", () => {
+    const page = readFileSync(resolve(PAGE_DIR, "page.tsx"), "utf-8");
+    // The outer div must NOT have a hardcoded max-w-3xl — it must be conditional
+    expect(page).not.toMatch(/className="mx-auto max-w-3xl p-6"/);
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -257,7 +257,7 @@ export default async function PageView({
   const isDatabase = page.is_database === true;
 
   return (
-    <div className="mx-auto max-w-3xl p-6">
+    <div className={`mx-auto p-6 ${isDatabase ? "" : "max-w-3xl"}`}>
       <div className="mb-2">
         <PageBreadcrumb items={breadcrumbItems} />
       </div>


### PR DESCRIPTION
Closes #569

## What

The database view was constrained to `max-w-3xl` (the same max-width as the text editor), causing unnecessary horizontal scrolling on wider screens when a database had multiple columns. Database tables need more horizontal space than prose content.

## How

The page layout container in `page.tsx` now conditionally applies `max-w-3xl` only for non-database pages. Database pages (`is_database === true`) get full available width while text editor pages retain the existing `max-w-3xl` constraint for readability. The `isDatabase` flag was already computed from the Supabase query — the fix uses it to toggle the class.

## Testing

Added `database-width.test.ts` — a static analysis regression test that verifies:
- The page layout conditionally applies `max-w-3xl` based on `isDatabase`
- Non-database pages still get the `max-w-3xl` constraint
- The outer container no longer has a hardcoded `max-w-3xl`

All 755 unit tests pass. Lint and typecheck clean.