### PR TITLE
fix: downgrade StorageApiError timeouts to warning level (#599)

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -199,6 +199,24 @@ export function isStatementTimeoutError(error: Error): boolean {
 }
 
 /**
+ * True when the error is a Supabase Storage API timeout. These are server-side
+ * connection pool timeouts returned as HTTP 544 responses, not client-side
+ * fetch failures. The `StorageApiError` from `@supabase/storage-js` has
+ * `message` and `name` but lacks `code`, `details`, and `hint` — so it fails
+ * the `isPostgrestError` check and none of the existing transient classifiers
+ * match it.
+ *
+ * See: Sentry MEMO-1N
+ */
+export function isTransientStorageError(error: Error): boolean {
+  const msg = error.message;
+  return (
+    msg.includes("The connection to the database timed out") ||
+    msg.includes("connection terminated due to connection timeout")
+  );
+}
+
+/**
  * Node.js native fetch (undici) wraps the real network error in the `cause`
  * property. These substrings in the cause message indicate transient failures.
  */
@@ -350,6 +368,7 @@ export function captureSupabaseError(
 
   if (
     isTransientNetworkError(error) ||
+    isTransientStorageError(error) ||
     isSchemaNotFoundError(error) ||
     isInsufficientPrivilegeError(error) ||
     isForeignKeyViolationError(error) ||

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -10,6 +10,7 @@ vi.mock("@sentry/nextjs", () => ({
 
 import {
   isTransientNetworkError,
+  isTransientStorageError,
   isSchemaNotFoundError,
   isInsufficientPrivilegeError,
   isForeignKeyViolationError,
@@ -422,6 +423,43 @@ describe("isStatementTimeoutError", () => {
   });
 });
 
+describe("isTransientStorageError", () => {
+  it("detects StorageApiError database timeout (MEMO-1N)", () => {
+    const error = new Error("The connection to the database timed out");
+    error.name = "StorageApiError";
+    expect(isTransientStorageError(error)).toBe(true);
+  });
+
+  it("detects connection terminated due to connection timeout", () => {
+    const error = new Error("connection terminated due to connection timeout");
+    error.name = "StorageApiError";
+    expect(isTransientStorageError(error)).toBe(true);
+  });
+
+  it("detects timeout message regardless of error name", () => {
+    const error = new Error("The connection to the database timed out");
+    expect(isTransientStorageError(error)).toBe(true);
+  });
+
+  it("returns false for transient network errors", () => {
+    const error = new Error("Failed to fetch");
+    expect(isTransientStorageError(error)).toBe(false);
+  });
+
+  it("returns false for generic application errors", () => {
+    const error = new Error("Something went wrong");
+    expect(isTransientStorageError(error)).toBe(false);
+  });
+
+  it("returns false for PostgrestError timeouts (handled by isStatementTimeoutError)", () => {
+    const error = makePostgrestError({
+      message: "canceling statement due to statement timeout",
+      code: "57014",
+    });
+    expect(isTransientStorageError(error)).toBe(false);
+  });
+});
+
 describe("isSupabaseAuthLockError", () => {
   it("detects AbortError in PostgrestError details (MEMO-16/17/19)", () => {
     const error = makePostgrestError({
@@ -619,6 +657,18 @@ describe("captureSupabaseError", () => {
     expect(opts.level).toBe("warning");
     expect(opts.extra.operation).toBe("delete_account");
     expect(opts.extra.code).toBe("57014");
+  });
+
+  it("captures StorageApiError database timeout at warning level (MEMO-1N)", async () => {
+    const error = new Error("The connection to the database timed out");
+    error.name = "StorageApiError";
+    captureSupabaseError(error, "image-plugin:upload");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("image-plugin:upload");
   });
 
   it("includes PostgrestError fields in extra", async () => {


### PR DESCRIPTION
Closes #599

## What

`StorageApiError: The connection to the database timed out` from Supabase Storage image uploads was captured at error level in Sentry (MEMO-1N). This is a transient server-side connection pool timeout (HTTP 544), not an application bug. The `StorageApiError` from `@supabase/storage-js` lacks `code`, `details`, and `hint` properties, so it failed the `isPostgrestError` duck-type check and none of the existing transient error classifiers matched its message.

## How

Added `isTransientStorageError` helper in `src/lib/sentry.ts` that detects known transient `StorageApiError` messages ("The connection to the database timed out", "connection terminated due to connection timeout"). Integrated it into the warning-level downgrade check in `captureSupabaseError` alongside the existing transient classifiers.

## Testing

Added 7 regression tests in `src/lib/sentry.unit.test.ts`:
- `isTransientStorageError` describe block (6 tests): detects database timeout message, connection terminated message, works regardless of error name, returns false for network errors / generic errors / PostgrestError timeouts
- `captureSupabaseError` integration test: verifies `StorageApiError` database timeout is captured at warning level with correct operation tag

Verify with: `pnpm test -- src/lib/sentry.unit.test.ts`