### PR TITLE
fix: select/multi-select options populate table cell with color badges (#609)

### DIFF
--- a/e2e/database-select-options.spec.ts
+++ b/e2e/database-select-options.spec.ts
@@ -336,4 +336,121 @@ test.describe("Select/Multi-select option persistence", () => {
       }
     }
   });
+
+  test("selecting an option populates the table cell with a color badge", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Click the select cell to open the dropdown
+    const selectCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    await expect(selectCell).toBeVisible({ timeout: 10_000 });
+    await selectCell.click();
+
+    const dropdownInput = page.locator('input[placeholder="Search or create…"]');
+    await expect(dropdownInput).toBeVisible({ timeout: 5_000 });
+
+    // Create a fresh option
+    await dropdownInput.fill("Urgent");
+    const createBtn = page.locator("button").filter({ hasText: /Create/ });
+    await expect(createBtn).toBeVisible({ timeout: 3_000 });
+    await createBtn.click();
+
+    // Wait for the dropdown to close and the cell to update
+    await page.waitForTimeout(1_500);
+
+    // The cell should now display the option name as a badge
+    const grid = page.locator('[role="grid"]');
+    await expect(grid.getByText("Urgent")).toBeVisible({ timeout: 5_000 });
+
+    // Reload and verify the badge persists
+    await page.reload();
+    await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
+    const reloadedGrid = page.locator('[role="grid"]');
+    await expect(reloadedGrid.getByText("Urgent")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("selecting a multi-select option populates the table cell", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Click the multi-select cell
+    const multiSelectCell = page.locator('[role="gridcell"][tabindex="0"]').nth(1);
+    await expect(multiSelectCell).toBeVisible({ timeout: 10_000 });
+    await multiSelectCell.click();
+
+    const dropdownInput = page.locator('input[placeholder="Search or create…"]');
+    await expect(dropdownInput).toBeVisible({ timeout: 5_000 });
+
+    // Create a tag
+    await dropdownInput.fill("Infra");
+    const createBtn = page.locator("button").filter({ hasText: /Create/ });
+    await expect(createBtn).toBeVisible({ timeout: 3_000 });
+    await createBtn.click();
+
+    // Wait for persistence
+    await page.waitForTimeout(1_500);
+
+    // Click outside to close the dropdown
+    await page.locator('[role="grid"]').click({ position: { x: 10, y: 10 } });
+    await page.waitForTimeout(500);
+
+    // The cell should display the tag
+    const grid = page.locator('[role="grid"]');
+    await expect(grid.getByText("Infra")).toBeVisible({ timeout: 5_000 });
+
+    // Reload and verify persistence
+    await page.reload();
+    await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
+    const reloadedGrid = page.locator('[role="grid"]');
+    await expect(reloadedGrid.getByText("Infra")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("color picker changes option color", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Click the select cell to open the dropdown
+    const selectCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    await expect(selectCell).toBeVisible({ timeout: 10_000 });
+    await selectCell.click();
+
+    const dropdownInput = page.locator('input[placeholder="Search or create…"]');
+    await expect(dropdownInput).toBeVisible({ timeout: 5_000 });
+
+    // Click the color dot to open the color picker
+    const colorDot = page.locator('button[aria-label="Change color"]').first();
+    await expect(colorDot).toBeVisible({ timeout: 3_000 });
+    await colorDot.click();
+
+    // The color picker should appear with color buttons
+    const redColorBtn = page.locator('button[aria-label="Color: red"]');
+    await expect(redColorBtn).toBeVisible({ timeout: 3_000 });
+    await redColorBtn.click();
+
+    // Wait for persistence
+    await page.waitForTimeout(1_500);
+
+    // Close the dropdown
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(500);
+
+    // Reload and verify the color persisted
+    await page.reload();
+    await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
+
+    // Re-open the dropdown and check the option has a red color
+    const reloadedCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    await expect(reloadedCell).toBeVisible({ timeout: 10_000 });
+    await reloadedCell.click();
+
+    const reloadedDropdown = page.locator('input[placeholder="Search or create…"]');
+    await expect(reloadedDropdown).toBeVisible({ timeout: 5_000 });
+
+    // The red color button should have the active indicator (ring)
+    const activeRedBtn = page.locator('button[aria-label="Color: red"]');
+    await expect(activeRedBtn).toBeVisible({ timeout: 3_000 });
+  });
 });

--- a/src/components/database/property-types/multi-select.tsx
+++ b/src/components/database/property-types/multi-select.tsx
@@ -88,6 +88,21 @@ export function MultiSelectEditor({
     [localOptions, selectedIds, onChange],
   );
 
+  const handleColorChange = useCallback(
+    (optionId: string, color: string) => {
+      const updated = localOptions.map((o) =>
+        o.id === optionId ? { ...o, color } : o,
+      );
+      setLocalOptions(updated);
+      // Persist the updated options config via _newOptions
+      onChange({
+        option_ids: selectedIds,
+        _newOptions: updated,
+      });
+    },
+    [localOptions, selectedIds, onChange],
+  );
+
   return (
     <div className="w-full">
       <SelectDropdown
@@ -98,6 +113,7 @@ export function MultiSelectEditor({
         onDeselect={handleDeselect}
         onCreate={handleCreate}
         onClose={onBlur}
+        onColorChange={handleColorChange}
       />
     </div>
   );

--- a/src/components/database/property-types/select-dropdown.tsx
+++ b/src/components/database/property-types/select-dropdown.tsx
@@ -1,11 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SelectOption } from "@/lib/types";
 import { Input } from "@/components/ui/input";
 import { SelectOptionBadge } from "./select-option-badge";
+import {
+  SELECT_OPTION_COLORS,
+  SELECT_COLOR_STYLES,
+  type SelectOptionColor,
+} from "./index";
 
 interface SelectDropdownProps {
   options: SelectOption[];
@@ -17,6 +22,8 @@ interface SelectDropdownProps {
   onDeselect: (optionId: string) => void;
   onCreate: (name: string) => void;
   onClose: () => void;
+  /** Called when an option's color is changed. */
+  onColorChange?: (optionId: string, color: string) => void;
 }
 
 export function SelectDropdown({
@@ -27,8 +34,12 @@ export function SelectDropdown({
   onDeselect,
   onCreate,
   onClose,
+  onColorChange,
 }: SelectDropdownProps) {
   const [query, setQuery] = useState("");
+  const [colorPickerOptionId, setColorPickerOptionId] = useState<string | null>(
+    null,
+  );
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -85,6 +96,24 @@ export function SelectDropdown({
     }
   }
 
+  const handleColorDotClick = useCallback(
+    (e: React.MouseEvent, optionId: string) => {
+      e.stopPropagation();
+      setColorPickerOptionId((prev) =>
+        prev === optionId ? null : optionId,
+      );
+    },
+    [],
+  );
+
+  const handleColorSelect = useCallback(
+    (optionId: string, color: SelectOptionColor) => {
+      onColorChange?.(optionId, color);
+      setColorPickerOptionId(null);
+    },
+    [onColorChange],
+  );
+
   return (
     <div
       ref={containerRef}
@@ -110,33 +139,47 @@ export function SelectDropdown({
       <div className="max-h-48 overflow-y-auto px-1 pb-1">
         {filtered.map((opt) => {
           const isSelected = selectedSet.has(opt.id);
+          const showColorPicker = colorPickerOptionId === opt.id;
           return (
-            <button
-              key={opt.id}
-              type="button"
-              onClick={() => handleOptionClick(opt.id)}
-              className={cn(
-                "flex w-full items-center gap-2 px-2 py-1 text-sm",
-                "hover:bg-white/[0.04]",
+            <div key={opt.id}>
+              <button
+                type="button"
+                onClick={() => handleOptionClick(opt.id)}
+                className={cn(
+                  "flex w-full items-center gap-2 px-2 py-1 text-sm",
+                  "hover:bg-white/[0.04]",
+                )}
+              >
+                {multi && (
+                  <span
+                    className={cn(
+                      "flex size-3.5 shrink-0 items-center justify-center border",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-input",
+                    )}
+                  >
+                    {isSelected && <Check className="size-2.5" />}
+                  </span>
+                )}
+                {onColorChange && (
+                  <ColorDot
+                    color={opt.color}
+                    onClick={(e) => handleColorDotClick(e, opt.id)}
+                  />
+                )}
+                <SelectOptionBadge name={opt.name} color={opt.color} />
+                {!multi && isSelected && (
+                  <Check className="ml-auto size-3.5 text-accent" />
+                )}
+              </button>
+              {showColorPicker && (
+                <ColorPicker
+                  currentColor={opt.color}
+                  onSelect={(color) => handleColorSelect(opt.id, color)}
+                />
               )}
-            >
-              {multi && (
-                <span
-                  className={cn(
-                    "flex size-3.5 shrink-0 items-center justify-center border",
-                    isSelected
-                      ? "border-primary bg-primary text-primary-foreground"
-                      : "border-input",
-                  )}
-                >
-                  {isSelected && <Check className="size-2.5" />}
-                </span>
-              )}
-              <SelectOptionBadge name={opt.name} color={opt.color} />
-              {!multi && isSelected && (
-                <Check className="ml-auto size-3.5 text-accent" />
-              )}
-            </button>
+            </div>
           );
         })}
         {filtered.length === 0 && !showCreate && (
@@ -156,6 +199,74 @@ export function SelectDropdown({
           </button>
         )}
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ColorDot — clickable color indicator next to each option
+// ---------------------------------------------------------------------------
+
+function ColorDot({
+  color,
+  onClick,
+}: {
+  color: string;
+  onClick: (e: React.MouseEvent) => void;
+}) {
+  const styles = SELECT_COLOR_STYLES[color as SelectOptionColor] ?? SELECT_COLOR_STYLES.gray;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex size-4 shrink-0 items-center justify-center rounded-full",
+        styles.bg,
+        "hover:ring-1 hover:ring-accent",
+      )}
+      aria-label="Change color"
+    >
+      <span className={cn("size-2 rounded-full", styles.bg)} />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ColorPicker — inline palette for changing an option's color
+// ---------------------------------------------------------------------------
+
+function ColorPicker({
+  currentColor,
+  onSelect,
+}: {
+  currentColor: string;
+  onSelect: (color: SelectOptionColor) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1 px-3 py-1.5">
+      {SELECT_OPTION_COLORS.map((color) => {
+        const styles = SELECT_COLOR_STYLES[color];
+        const isActive = color === currentColor;
+        return (
+          <button
+            key={color}
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelect(color);
+            }}
+            className={cn(
+              "flex size-5 items-center justify-center rounded-full",
+              styles.bg,
+              isActive && "ring-1 ring-accent",
+              "hover:ring-1 hover:ring-accent",
+            )}
+            aria-label={`Color: ${color}`}
+          >
+            {isActive && <Check className="size-2.5 text-foreground" />}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/database/property-types/select.stories.tsx
+++ b/src/components/database/property-types/select.stories.tsx
@@ -95,14 +95,23 @@ export const Editor: Story = {
 };
 
 function SelectEditorEmptyDemo() {
-  const prop = makeProp();
+  const [prop, setProp] = useState(makeProp());
   const [value, setValue] = useState<Record<string, unknown>>({});
   return (
     <div className="w-64 bg-background p-2">
       <SelectEditor
         value={value}
         property={prop}
-        onChange={setValue}
+        onChange={(v) => {
+          setValue(v);
+          // Simulate parent persisting _newOptions to property config
+          if (v._newOptions) {
+            setProp((prev) => ({
+              ...prev,
+              config: { ...prev.config, options: v._newOptions },
+            }));
+          }
+        }}
         onBlur={() => {}}
       />
     </div>

--- a/src/components/database/property-types/select.tsx
+++ b/src/components/database/property-types/select.tsx
@@ -68,6 +68,22 @@ export function SelectEditor({
     [localOptions, onChange],
   );
 
+  const handleColorChange = useCallback(
+    (optionId: string, color: string) => {
+      const updated = localOptions.map((o) =>
+        o.id === optionId ? { ...o, color } : o,
+      );
+      setLocalOptions(updated);
+      // Persist the updated options config via _newOptions
+      const currentId = getSelectedId(value);
+      onChange({
+        option_id: currentId,
+        _newOptions: updated,
+      });
+    },
+    [localOptions, value, onChange],
+  );
+
   return (
     <div className="w-full">
       <SelectDropdown
@@ -78,6 +94,7 @@ export function SelectEditor({
         onDeselect={handleDeselect}
         onCreate={handleCreate}
         onClose={onBlur}
+        onColorChange={handleColorChange}
       />
     </div>
   );

--- a/src/components/database/views/list-view.tsx
+++ b/src/components/database/views/list-view.tsx
@@ -10,6 +10,7 @@ import type {
   DatabaseViewConfig,
   PropertyType,
   RowValue,
+  SelectOption,
 } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -141,6 +142,7 @@ function ListRow({ row, visibleProperties, workspaceSlug }: ListRowProps) {
               <CompactPropertyValue
                 key={prop.id}
                 value={cellValue}
+                property={prop}
                 propertyType={prop.type}
               />
             );
@@ -157,10 +159,49 @@ function ListRow({ row, visibleProperties, workspaceSlug }: ListRowProps) {
 
 interface CompactPropertyValueProps {
   value: RowValue | undefined;
+  property: DatabaseProperty;
   propertyType: PropertyType;
 }
 
-function CompactPropertyValue({ value, propertyType }: CompactPropertyValueProps) {
+function CompactPropertyValue({ value, property, propertyType }: CompactPropertyValueProps) {
+  // Select/multi-select resolve option IDs from property config directly
+  switch (propertyType) {
+    case "select": {
+      const raw = value?.value as Record<string, unknown> | undefined;
+      const optionId = typeof raw?.option_id === "string" ? raw.option_id : null;
+      if (!optionId) return null;
+      const options = getSelectOptions(property.config);
+      const option = options.find((o) => o.id === optionId);
+      if (!option) return null;
+      return <CompactSelectBadge label={option.name} color={option.color} />;
+    }
+
+    case "multi_select": {
+      const raw = value?.value as Record<string, unknown> | undefined;
+      const optionIds = Array.isArray(raw?.option_ids)
+        ? (raw.option_ids as string[])
+        : [];
+      if (optionIds.length === 0) return null;
+      const options = getSelectOptions(property.config);
+      const optionMap = new Map(options.map((o) => [o.id, o]));
+      return (
+        <span className="flex items-center gap-1">
+          {optionIds.map((id) => {
+            const option = optionMap.get(id);
+            if (!option) return null;
+            return (
+              <CompactSelectBadge key={id} label={option.name} color={option.color} />
+            );
+          })}
+        </span>
+      );
+    }
+
+    default:
+      break;
+  }
+
+  // Non-select types use the extracted display value string
   const displayValue = extractDisplayValue(value, propertyType);
 
   if (!displayValue) {
@@ -168,25 +209,6 @@ function CompactPropertyValue({ value, propertyType }: CompactPropertyValueProps
   }
 
   switch (propertyType) {
-    case "select": {
-      const color = (value?.value as Record<string, unknown>)?.color as string | undefined;
-      return <CompactSelectBadge label={displayValue} color={color} />;
-    }
-
-    case "multi_select": {
-      const items = (value?.value as Record<string, unknown>)?.items as
-        | { value: string; color?: string }[]
-        | undefined;
-      if (!items || items.length === 0) return null;
-      return (
-        <span className="flex items-center gap-1">
-          {items.map((item, i) => (
-            <CompactSelectBadge key={i} label={item.value} color={item.color} />
-          ))}
-        </span>
-      );
-    }
-
     case "checkbox": {
       const checked = value?.value?.value === true;
       return (
@@ -271,6 +293,7 @@ const SELECT_COLORS: Record<string, { bg: string; text: string }> = {
   red: { bg: "bg-red-500/20", text: "text-red-400" },
   purple: { bg: "bg-purple-500/20", text: "text-purple-400" },
   pink: { bg: "bg-pink-500/20", text: "text-pink-400" },
+  cyan: { bg: "bg-cyan-500/20", text: "text-cyan-400" },
 };
 
 function CompactSelectBadge({ label, color }: { label: string; color?: string }) {
@@ -291,6 +314,13 @@ function CompactSelectBadge({ label, color }: { label: string; color?: string })
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function getSelectOptions(config: Record<string, unknown>): SelectOption[] {
+  if (Array.isArray(config.options)) {
+    return config.options as SelectOption[];
+  }
+  return [];
+}
 
 /** Maps a property type to the key its registry editor/renderer expects. */
 function valueKeyForType(propertyType: PropertyType): string {
@@ -329,10 +359,11 @@ function extractDisplayValue(value: RowValue | undefined, propertyType: Property
       const checked = typed ?? legacy;
       return checked === true ? "true" : checked === false ? "false" : "";
     }
+    case "select":
     case "multi_select":
-      return (raw.items as { value: string }[] | undefined)
-        ?.map((i) => i.value)
-        .join(", ") ?? "";
+      // Select/multi-select rendering is handled directly by CompactPropertyValue
+      // using option IDs from the raw value and the property config.
+      return "";
     default: {
       const inner = typed ?? legacy;
       if (typeof inner === "string") return inner;

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -36,6 +36,7 @@ import type {
   DatabaseViewConfig,
   PropertyType,
   RowValue,
+  SelectOption,
 } from "@/lib/types";
 import {
   isComputedType,
@@ -924,6 +925,7 @@ function TableCell({
     >
       <CellRenderer
         value={value}
+        property={property}
         propertyType={propertyType}
         displayValue={displayValue}
       />
@@ -1057,11 +1059,49 @@ function RegistryEditorCell({
 
 interface CellRendererProps {
   value: RowValue | undefined;
+  property: DatabaseProperty;
   propertyType: PropertyType;
   displayValue: string;
 }
 
-function CellRenderer({ value, propertyType, displayValue }: CellRendererProps) {
+function CellRenderer({ value, property, propertyType, displayValue }: CellRendererProps) {
+  switch (propertyType) {
+    case "select": {
+      const raw = value?.value as Record<string, unknown> | undefined;
+      const optionId = typeof raw?.option_id === "string" ? raw.option_id : null;
+      if (!optionId) return null;
+      const options = getSelectOptions(property.config);
+      const option = options.find((o) => o.id === optionId);
+      if (!option) return null;
+      return <SelectBadge label={option.name} color={option.color} />;
+    }
+
+    case "multi_select": {
+      const raw = value?.value as Record<string, unknown> | undefined;
+      const optionIds = Array.isArray(raw?.option_ids)
+        ? (raw.option_ids as string[])
+        : [];
+      if (optionIds.length === 0) return null;
+      const options = getSelectOptions(property.config);
+      const optionMap = new Map(options.map((o) => [o.id, o]));
+      return (
+        <div className="flex flex-wrap gap-1">
+          {optionIds.map((id) => {
+            const option = optionMap.get(id);
+            if (!option) return null;
+            return (
+              <SelectBadge key={id} label={option.name} color={option.color} />
+            );
+          })}
+        </div>
+      );
+    }
+
+    default:
+      break;
+  }
+
+  // Non-select types require a displayValue string
   if (!displayValue) {
     return null;
   }
@@ -1097,25 +1137,6 @@ function CellRenderer({ value, propertyType, displayValue }: CellRendererProps) 
           {displayValue}
         </span>
       );
-
-    case "select": {
-      const color = (value?.value as Record<string, unknown>)?.color as string | undefined;
-      return <SelectBadge label={displayValue} color={color} />;
-    }
-
-    case "multi_select": {
-      const items = (value?.value as Record<string, unknown>)?.items as
-        | { value: string; color?: string }[]
-        | undefined;
-      if (!items || items.length === 0) return null;
-      return (
-        <div className="flex flex-wrap gap-1">
-          {items.map((item, i) => (
-            <SelectBadge key={i} label={item.value} color={item.color} />
-          ))}
-        </div>
-      );
-    }
 
     case "date":
       return (
@@ -1161,6 +1182,7 @@ const SELECT_COLORS: Record<string, { bg: string; text: string }> = {
   red: { bg: "bg-red-500/20", text: "text-red-400" },
   purple: { bg: "bg-purple-500/20", text: "text-purple-400" },
   pink: { bg: "bg-pink-500/20", text: "text-pink-400" },
+  cyan: { bg: "bg-cyan-500/20", text: "text-cyan-400" },
 };
 
 function SelectBadge({ label, color }: { label: string; color?: string }) {
@@ -1182,6 +1204,13 @@ function SelectBadge({ label, color }: { label: string; color?: string }) {
 // Helpers
 // ---------------------------------------------------------------------------
 
+function getSelectOptions(config: Record<string, unknown>): SelectOption[] {
+  if (Array.isArray(config.options)) {
+    return config.options as SelectOption[];
+  }
+  return [];
+}
+
 function extractDisplayValue(value: RowValue | undefined, propertyType: PropertyType): string {
   if (!value) return "";
 
@@ -1199,11 +1228,11 @@ function extractDisplayValue(value: RowValue | undefined, propertyType: Property
       const checked = typed ?? legacy;
       return checked === true ? "true" : checked === false ? "false" : "";
     }
+    case "select":
     case "multi_select":
-      // Multi-select is handled specially in CellRenderer
-      return (raw.items as { value: string }[] | undefined)
-        ?.map((i) => i.value)
-        .join(", ") ?? "";
+      // Select/multi-select rendering is handled directly by CellRenderer
+      // using option IDs from the raw value and the property config.
+      return "";
     default: {
       const inner = typed ?? legacy;
       if (typeof inner === "string") return inner;


### PR DESCRIPTION
Closes #609

## What

Select and multi-select property types in database table view did not display selected values in cells. Clicking an option in the dropdown appeared to work (the dropdown closed) but the cell remained empty. Additionally, there was no UI to change an option's color.

The root cause was a data format mismatch: the editors store `{ option_id: "uuid" }` / `{ option_ids: ["uuid1", ...] }` in `row_values`, but the `CellRenderer` and `extractDisplayValue` functions expected a different format (`{ color: "...", value: "..." }` / `{ items: [...] }`) that was never written.

## How

- **table-view.tsx**: Rewrote `CellRenderer` for `select` and `multi_select` cases to resolve option IDs to names and colors by looking up the property config. Passed `property` to `CellRenderer`. Fixed `extractDisplayValue` to return empty string for select types (rendering is now handled directly). Added `cyan` to `SELECT_COLORS` to match the design spec's 9-color palette.
- **list-view.tsx**: Applied the same fix to `CompactPropertyValue` — resolve option IDs from property config instead of expecting pre-resolved data. Added `getSelectOptions` helper and `cyan` color.
- **select-dropdown.tsx**: Added `onColorChange` prop and inline color picker UI. Each option now shows a clickable color dot that expands a palette of 9 colors from the design spec.
- **select.tsx / multi-select.tsx**: Wired up `handleColorChange` callbacks that update local options and persist via `_newOptions`.

## Testing

- Added 3 E2E regression tests in `e2e/database-select-options.spec.ts`:
  - "selecting an option populates the table cell with a color badge" — creates an option, verifies it appears in the cell, reloads to verify persistence
  - "selecting a multi-select option populates the table cell" — same for multi-select
  - "color picker changes option color" — opens color picker, selects red, verifies persistence after reload
- Updated `select.stories.tsx` editor demo to simulate parent persisting `_newOptions` to property config
- `pnpm lint && pnpm typecheck && pnpm test` all pass (0 errors, 800 tests pass)