### PR TITLE
fix: add files and relation property types to PropertyTypePicker (#585)

### DIFF
--- a/src/components/database/property-types/index.ts
+++ b/src/components/database/property-types/index.ts
@@ -106,7 +106,7 @@ const registry: Partial<Record<PropertyType, PropertyTypeConfig>> = {
 
 /**
  * Look up the renderer and editor for a property type.
- * Returns undefined for types not yet implemented (files, formula).
+ * Returns undefined for types not yet implemented.
  * Computed types (created_time, updated_time, created_by) have Editor: null.
  */
 export function getPropertyTypeConfig(
@@ -131,10 +131,12 @@ export const STANDARD_PROPERTY_TYPES: readonly PropertyType[] = [
   "email",
   "phone",
   "person",
+  "files",
 ] as const;
 
 /** Auto-derived read-only property types shown under "Advanced" in type pickers. */
 export const ADVANCED_PROPERTY_TYPES: readonly PropertyType[] = [
+  "relation",
   "formula",
   "created_time",
   "updated_time",


### PR DESCRIPTION
Closes #585

## What

The `files` and `relation` property types had full renderer/editor implementations registered in the property type registry, with icons and labels defined in `property-icons.ts`, but were missing from the `STANDARD_PROPERTY_TYPES` and `ADVANCED_PROPERTY_TYPES` arrays. Users could not create columns of these types from the PropertyTypePicker dropdown.

## How

Added `"files"` to `STANDARD_PROPERTY_TYPES` (alongside other editable types like text, number, person) and `"relation"` to `ADVANCED_PROPERTY_TYPES` (since it requires a target database configuration, it fits with the advanced/computed types). Also fixed a stale JSDoc comment that incorrectly listed files as "not yet implemented."

## Testing

- All 763 Vitest tests pass, including the existing PropertyTypePicker regression tests
- Lint and typecheck pass cleanly
- No existing E2E tests are affected — the `addColumnViaTypePicker` helper defaults to "Text" and no tests reference files/relation selectors
- Visual regression snapshot for PropertyTypePicker (closed state) is unaffected since it only captures the trigger button