### PR TITLE
fix: E2E color picker test creates option before changing color (#611)

### DIFF
--- a/e2e/database-select-options.spec.ts
+++ b/e2e/database-select-options.spec.ts
@@ -420,6 +420,21 @@ test.describe("Select/Multi-select option persistence", () => {
     const dropdownInput = page.locator('input[placeholder="Search or create…"]');
     await expect(dropdownInput).toBeVisible({ timeout: 5_000 });
 
+    // Create an option first — the color change button only appears next to existing options
+    await dropdownInput.fill("ColorTest");
+    const createBtn = page.locator("button").filter({ hasText: /Create/ });
+    await expect(createBtn).toBeVisible({ timeout: 3_000 });
+    await createBtn.click();
+
+    // Wait for persistence, then re-open the dropdown
+    await page.waitForTimeout(1_500);
+    const selectCellAgain = page.locator('[role="gridcell"][tabindex="0"]').first();
+    await expect(selectCellAgain).toBeVisible({ timeout: 5_000 });
+    await selectCellAgain.click();
+
+    const dropdownInputAgain = page.locator('input[placeholder="Search or create…"]');
+    await expect(dropdownInputAgain).toBeVisible({ timeout: 5_000 });
+
     // Click the color dot to open the color picker
     const colorDot = page.locator('button[aria-label="Change color"]').first();
     await expect(colorDot).toBeVisible({ timeout: 3_000 });


### PR DESCRIPTION
Closes #611

## What
The E2E test "color picker changes option color" in `e2e/database-select-options.spec.ts` fails because it opens a select cell dropdown and immediately looks for `button[aria-label="Change color"]`. The color change button only appears next to existing options, but the dropdown starts empty — so the locator times out with "element(s) not found".

## How
Added an option creation step before attempting to interact with the color picker. The test now creates a "ColorTest" option (fill input → click Create), waits for persistence, re-opens the dropdown, and then clicks the color change button. This matches the pattern used by sibling tests in the same file.

## Testing
- `pnpm lint` — passes (0 errors)
- `pnpm typecheck` — passes
- `pnpm test` — 73 files, 800 tests pass
- Verified no other E2E tests reference the changed selectors (`grep -r 'Change color|ColorTest' e2e/`)