### PR TITLE
fix: add ON DELETE SET NULL to page_versions.created_by FK (#595)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -544,6 +544,14 @@ Rules:
 - Always use `npx supabase migration new` — never create migration files manually.
 - One migration per logical change (table + its RLS policies together).
 - Auto-applied on merge to main via the deploy-migrations CI workflow.
+- Every FK referencing `profiles(id)` or `auth.users(id)` must include an `ON DELETE`
+  clause (`CASCADE` or `SET NULL`). Omitting it causes the `delete_account` RPC to fail
+  with a FK violation when a user deletes their account.
+- When adding a new table with a `user_id` or `created_by` FK to `profiles` or
+  `auth.users`, also update the `delete_account` RPC
+  (`supabase/migrations/20260420150359_delete_account_rpc.sql`) to explicitly handle
+  the new table before the profile/auth deletion step. Relying solely on FK cascades
+  is fragile — being explicit prevents future breakage.
 
 ## Testing
 

--- a/src/components/version-history-panel.tsx
+++ b/src/components/version-history-panel.tsx
@@ -19,7 +19,7 @@ interface VersionSummary {
   id: string;
   page_id: string;
   created_at: string;
-  created_by: string;
+  created_by: string | null;
 }
 
 interface VersionHistoryPanelProps {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -104,7 +104,7 @@ export interface PageVersion {
   page_id: string;
   content: Record<string, unknown> | null;
   created_at: string;
-  created_by: string;
+  created_by: string | null;
 }
 
 export interface PageLink {

--- a/supabase/migrations/20260422215417_fix_page_versions_created_by_fk.sql
+++ b/supabase/migrations/20260422215417_fix_page_versions_created_by_fk.sql
@@ -1,0 +1,104 @@
+-- Fix page_versions.created_by FK: add ON DELETE SET NULL so that deleting a
+-- profile (during account deletion) does not fail with a FK violation.
+-- Version history in team workspaces is preserved with created_by = NULL.
+
+-- 1. Allow NULL in created_by (versions are immutable history; a deleted author
+--    should not destroy the version record).
+alter table public.page_versions
+  alter column created_by drop not null;
+
+-- 2. Replace the FK constraint to add ON DELETE SET NULL.
+alter table public.page_versions
+  drop constraint page_versions_created_by_fkey;
+
+alter table public.page_versions
+  add constraint page_versions_created_by_fkey
+  foreign key (created_by) references public.profiles(id) on delete set null;
+
+-- 3. Recreate delete_account to explicitly handle page_versions and other tables
+--    added after the original RPC was written (favorites, page_visits,
+--    user_feedback, usage_events). While most of these cascade via their FK,
+--    being explicit avoids future surprises when new tables are added.
+create or replace function delete_account()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  _user_id uuid;
+  _sole_owner_names text;
+begin
+  _user_id := auth.uid();
+  if _user_id is null then
+    raise exception 'Not authenticated'
+      using errcode = '28000'; -- invalid_authorization_specification
+  end if;
+
+  -- Check sole-owner constraint: block deletion if the user is the only
+  -- owner of any non-personal workspace.
+  select string_agg(w.name, ', ')
+  into _sole_owner_names
+  from public.members m
+  join public.workspaces w on w.id = m.workspace_id
+  where m.user_id = _user_id
+    and m.role = 'owner'
+    and w.is_personal = false
+    and not exists (
+      select 1 from public.members m2
+      where m2.workspace_id = m.workspace_id
+        and m2.role = 'owner'
+        and m2.user_id <> _user_id
+    );
+
+  if _sole_owner_names is not null then
+    raise exception 'You are the sole owner of: %. Transfer ownership before deleting your account.',
+      _sole_owner_names
+      using errcode = 'P0002';
+  end if;
+
+  -- Nullify page_versions authored by this user (preserves history in team workspaces)
+  update public.page_versions
+  set created_by = null
+  where created_by = _user_id;
+
+  -- Remove favorites
+  delete from public.favorites
+  where user_id = _user_id;
+
+  -- Remove page visits
+  delete from public.page_visits
+  where user_id = _user_id;
+
+  -- Remove user feedback
+  delete from public.user_feedback
+  where user_id = _user_id;
+
+  -- Remove usage events
+  delete from public.usage_events
+  where user_id = _user_id;
+
+  -- Remove membership from all workspaces (non-personal ones stay intact)
+  delete from public.members
+  where user_id = _user_id;
+
+  -- Delete pages in personal workspace(s)
+  delete from public.pages
+  where workspace_id in (
+    select id from public.workspaces
+    where created_by = _user_id and is_personal = true
+  );
+
+  -- Delete personal workspace(s)
+  delete from public.workspaces
+  where created_by = _user_id and is_personal = true;
+
+  -- Delete profile
+  delete from public.profiles
+  where id = _user_id;
+
+  -- Delete auth record (cascades are already handled above explicitly)
+  delete from auth.users
+  where id = _user_id;
+end;
+$$;

--- a/supabase/migrations/migrations.test.ts
+++ b/supabase/migrations/migrations.test.ts
@@ -22,6 +22,16 @@ function stripComments(sql: string): string {
     .trim();
 }
 
+/**
+ * Concatenates all migration SQL in order to simulate the final schema state.
+ */
+function getAllMigrationsSql(): string {
+  return getMigrationFiles()
+    .sort()
+    .map((f) => readFileSync(join(migrationsDir, f), "utf-8"))
+    .join("\n");
+}
+
 describe("database migrations", () => {
   const files = getMigrationFiles();
 
@@ -33,5 +43,39 @@ describe("database migrations", () => {
     const content = readFileSync(join(migrationsDir, filename), "utf-8");
     const sql = stripComments(content);
     expect(sql.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Regression test for issue #595: page_versions.created_by FK lacked
+ * ON DELETE SET NULL, causing delete_account RPC to fail with a FK violation.
+ *
+ * Verifies that the final migration state includes the fix.
+ */
+describe("delete_account RPC handles all user-referencing tables", () => {
+  const allSql = getAllMigrationsSql();
+
+  it("page_versions.created_by FK uses ON DELETE SET NULL", () => {
+    // The fix migration must re-add the constraint with on delete set null
+    expect(allSql).toContain(
+      "foreign key (created_by) references public.profiles(id) on delete set null"
+    );
+  });
+
+  it("delete_account RPC nullifies page_versions before deleting profile", () => {
+    // The updated RPC must handle page_versions explicitly
+    expect(allSql).toMatch(
+      /update public\.page_versions\s+set created_by = null/
+    );
+  });
+
+  it("delete_account RPC handles tables added after original RPC", () => {
+    // Tables added after the original delete_account RPC was written
+    const tablesHandled = ["favorites", "page_visits", "user_feedback", "usage_events"];
+    for (const table of tablesHandled) {
+      expect(allSql).toMatch(
+        new RegExp(`delete from public\\.${table}\\s+where user_id = _user_id`)
+      );
+    }
   });
 });


### PR DESCRIPTION
Closes #595

## What

The `delete_account` RPC fails on production because `page_versions.created_by` references `profiles(id)` without an `ON DELETE` clause. When the RPC deletes the profile row, PostgreSQL blocks it with a FK violation if the user has authored any page versions — particularly in team workspaces whose pages aren't deleted during account deletion. This is the root cause of the E2E "full deletion flow" test failure.

## How

- New migration adds `ON DELETE SET NULL` to the `page_versions.created_by` FK (column made nullable). This preserves version history in team workspaces with `created_by = NULL` for deleted authors.
- Updated the `delete_account` RPC to explicitly nullify `page_versions.created_by` and delete rows from `favorites`, `page_visits`, `user_feedback`, and `usage_events` — all tables added after the original RPC was written.
- Updated `PageVersion` type and `VersionSummary` interface to reflect nullable `created_by`.
- Added convention to `.agents/conventions.md` requiring `ON DELETE` clauses on all `profiles(id)` / `auth.users(id)` FKs and explicit handling in `delete_account` for new tables.

## Testing

- Added regression tests in `migrations.test.ts` that verify:
  - The FK constraint includes `ON DELETE SET NULL`
  - The RPC nullifies `page_versions` before profile deletion
  - The RPC handles all post-original tables (`favorites`, `page_visits`, `user_feedback`, `usage_events`)
- `pnpm lint && pnpm typecheck && pnpm test` all pass (788/788 tests)