### PR TITLE
fix: downgrade PGRST116 empty result errors to warning level (#606)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -1244,6 +1244,34 @@ Additionally, `captureSupabaseError` automatically downgrades `PGRST205` errors 
 `warning` level as a safety net, but callers should still skip the call entirely for
 read operations on optional tables to avoid unnecessary noise.
 
+## Empty Result from `.single()` (PostgREST PGRST116)
+
+When a `.single()` call returns 0 rows, PostgREST returns PGRST116 ("Cannot coerce
+the result to a single JSON object"). This happens when the target row was deleted
+between the user action and the lookup — a race condition during concurrent deletion
+or E2E test teardown. The caller already handles the null result gracefully (returns
+`{ data: null, error }`), so this is not an application bug.
+
+`captureSupabaseError` automatically downgrades PGRST116 to `warning` level via
+`isEmptyResultError`. No per-call-site changes are needed — all ~12 `.single()` calls
+in `database.ts` benefit from the general classifier.
+
+If a caller needs to distinguish "not found" from other errors (e.g. to return 404),
+use `isEmptyResultError` before `captureSupabaseError`:
+
+```typescript
+import { captureSupabaseError, isEmptyResultError } from "@/lib/sentry";
+
+const { data, error } = await supabase.from("pages").select("*").eq("id", id).single();
+if (error) {
+  if (isEmptyResultError(error)) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  captureSupabaseError(error, "pages:lookup");
+  return NextResponse.json({ error: "Operation failed" }, { status: 500 });
+}
+```
+
 ## Authorization Errors in API Routes (PostgreSQL 42501)
 
 When an RPC uses `RAISE EXCEPTION` to reject callers who lack access (e.g.

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -199,6 +199,20 @@ export function isStatementTimeoutError(error: Error): boolean {
 }
 
 /**
+ * True when PostgREST returns PGRST116 — "Cannot coerce the result to a
+ * single JSON object". This happens when `.single()` finds 0 rows, typically
+ * because the target row was deleted between the user action and the lookup
+ * (race condition during concurrent deletion or E2E test teardown). The
+ * caller already handles the null result gracefully, so this is not an
+ * application bug — it should be reported at warning level.
+ *
+ * See: Sentry MEMO-1P
+ */
+export function isEmptyResultError(error: Error): boolean {
+  return isPostgrestError(error) && error.code === "PGRST116";
+}
+
+/**
  * True when the error is a Supabase Storage API timeout. These are server-side
  * connection pool timeouts returned as HTTP 544 responses, not client-side
  * fetch failures. The `StorageApiError` from `@supabase/storage-js` has
@@ -374,7 +388,8 @@ export function captureSupabaseError(
     isForeignKeyViolationError(error) ||
     isDuplicateKeyError(error) ||
     isSupabaseAuthLockError(error) ||
-    isStatementTimeoutError(error)
+    isStatementTimeoutError(error) ||
+    isEmptyResultError(error)
   ) {
     lazyCaptureException(error, { extra, level: "warning" });
     return;

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -16,6 +16,7 @@ import {
   isForeignKeyViolationError,
   isDuplicateKeyError,
   isStatementTimeoutError,
+  isEmptyResultError,
   isSupabaseAuthLockError,
   isSupabaseAuthLockContention,
   captureSupabaseError,
@@ -423,6 +424,38 @@ describe("isStatementTimeoutError", () => {
   });
 });
 
+describe("isEmptyResultError", () => {
+  it("detects PGRST116 empty result from .single() (MEMO-1P)", () => {
+    const error = makePostgrestError({
+      message: "Cannot coerce the result to a single JSON object",
+      code: "PGRST116",
+      details: "The result contains 0 rows",
+    });
+    expect(isEmptyResultError(error)).toBe(true);
+  });
+
+  it("returns false for other PostgREST errors", () => {
+    const error = makePostgrestError({
+      message: "some error",
+      code: "PGRST205",
+    });
+    expect(isEmptyResultError(error)).toBe(false);
+  });
+
+  it("returns false for generic errors with code property", () => {
+    const error = Object.assign(
+      new Error("some error"),
+      { code: "PGRST116" },
+    );
+    expect(isEmptyResultError(error)).toBe(false);
+  });
+
+  it("returns false for plain errors", () => {
+    const error = new Error("Cannot coerce the result to a single JSON object");
+    expect(isEmptyResultError(error)).toBe(false);
+  });
+});
+
 describe("isTransientStorageError", () => {
   it("detects StorageApiError database timeout (MEMO-1N)", () => {
     const error = new Error("The connection to the database timed out");
@@ -657,6 +690,22 @@ describe("captureSupabaseError", () => {
     expect(opts.level).toBe("warning");
     expect(opts.extra.operation).toBe("delete_account");
     expect(opts.extra.code).toBe("57014");
+  });
+
+  it("captures PGRST116 empty result at warning level (MEMO-1P)", async () => {
+    const error = makePostgrestError({
+      message: "Cannot coerce the result to a single JSON object",
+      code: "PGRST116",
+      details: "The result contains 0 rows",
+    });
+    captureSupabaseError(error, "database.addRow:lookup");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("database.addRow:lookup");
+    expect(opts.extra.code).toBe("PGRST116");
   });
 
   it("captures StorageApiError database timeout at warning level (MEMO-1N)", async () => {


### PR DESCRIPTION
Closes #606

## What

`database.addRow:lookup` in `src/lib/database.ts` uses `.single()` to look up a database page's `workspace_id`. When the page doesn't exist (0 rows), PostgREST returns PGRST116 ("Cannot coerce the result to a single JSON object"). This was captured at error level via `captureSupabaseError` because there was no classifier for PGRST116. The error is an expected race condition — the page was deleted between the user action and the lookup (e.g. during E2E test teardown or concurrent deletion).

## How

Added `isEmptyResultError` helper to `src/lib/sentry.ts` that detects PGRST116 errors, following the same pattern as `isSchemaNotFoundError`, `isDuplicateKeyError`, etc. Wired it into `captureSupabaseError`'s warning-level downgrade list. This is a general classifier — all ~12 `.single()` calls in `database.ts` benefit without per-call-site changes.

## Testing

- Added 4 unit tests for `isEmptyResultError` (PGRST116 detection, non-matching codes, generic errors, plain errors)
- Added 1 integration test for `captureSupabaseError` verifying PGRST116 is captured at warning level with correct operation and code in extras
- All 800 Vitest tests pass
- Lint and typecheck clean
- Updated `.agents/conventions.md` with PGRST116 convention and usage pattern