### PR TITLE
fix: prevent automation auditor from overwriting previous weekly reports

### DIFF
--- a/.ona/automations/automation-auditor.yaml
+++ b/.ona/automations/automation-auditor.yaml
@@ -53,7 +53,7 @@ action:
 
                 ## Output
 
-                Create a branch: `chore/audit-YYYY-WNN`
+                Create a branch: `chore/audit-YYYY-MM-DD`
 
                 Update these files as needed (include in the same commit):
                 - `.agents/quality.md` — always update with current grades
@@ -62,7 +62,13 @@ action:
                 - `.agents/design.md` — if new UI patterns need documenting
                 - `AGENTS.md` — if rules need adding or updating (only for clear, repeated problems)
 
-                Write metrics/weekly/YYYY-WNN-audit.md:
+                IMPORTANT: If a previous audit file already exists for this week (e.g.,
+                `metrics/weekly/YYYY-WNN-audit.md` or `metrics/weekly/YYYY-WNN-audit-*.md`),
+                do NOT overwrite it. Instead, append a date suffix to the new file:
+                `metrics/weekly/YYYY-WNN-audit-YYYY-MM-DD.md`. This preserves the historical
+                record from earlier runs.
+
+                Write metrics/weekly/YYYY-WNN-audit-YYYY-MM-DD.md (or YYYY-WNN-audit.md if this is the first run of the week):
 
                 # Automation Audit — Week NN
 
@@ -124,5 +130,5 @@ action:
                 - Keep additions minimal — one rule per observed problem.
                 - If everything is working well, say so and move on.
 
-                Commit: `chore: automation audit YYYY-WNN`
+                Commit: `chore: automation audit YYYY-MM-DD`
                 Push and open a PR.

--- a/metrics/weekly/2026-W17-audit-2026-04-23.md
+++ b/metrics/weekly/2026-W17-audit-2026-04-23.md
@@ -1,0 +1,74 @@
+# Automation Audit — Week 17
+
+## Summary
+- Automations active: 10
+- PRs opened by automations: 257
+- PRs merged: 250
+- PRs closed (not merged): 7
+- CI fixes applied: 21 (all on distinct PRs — no repeated failures)
+- Bug issues created: 108
+- Feature issues created: 39
+- Enhancement issues created: 47
+
+## Per-Automation Assessment
+
+### Feature Builder
+- Issues completed: 59
+- Success rate: 100% (59/59 merged)
+- Recurring problems: none — all PRs merged successfully
+
+### Bug Fixer
+- Bugs fixed: 79
+- Bugs escalated (needs-human): 1 (#541 — slider background color, closed)
+- PRs closed without merge: 6 (#594, #551, #457, #408, #406, #194)
+- Success rate: 93% (79/85)
+- Recurring problems: E2E test updates after interaction flow changes. PRs #551 and #594 were superseded by better fixes (#556 and #591 respectively). PRs #408 and #406 were closed when the underlying table bugs were fixed differently. PR #457 was superseded by #458. PR #194 was superseded by a different approach. All closures were correct — the automation recognized when a different fix was better.
+
+### PR Reviewer
+- PRs reviewed: 257
+- CI fixes: 21 (all on distinct PRs, no repeated failures on the same PR)
+- False positives: none observed
+
+### Post-Merge Verifier
+- Verifications run: ~250 (one per merge)
+- Regressions caught: 11 (E2E regression and UI regression issues filed)
+- Notable: caught regressions from PRs #543, #544, #424, #242, #240, #189, #188, #185, #179, #176, #164
+
+### UI Verifier
+- Verifications run: ~60 (UI-touching PRs)
+- Design violations found: 19 (all filed as issues, all resolved)
+- Pattern: most violations were in the database feature area (PRs #478, #480, #481, #472, #467, #465, #471, #475, #459) — expected given the volume of new database UI this week
+
+### Incident Responder
+- Errors triaged: 28 Sentry issues
+- Bug issues created: 28
+- PRs merged: 18
+- Pattern: heavy focus on Sentry noise reduction — RLS violations, transient network errors, auth lock contention, FK violations, statement timeouts, PGRST116/PGRST205 classification. The error classification layer in `sentry.ts` is now mature with 103 unit tests.
+
+## Label Hygiene
+- Stalled in-progress issues (>24h): none (0 open issues)
+- Backlog issues missing priority: #541 (closed, `status:backlog` + `needs-human` but no `priority:*`)
+- needs-human issues open >7 days: none (only #541, created Apr 22, already closed)
+- All 215 issues created this week are closed. Zero open issues in the repository.
+
+## Knowledge Base Updates
+- **AGENTS.md**: no changes — rules are accurate and no repeated problems observed
+- **architecture.md**: updated — significant drift in component map
+  - DatabaseNode and DatabasePlugin changed from "Planned" to "Implemented"
+  - Added 5 new editor plugins: TurnIntoPlugin, AutoLinkPlugin, WordCountPlugin, CodeLanguageSelectorPlugin, TurnIntoMenu
+  - Added 2 new database components: PropertyTypePicker, RenamePropertyDialog
+  - Added feedback/, keyboard-shortcuts-dialog.tsx, providers.tsx to component map
+  - Added 3 new UI components: checkbox.tsx, context-menu.tsx, textarea.tsx
+  - Added 10 new lib files: capture.ts, database-filters.ts, formula.ts, property-icons.ts, toast.ts, track-event.ts, track-event-server.ts, use-persisted-expanded.ts, use-screenshot.ts, word-count.ts
+  - Added api/feedback/route.ts to API routes
+- **conventions.md**: no changes — conventions are comprehensive and well-maintained. The conventions file was actively updated this week (PR #580 strengthened testing requirements, multiple Sentry error classification patterns were added as bugs were fixed).
+- **design.md**: no changes — design spec is comprehensive and covers all database view patterns
+- **quality.md**: updated UI Components note (13 → 16 shadcn/ui components)
+
+## Recommendations
+
+1. **Architecture doc auto-update**: The component map in `architecture.md` drifted significantly this week because the Feature Builder adds new files without updating the map. Consider adding a convention that Feature Builder PRs adding new files to `src/components/` or `src/lib/` must also update the component map in `architecture.md`.
+
+2. **Database area stabilization**: 19 UI design spec violations and 11 post-merge regressions were concentrated in the database feature area. This is expected for a new feature area with high velocity (59 feature PRs). As the database feature matures, the Bug Fixer and UI Verifier workload should decrease. No action needed — the automation loop caught and fixed all issues.
+
+3. **Closed-PR ratio is healthy**: 7 closed-without-merge out of 257 (2.7%) is a good signal. The automation correctly abandoned superseded approaches rather than forcing bad fixes through.

--- a/metrics/weekly/2026-W17-audit.md
+++ b/metrics/weekly/2026-W17-audit.md
@@ -2,73 +2,99 @@
 
 ## Summary
 - Automations active: 10
-- PRs opened by automations: 257
-- PRs merged: 250
-- PRs closed (not merged): 7
-- CI fixes applied: 21 (all on distinct PRs — no repeated failures)
-- Bug issues created: 108
-- Feature issues created: 39
-- Enhancement issues created: 47
+- PRs opened by automations: 100 (97 merged, 3 closed without merge)
+- PRs merged: 97
+- CI fixes applied: 5 (PRs #195, #196, #197, #198, #240 had multi-commit CI fix cycles)
+- Bug issues created: 52
+- Feature/enhancement issues created: 39
+- Chore issues created: 7
 
 ## Per-Automation Assessment
 
 ### Feature Builder
-- Issues completed: 59
-- Success rate: 100% (59/59 merged)
-- Recurring problems: none — all PRs merged successfully
+- Issues completed: 39 (features, enhancements, test additions)
+- PRs merged: ~25 (feat/test/refactor PRs)
+- Success rate: 100% (all issues closed, no open backlog)
+- Recurring problems: none
+
+The Feature Builder had a productive week. Major deliverables: page icon emoji picker (#174), loading skeletons (#173), keyboard shortcuts (⌘+K #171, ⌘+N #172), markdown shortcuts (#207), dynamic page titles (#250), custom not-found pages (#251), route-level error boundaries (#252), copyable invite links (#239), and 9 new E2E test specs (#221–#226, #233). All features landed cleanly.
 
 ### Bug Fixer
-- Bugs fixed: 79
-- Bugs escalated (needs-human): 1 (#541 — slider background color, closed)
-- PRs closed without merge: 6 (#594, #551, #457, #408, #406, #194)
-- Success rate: 93% (79/85)
-- Recurring problems: E2E test updates after interaction flow changes. PRs #551 and #594 were superseded by better fixes (#556 and #591 respectively). PRs #408 and #406 were closed when the underlying table bugs were fixed differently. PR #457 was superseded by #458. PR #194 was superseded by a different approach. All closures were correct — the automation recognized when a different fix was better.
+- Bugs fixed: 52
+- Bugs escalated (needs-human): 0
+- Success rate: 85% (all bugs eventually fixed, but search empty state required 8 attempts)
+- Recurring problems:
+  - **Search empty state race condition** — 8 issues (#126, #136, #144, #162, #166, #178, #181, #192) about the same bug between Apr 16–17. Each fix addressed a symptom rather than the root cause (async state race in `page-search.tsx`). Finally resolved in PR #198 by replacing the generation counter with a cancelled flag. The Bug Fixer should be more cautious with async state management — when a bug recurs, it should analyze the full data flow rather than patching the immediate symptom.
+  - **E2E test regressions from feature PRs** — 7 issues where a feature PR broke existing E2E tests (#187, #193, #215, #241, #243, and others). The Feature Builder does not consistently run the full E2E suite before submitting PRs.
 
 ### PR Reviewer
-- PRs reviewed: 257
-- CI fixes: 21 (all on distinct PRs, no repeated failures on the same PR)
+- PRs reviewed: 97 merged + 3 closed = 100
+- CI fixes: 5 PRs needed multi-commit CI fix cycles (#195, #196, #197, #198, #240)
 - False positives: none observed
+- Closed PRs: 3 (#102, #180, #194 — superseded by better implementations)
+
+The PR Reviewer operated efficiently. CI fix rate was low (5%) and all fixes were legitimate (lint errors, type errors, test failures). No unnecessary change requests observed.
 
 ### Post-Merge Verifier
-- Verifications run: ~250 (one per merge)
-- Regressions caught: 11 (E2E regression and UI regression issues filed)
-- Notable: caught regressions from PRs #543, #544, #424, #242, #240, #189, #188, #185, #179, #176, #164
+- Verifications run: ~97 (one per merged PR)
+- Regressions caught: 8 (UI regression issues filed after merges)
+- Notable catches: search empty state regressions (#126, #166, #178, #181, #192), page 404 during icon removal (#193), E2E flakes (#215, #243)
+
+The Post-Merge Verifier caught real regressions consistently. The high regression count (8) reflects the search empty state bug recurring — not a verifier problem.
 
 ### UI Verifier
-- Verifications run: ~60 (UI-touching PRs)
-- Design violations found: 19 (all filed as issues, all resolved)
-- Pattern: most violations were in the database feature area (PRs #478, #480, #481, #472, #467, #465, #471, #475, #459) — expected given the volume of new database UI this week
+- Verifications run: ~97
+- Design violations found: 10 issues (#38, #47, #56, #61, #64, #87, #165, #186, #191, #201)
+
+The UI Verifier caught legitimate design spec violations after feature PRs. All were fixed promptly. The violations were mostly spacing, opacity, and visual distinction issues — the Feature Builder should reference `.agents/design.md` more carefully before submitting UI changes.
 
 ### Incident Responder
-- Errors triaged: 28 Sentry issues
-- Bug issues created: 28
-- PRs merged: 18
-- Pattern: heavy focus on Sentry noise reduction — RLS violations, transient network errors, auth lock contention, FK violations, statement timeouts, PGRST116/PGRST205 classification. The error classification layer in `sentry.ts` is now mature with 103 unit tests.
+- Errors triaged: 6 Sentry issues (MEMO-4, MEMO-5, MEMO-7, MEMO-8, MEMO-9, plus one unnamed)
+- Bug issues created: 6 (#101, #128, #130, #131, #132, #149)
+
+All Sentry errors were triaged into actionable bug issues and subsequently fixed. The Incident Responder is working well.
+
+### Feature Planner
+- Ran on demand to decompose the product spec into issues
+- Created the initial issue set (#23–#32) and triaged incoming issues throughout the week
+
+### Performance Monitor
+- No performance issues flagged this week
+
+### Needs-Human Requeue
+- 1 PR (#197) had `needs-human` label — was resolved and merged
 
 ## Label Hygiene
 - Stalled in-progress issues (>24h): none (0 open issues)
-- Backlog issues missing priority: #541 (closed, `status:backlog` + `needs-human` but no `priority:*`)
-- needs-human issues open >7 days: none (only #541, created Apr 22, already closed)
-- All 215 issues created this week are closed. Zero open issues in the repository.
+- Backlog issues missing priority: none (0 open backlog issues)
+- needs-human issues open >7 days: none
+- **Dual status labels**: 5 closed issues have both `status:in-review` and `status:done` (#87, #165, #178, #187) or `status:in-progress` and `status:done` (#74). The PR Reviewer adds `status:done` without removing the previous status label. This is cosmetic (issues are closed) but should be fixed for clean label queries.
+- **Stale merge conflict marker**: `conventions.md` line 707 had a `<<<<<<< HEAD` marker with no matching end — removed in this audit.
 
 ## Knowledge Base Updates
-- **AGENTS.md**: no changes — rules are accurate and no repeated problems observed
-- **architecture.md**: updated — significant drift in component map
-  - DatabaseNode and DatabasePlugin changed from "Planned" to "Implemented"
-  - Added 5 new editor plugins: TurnIntoPlugin, AutoLinkPlugin, WordCountPlugin, CodeLanguageSelectorPlugin, TurnIntoMenu
-  - Added 2 new database components: PropertyTypePicker, RenamePropertyDialog
-  - Added feedback/, keyboard-shortcuts-dialog.tsx, providers.tsx to component map
-  - Added 3 new UI components: checkbox.tsx, context-menu.tsx, textarea.tsx
-  - Added 10 new lib files: capture.ts, database-filters.ts, formula.ts, property-icons.ts, toast.ts, track-event.ts, track-event-server.ts, use-persisted-expanded.ts, use-screenshot.ts, word-count.ts
-  - Added api/feedback/route.ts to API routes
-- **conventions.md**: no changes — conventions are comprehensive and well-maintained. The conventions file was actively updated this week (PR #580 strengthened testing requirements, multiple Sentry error classification patterns were added as bugs were fixed).
-- **design.md**: no changes — design spec is comprehensive and covers all database view patterns
-- **quality.md**: updated UI Components note (13 → 16 shadcn/ui components)
+- **AGENTS.md**: no changes needed — rules are accurate and routing table is correct
+- **architecture.md**: updated Component Map to reflect 15 new/changed files added since last update:
+  - Added: `not-found.tsx` (root + app), `error.tsx` (workspace + page), `loading.tsx` (app + workspace + page), `auth/callback/route.ts`, `sign-in-form.tsx`, `sign-up-form.tsx`, `list-tab-indentation-plugin.tsx`, `emoji-picker.tsx`, `page-icon.tsx`, `relative-time.tsx`, `route-error.tsx`, `retry.ts`
+  - Updated: `pending-invite-list.tsx` description (copyable invite link), route pages now note `generateMetadata`
+  - Added `icon: text` to pages data model
+  - Added `ListTabIndentationPlugin` to custom plugins table
+- **conventions.md**: added 4 new patterns:
+  - Route-level error boundaries (reusable `RouteError` component)
+  - Dynamic page titles (`generateMetadata` pattern)
+  - Loading skeletons (`loading.tsx` pattern)
+  - Not-found pages pattern
+  - Fixed stale `<<<<<<< HEAD` merge conflict marker on line 707
+- **design.md**: added 4 new component specs:
+  - Page icon (editor) — position, states, interaction
+  - Emoji picker — layout, search, grid, close behavior
+  - Not-found pages — icon, heading, description, CTA pattern
+  - Error boundaries — matching not-found layout pattern
+- **quality.md**: no changes — grades verified accurate, test counts match (270 Vitest / 74 E2E / 56 files)
 
 ## Recommendations
 
-1. **Architecture doc auto-update**: The component map in `architecture.md` drifted significantly this week because the Feature Builder adds new files without updating the map. Consider adding a convention that Feature Builder PRs adding new files to `src/components/` or `src/lib/` must also update the component map in `architecture.md`.
+1. **Add E2E smoke test to Feature Builder pre-submit**: The search empty state bug recurred 8 times because feature PRs broke the search component without running E2E tests. The Feature Builder should run `pnpm test:e2e` (or at least the affected spec files) before opening a PR. This would have caught 7 of the 8 regressions before merge.
 
-2. **Database area stabilization**: 19 UI design spec violations and 11 post-merge regressions were concentrated in the database feature area. This is expected for a new feature area with high velocity (59 feature PRs). As the database feature matures, the Bug Fixer and UI Verifier workload should decrease. No action needed — the automation loop caught and fixed all issues.
+2. **Clean up dual status labels on issue close**: The PR Reviewer should remove `status:in-review` or `status:in-progress` when adding `status:done` to an issue. Add this to the PR Reviewer's prompt: "When closing an issue with `status:done`, remove any other `status:*` labels first."
 
-3. **Closed-PR ratio is healthy**: 7 closed-without-merge out of 257 (2.7%) is a good signal. The automation correctly abandoned superseded approaches rather than forcing bad fixes through.
+3. **Bug Fixer: analyze full data flow on recurring bugs**: When a bug recurs after a fix, the Bug Fixer should trace the complete async data flow rather than patching the immediate symptom. The search empty state bug was a state management race condition that required understanding the full effect chain — not just the visible symptom.


### PR DESCRIPTION
Running the Automation Auditor more than once in a week overwrites the previous audit file, as seen in #616 — the second run replaced the first run's data (100 PRs → 257 PRs) in `metrics/weekly/2026-W17-audit.md`.

### Changes

**Automation fix** (`.ona/automations/automation-auditor.yaml`):
- Branch and commit names now use `YYYY-MM-DD` instead of `YYYY-WNN` to avoid branch collisions on repeat runs
- Added instructions to check for existing audit files before writing — subsequent runs in the same week use a `-YYYY-MM-DD` date suffix instead of overwriting

**Data restoration**:
- `metrics/weekly/2026-W17-audit.md` — restored to the original first-run content (100 PRs, committed Apr 20)
- `metrics/weekly/2026-W17-audit-2026-04-23.md` — preserved the second-run content (257 PRs, committed Apr 23) as a separate file