### PR TITLE
fix: skip Sentry reporting for RLS violations in database cell updates (#578)

### DIFF
--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -514,6 +514,9 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
 
       const { error } = await updateRowValue(rowId, propertyId, newValue);
       if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-view:move-card");
+        }
         toast.error("Failed to move card", { duration: 8000 });
       }
     },
@@ -548,6 +551,9 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
 
       const { error } = await updateRowValue(rowId, propertyId, value);
       if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-view:update-cell");
+        }
         toast.error("Failed to update cell", { duration: 8000 });
       }
     },

--- a/src/lib/database.test.ts
+++ b/src/lib/database.test.ts
@@ -474,17 +474,14 @@ describe("updateRowValue", () => {
     expect(tableMocks["row_values"].calls["upsert"]).toBeDefined();
   });
 
-  it("captures error on failure", async () => {
+  it("returns error without reporting to Sentry (callers decide)", async () => {
     const dbError = new Error("upsert failed");
     mockTable("row_values", { data: null, error: dbError });
 
     const result = await updateRowValue("row-1", "prop-1", { text: "X" });
 
     expect(result.error).toBe(dbError);
-    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
-      dbError,
-      "database.updateRowValue",
-    );
+    expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -377,7 +377,6 @@ export async function updateRowValue(
     .single();
 
   if (error) {
-    captureSupabaseError(error, "database.updateRowValue");
     return { data: null, error };
   }
   return { data: data as RowValue, error: null };


### PR DESCRIPTION
Closes #578

## What

`handleCellUpdate` and `handleCardMove` in `database-view-client.tsx` triggered Sentry warnings for RLS violations (PostgreSQL 42501) when users hit workspace limits. The user already sees a toast error, so these reports are noise. This is the same class of issue already fixed for `handleDeleteRow` in the same file.

## How

Moved Sentry error reporting out of `updateRowValue` in `database.ts` and into its callers, matching the established pattern where callers decide what to report. Added `isInsufficientPrivilegeError` guards in `handleCellUpdate` and `handleCardMove`, consistent with the existing `handleDeleteRow` guard and the client-side RLS skip convention in `.agents/conventions.md`.

## Testing

- Updated the `updateRowValue` unit test to verify it no longer calls `captureSupabaseError` (callers are now responsible).
- The existing static analysis test in `sentry.test.ts` enforces that all client components importing `captureSupabaseError` also import `isInsufficientPrivilegeError`.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (763 tests, 0 failures).