### PR TITLE
fix: safe JSON parse in delete-account client and statement timeout classification

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1424,6 +1424,43 @@ if (error) {
 }
 ```
 
+### Statement timeouts (PostgreSQL 57014)
+
+When a query or RPC exceeds the configured statement timeout, PostgreSQL returns
+error code `57014`. This typically happens during cascading deletes or heavy
+operations on cold connections. It is a transient infrastructure issue, not an
+application bug.
+
+`captureSupabaseError` automatically downgrades `57014` to warning level via
+`isStatementTimeoutError`. No caller-side skip is needed — the warning-level
+classification is sufficient since statement timeouts are rare and worth tracking.
+
+### Safe response parsing in client-side fetch handlers
+
+When calling internal API routes via `fetch()`, always parse the response body
+defensively. The server may return non-JSON responses (e.g. 405 Method Not
+Allowed with empty body, 502 Bad Gateway with HTML). Calling `res.json()`
+directly throws `SyntaxError` on non-JSON bodies.
+
+```typescript
+const res = await fetch("/api/endpoint", { method: "DELETE" });
+
+let body: { ok?: boolean; error?: string };
+try {
+  body = await res.json();
+} catch (_e) {
+  body = { error: "Operation failed." };
+}
+
+if (!res.ok) {
+  setError(body.error ?? "Operation failed.");
+  return;
+}
+```
+
+This prevents `SyntaxError: Unexpected end of JSON input` from reaching the
+outer catch block and being reported to Sentry as an application error.
+
 ## Usage Event Tracking
 
 Product analytics events are recorded via two modules — `src/lib/track-event-server.ts`

--- a/src/components/delete-account-section.tsx
+++ b/src/components/delete-account-section.tsx
@@ -54,7 +54,15 @@ export function DeleteAccountSection({ userEmail }: DeleteAccountSectionProps) {
 
     try {
       const res = await fetch("/api/account", { method: "DELETE" });
-      const body = await res.json();
+
+      // The API may return non-JSON responses (e.g. 405 with empty body),
+      // so parse defensively to avoid SyntaxError on empty/malformed bodies.
+      let body: { ok?: boolean; error?: string };
+      try {
+        body = await res.json();
+      } catch (_e) {
+        body = { error: "Account deletion failed." };
+      }
 
       if (!res.ok) {
         setError(body.error ?? "Account deletion failed.");

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -178,6 +178,27 @@ export function isDuplicateKeyError(error: Error): boolean {
 }
 
 /**
+ * True when PostgreSQL raises `statement_timeout` (57014). This occurs when a
+ * query or RPC exceeds the configured statement timeout — typically during
+ * cascading deletes or heavy operations on cold connections. This is a
+ * transient infrastructure issue, not an application bug, so it should be
+ * reported at warning level.
+ *
+ * Matches two shapes:
+ * 1. PostgrestError objects with `code: "57014"` (from `{ data, error }` path)
+ * 2. Generic Error with a `code` property set to `"57014"` (thrown path)
+ */
+export function isStatementTimeoutError(error: Error): boolean {
+  if (isPostgrestError(error)) {
+    return error.code === "57014";
+  }
+  return (
+    "code" in error &&
+    (error as Record<string, unknown>).code === "57014"
+  );
+}
+
+/**
  * Node.js native fetch (undici) wraps the real network error in the `cause`
  * property. These substrings in the cause message indicate transient failures.
  */
@@ -333,7 +354,8 @@ export function captureSupabaseError(
     isInsufficientPrivilegeError(error) ||
     isForeignKeyViolationError(error) ||
     isDuplicateKeyError(error) ||
-    isSupabaseAuthLockError(error)
+    isSupabaseAuthLockError(error) ||
+    isStatementTimeoutError(error)
   ) {
     lazyCaptureException(error, { extra, level: "warning" });
     return;

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -14,6 +14,7 @@ import {
   isInsufficientPrivilegeError,
   isForeignKeyViolationError,
   isDuplicateKeyError,
+  isStatementTimeoutError,
   isSupabaseAuthLockError,
   isSupabaseAuthLockContention,
   captureSupabaseError,
@@ -382,6 +383,45 @@ describe("isDuplicateKeyError", () => {
   });
 });
 
+describe("isStatementTimeoutError", () => {
+  it("detects PostgreSQL 57014 (statement_timeout) from PostgrestError", () => {
+    const error = makePostgrestError({
+      message: "canceling statement due to statement timeout",
+      code: "57014",
+    });
+    expect(isStatementTimeoutError(error)).toBe(true);
+  });
+
+  it("detects 57014 from generic Error with code property (thrown path)", () => {
+    const error = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014" },
+    );
+    expect(isStatementTimeoutError(error)).toBe(true);
+  });
+
+  it("returns false for other PostgrestError codes", () => {
+    const error = makePostgrestError({
+      message: "some error",
+      code: "42501",
+    });
+    expect(isStatementTimeoutError(error)).toBe(false);
+  });
+
+  it("returns false for generic errors without code", () => {
+    const error = new Error("canceling statement due to statement timeout");
+    expect(isStatementTimeoutError(error)).toBe(false);
+  });
+
+  it("returns false for generic Error with non-57014 code property", () => {
+    const error = Object.assign(
+      new Error("some error"),
+      { code: "23505" },
+    );
+    expect(isStatementTimeoutError(error)).toBe(false);
+  });
+});
+
 describe("isSupabaseAuthLockError", () => {
   it("detects AbortError in PostgrestError details (MEMO-16/17/19)", () => {
     const error = makePostgrestError({
@@ -564,6 +604,21 @@ describe("captureSupabaseError", () => {
     expect(opts.level).toBe("warning");
     expect(opts.extra.operation).toBe("database.addProperty");
     expect(opts.extra.code).toBe("23505");
+  });
+
+  it("captures statement timeout (57014) at warning level (MEMO-1J)", async () => {
+    const error = makePostgrestError({
+      message: "canceling statement due to statement timeout",
+      code: "57014",
+    });
+    captureSupabaseError(error, "delete_account");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("delete_account");
+    expect(opts.extra.code).toBe("57014");
   });
 
   it("includes PostgrestError fields in extra", async () => {


### PR DESCRIPTION
## Summary

Fixes two Sentry issues in the delete account flow:

**MEMO-1K (production):** The client-side `handleDelete` in `delete-account-section.tsx` called `res.json()` unconditionally. When the server returned a 405 with an empty body, `res.json()` threw `SyntaxError: Unexpected end of JSON input`, crashing the error handling flow.

**MEMO-1J (development):** The `delete_account` RPC timed out with PostgreSQL error code `57014` (statement_timeout). `captureSupabaseError` had no classifier for this, so it was reported at error level. Statement timeouts are transient infrastructure issues, not application bugs.

## Changes

- **`src/components/delete-account-section.tsx`**: Wrap `res.json()` in try-catch, falling back to `{ error: "Account deletion failed." }` on parse failure
- **`src/lib/sentry.ts`**: Add `isStatementTimeoutError` helper for PostgreSQL `57014`; add it to the warning-level downgrade list in `captureSupabaseError`
- **`src/lib/sentry.unit.test.ts`**: Regression tests for `isStatementTimeoutError` (5 cases) and `captureSupabaseError` warning-level downgrade for `57014`
- **`.agents/conventions.md`**: Document safe response parsing pattern and statement timeout classification

## Sentry Issues

- [MEMO-1K](https://ona-2j.sentry.io/issues/MEMO-1K) — SyntaxError on non-JSON response in delete account client
- [MEMO-1J](https://ona-2j.sentry.io/issues/MEMO-1J) — Statement timeout not classified as warning

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 72 files, 779 tests pass

Closes #592