### PR TITLE
fix(database): add files and relation types to PropertyTypePicker (#585)

### DIFF
--- a/src/components/database/property-type-picker-completeness.test.ts
+++ b/src/components/database/property-type-picker-completeness.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  STANDARD_PROPERTY_TYPES,
+  ADVANCED_PROPERTY_TYPES,
+  getPropertyTypeConfig,
+} from "./property-types";
+import { PROPERTY_TYPE_ICON, PROPERTY_TYPE_LABEL } from "@/lib/property-icons";
+import type { PropertyType } from "@/lib/types";
+
+/**
+ * Regression test for issue #585: files and relation property types were
+ * registered in the renderer/editor registry but missing from the picker
+ * arrays, making them impossible to create from the UI.
+ */
+describe("property type picker completeness (#585)", () => {
+  const allPickerTypes: readonly PropertyType[] = [
+    ...STANDARD_PROPERTY_TYPES,
+    ...ADVANCED_PROPERTY_TYPES,
+  ];
+
+  it("includes 'files' in the picker", () => {
+    expect(allPickerTypes).toContain("files");
+  });
+
+  it("includes 'relation' in the picker", () => {
+    expect(allPickerTypes).toContain("relation");
+  });
+
+  it("every registered property type with an editor is in the picker", () => {
+    // All types that have a renderer+editor in the registry should be
+    // selectable in the picker. Read-only computed types (Editor: null)
+    // are included in the advanced section.
+    const allPropertyTypes: PropertyType[] = [
+      "text",
+      "number",
+      "select",
+      "multi_select",
+      "checkbox",
+      "date",
+      "url",
+      "email",
+      "phone",
+      "person",
+      "files",
+      "relation",
+      "formula",
+      "created_time",
+      "updated_time",
+      "created_by",
+    ];
+
+    for (const type of allPropertyTypes) {
+      const config = getPropertyTypeConfig(type);
+      if (config) {
+        expect(
+          allPickerTypes,
+          `registered type "${type}" should be in STANDARD or ADVANCED arrays`,
+        ).toContain(type);
+      }
+    }
+  });
+
+  it("every picker type has an icon and label", () => {
+    for (const type of allPickerTypes) {
+      expect(
+        PROPERTY_TYPE_ICON[type],
+        `missing icon for "${type}"`,
+      ).toBeDefined();
+      expect(
+        PROPERTY_TYPE_LABEL[type],
+        `missing label for "${type}"`,
+      ).toBeDefined();
+    }
+  });
+
+  it("has no duplicate types across standard and advanced arrays", () => {
+    const seen = new Set<string>();
+    for (const type of allPickerTypes) {
+      expect(seen.has(type), `duplicate type "${type}" in picker arrays`).toBe(
+        false,
+      );
+      seen.add(type);
+    }
+  });
+});

--- a/src/components/database/property-types/index.ts
+++ b/src/components/database/property-types/index.ts
@@ -106,7 +106,7 @@ const registry: Partial<Record<PropertyType, PropertyTypeConfig>> = {
 
 /**
  * Look up the renderer and editor for a property type.
- * Returns undefined for types not yet implemented (files, formula).
+ * Returns undefined for types not yet implemented.
  * Computed types (created_time, updated_time, created_by) have Editor: null.
  */
 export function getPropertyTypeConfig(
@@ -131,10 +131,12 @@ export const STANDARD_PROPERTY_TYPES: readonly PropertyType[] = [
   "email",
   "phone",
   "person",
+  "files",
 ] as const;
 
 /** Auto-derived read-only property types shown under "Advanced" in type pickers. */
 export const ADVANCED_PROPERTY_TYPES: readonly PropertyType[] = [
+  "relation",
   "formula",
   "created_time",
   "updated_time",


### PR DESCRIPTION
Closes #585

## What

The `files` and `relation` property types had full renderer/editor implementations registered in the property type registry, but were missing from the `STANDARD_PROPERTY_TYPES` and `ADVANCED_PROPERTY_TYPES` arrays used by the `PropertyTypePicker` dropdown. Users could not create columns of these types from the UI.

## How

Added `"files"` to `STANDARD_PROPERTY_TYPES` (it's a standard editable type like person) and `"relation"` to `ADVANCED_PROPERTY_TYPES` (it requires target database configuration, fitting the advanced category). Also fixed a stale JSDoc comment that incorrectly listed files as "not yet implemented."

## Testing

Added `property-type-picker-completeness.test.ts` with regression tests that:
- Verify `files` and `relation` are present in the picker arrays
- Verify every registered property type in the registry is included in the picker
- Verify every picker type has a corresponding icon and label
- Verify no duplicate types across standard and advanced arrays

All 768 unit tests pass. Lint and typecheck clean. E2E tests could not run locally (dev server requires Supabase env vars) — CI will validate.