### PR TITLE
fix(database): auto-detect group_by/date_property and add config dropdowns

### DIFF
--- a/e2e/database-view-config.spec.ts
+++ b/e2e/database-view-config.spec.ts
@@ -1,0 +1,535 @@
+import { test, expect } from "./fixtures/auth";
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Admin client for setup and cleanup
+// ---------------------------------------------------------------------------
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const SELECT_OPTIONS_STATUS = [
+  { id: crypto.randomUUID(), name: "To Do", color: "blue" },
+  { id: crypto.randomUUID(), name: "In Progress", color: "yellow" },
+  { id: crypto.randomUUID(), name: "Done", color: "green" },
+];
+
+const SELECT_OPTIONS_PRIORITY = [
+  { id: crypto.randomUUID(), name: "High", color: "red" },
+  { id: crypto.randomUUID(), name: "Medium", color: "orange" },
+  { id: crypto.randomUUID(), name: "Low", color: "gray" },
+];
+
+const NOW = new Date();
+const YEAR = NOW.getFullYear();
+const MONTH = NOW.getMonth();
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function dateInCurrentMonth(day: number): string {
+  return `${YEAR}-${pad(MONTH + 1)}-${pad(day)}`;
+}
+
+// Track IDs for cleanup
+let databasePageId: string;
+let workspaceSlug: string;
+let statusPropertyId: string;
+let priorityPropertyId: string;
+let dueDatePropertyId: string;
+let createdDatePropertyId: string;
+const rowPageIds: string[] = [];
+
+// ---------------------------------------------------------------------------
+// Setup: database with two select properties and two date properties
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  const admin = getAdminClient();
+  const email = process.env.TEST_USER_EMAIL!;
+
+  // Find the test user
+  const { data: userList } = await admin.auth.admin.listUsers({
+    perPage: 1000,
+  });
+  let testUserId: string | undefined;
+  if (userList?.users) {
+    testUserId = userList.users.find((u) => u.email === email)?.id;
+  }
+  if (!testUserId) {
+    const { data: profileRows } = await admin
+      .from("profiles")
+      .select("id")
+      .limit(50);
+    if (profileRows) {
+      for (const p of profileRows) {
+        const { data: authUser } = await admin.auth.admin.getUserById(p.id);
+        if (authUser?.user?.email === email) {
+          testUserId = p.id;
+          break;
+        }
+      }
+    }
+  }
+  if (!testUserId) throw new Error(`Test user ${email} not found`);
+
+  // Get workspace
+  const { data: memberships } = await admin
+    .from("members")
+    .select("workspace_id, workspaces(id, slug, is_personal)")
+    .eq("user_id", testUserId)
+    .limit(10);
+
+  if (!memberships || memberships.length === 0) {
+    throw new Error("No workspace found for test user");
+  }
+
+  const ws = memberships[0].workspaces as unknown as {
+    id: string;
+    slug: string;
+  };
+  workspaceSlug = ws.slug;
+
+  // Create a database page
+  const { data: dbPage, error: dbErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      title: "View Config Test DB",
+      is_database: true,
+      position: 9970,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (dbErr || !dbPage)
+    throw new Error(`Failed to create database: ${dbErr?.message}`);
+  databasePageId = dbPage.id;
+
+  // Create Status select property (position 0 — first select)
+  const { data: statusProp, error: statusErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Status",
+      type: "select",
+      config: { options: SELECT_OPTIONS_STATUS },
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (statusErr || !statusProp)
+    throw new Error(`Failed to create Status property: ${statusErr?.message}`);
+  statusPropertyId = statusProp.id;
+
+  // Create Priority select property (position 1 — second select)
+  const { data: priorityProp, error: priorityErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Priority",
+      type: "select",
+      config: { options: SELECT_OPTIONS_PRIORITY },
+      position: 1,
+    })
+    .select()
+    .single();
+
+  if (priorityErr || !priorityProp)
+    throw new Error(
+      `Failed to create Priority property: ${priorityErr?.message}`,
+    );
+  priorityPropertyId = priorityProp.id;
+
+  // Create Due Date property (position 2 — first date)
+  const { data: dueProp, error: dueErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Due Date",
+      type: "date",
+      config: {},
+      position: 2,
+    })
+    .select()
+    .single();
+
+  if (dueErr || !dueProp)
+    throw new Error(
+      `Failed to create Due Date property: ${dueErr?.message}`,
+    );
+  dueDatePropertyId = dueProp.id;
+
+  // Create Created Date property (position 3 — second date)
+  const { data: createdProp, error: createdErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Created Date",
+      type: "date",
+      config: {},
+      position: 3,
+    })
+    .select()
+    .single();
+
+  if (createdErr || !createdProp)
+    throw new Error(
+      `Failed to create Created Date property: ${createdErr?.message}`,
+    );
+  createdDatePropertyId = createdProp.id;
+
+  // Create the default table view
+  const { error: tvErr } = await admin
+    .from("database_views")
+    .insert({
+      database_id: databasePageId,
+      name: "Table view",
+      type: "table",
+      config: {},
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (tvErr) throw new Error(`Failed to create table view: ${tvErr.message}`);
+
+  // Create rows with values for both select and date properties
+  const rowData = [
+    {
+      title: "Task Alpha",
+      statusOptionId: SELECT_OPTIONS_STATUS[0].id,
+      priorityOptionId: SELECT_OPTIONS_PRIORITY[0].id,
+      dueDay: 5,
+      createdDay: 1,
+    },
+    {
+      title: "Task Beta",
+      statusOptionId: SELECT_OPTIONS_STATUS[1].id,
+      priorityOptionId: SELECT_OPTIONS_PRIORITY[1].id,
+      dueDay: 12,
+      createdDay: 2,
+    },
+    {
+      title: "Task Gamma",
+      statusOptionId: SELECT_OPTIONS_STATUS[2].id,
+      priorityOptionId: SELECT_OPTIONS_PRIORITY[2].id,
+      dueDay: 20,
+      createdDay: 3,
+    },
+  ];
+
+  for (const row of rowData) {
+    const { data: rowPage, error: rowErr } = await admin
+      .from("pages")
+      .insert({
+        workspace_id: ws.id,
+        parent_id: databasePageId,
+        title: row.title,
+        is_database: false,
+        position: rowPageIds.length,
+        created_by: testUserId,
+      })
+      .select()
+      .single();
+
+    if (rowErr || !rowPage)
+      throw new Error(`Failed to create row: ${rowErr?.message}`);
+    rowPageIds.push(rowPage.id);
+
+    // Set Status value
+    await admin.from("row_values").insert({
+      row_id: rowPage.id,
+      property_id: statusPropertyId,
+      value: { option_id: row.statusOptionId },
+    });
+
+    // Set Priority value
+    await admin.from("row_values").insert({
+      row_id: rowPage.id,
+      property_id: priorityPropertyId,
+      value: { option_id: row.priorityOptionId },
+    });
+
+    // Set Due Date value
+    await admin.from("row_values").insert({
+      row_id: rowPage.id,
+      property_id: dueDatePropertyId,
+      value: { date: dateInCurrentMonth(row.dueDay) },
+    });
+
+    // Set Created Date value
+    await admin.from("row_values").insert({
+      row_id: rowPage.id,
+      property_id: createdDatePropertyId,
+      value: { date: dateInCurrentMonth(row.createdDay) },
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+test.afterAll(async () => {
+  const admin = getAdminClient();
+
+  const { data: allRows } = await admin
+    .from("pages")
+    .select("id")
+    .eq("parent_id", databasePageId);
+  if (allRows) {
+    for (const row of allRows) {
+      await admin.from("row_values").delete().eq("row_id", row.id);
+    }
+    for (const row of allRows) {
+      await admin.from("pages").delete().eq("id", row.id);
+    }
+  }
+
+  await admin
+    .from("database_views")
+    .delete()
+    .eq("database_id", databasePageId);
+  await admin
+    .from("database_properties")
+    .delete()
+    .eq("database_id", databasePageId);
+  await admin.from("pages").delete().eq("id", databasePageId);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function navigateToDatabase(page: import("@playwright/test").Page) {
+  await page.goto(`/${workspaceSlug}/${databasePageId}`);
+  await expect(
+    page.getByRole("button", { name: /Table view/i }),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests — run serially to avoid data race conditions
+// ---------------------------------------------------------------------------
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Board and calendar view configuration", () => {
+  test("creating a board view auto-selects the first select property as group_by", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Add a board view via the view tabs
+    const addViewBtn = page.locator('button[aria-label="Add view"]');
+    await expect(addViewBtn).toBeVisible({ timeout: 5_000 });
+    await addViewBtn.click();
+
+    const boardOption = page.locator('[role="menuitem"]', {
+      hasText: "Board view",
+    });
+    await expect(boardOption).toBeVisible({ timeout: 5_000 });
+    await boardOption.click();
+
+    // Wait for the board view to render — it should auto-select "Status"
+    // as group_by and show board columns (not the placeholder message)
+    await expect(
+      page.locator("a").filter({ hasText: "Task Alpha" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The "Group by" toolbar button should show "Status"
+    const groupByBtn = page.locator(
+      '[data-testid="view-config-group-by"]',
+    );
+    await expect(groupByBtn).toBeVisible({ timeout: 5_000 });
+    await expect(groupByBtn).toContainText("Status");
+
+    // Board columns should be visible for each Status option
+    for (const option of SELECT_OPTIONS_STATUS) {
+      await expect(
+        page
+          .locator("span", { hasText: new RegExp(option.name, "i") })
+          .first(),
+      ).toBeVisible({ timeout: 5_000 });
+    }
+  });
+
+  test("board view Group By dropdown changes the grouping property", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Switch to the Board view tab
+    const boardTab = page.getByRole("button", { name: /Board view/i });
+    await expect(boardTab).toBeVisible({ timeout: 10_000 });
+    await boardTab.click();
+
+    // Wait for board to render with Status grouping
+    await expect(
+      page.locator("a").filter({ hasText: "Task Alpha" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Click the "Group by" dropdown
+    const groupByBtn = page.locator(
+      '[data-testid="view-config-group-by"]',
+    );
+    await expect(groupByBtn).toBeVisible({ timeout: 5_000 });
+    await groupByBtn.click();
+
+    // Select "Priority" from the dropdown
+    const priorityOption = page.locator('[role="menuitem"]', {
+      hasText: "Priority",
+    });
+    await expect(priorityOption).toBeVisible({ timeout: 5_000 });
+    await priorityOption.click();
+
+    // Wait for the board to re-render with Priority columns
+    await page.waitForTimeout(2_000);
+
+    // The Group by button should now show "Priority"
+    await expect(groupByBtn).toContainText("Priority");
+
+    // Priority columns should be visible
+    for (const option of SELECT_OPTIONS_PRIORITY) {
+      await expect(
+        page
+          .locator("span", { hasText: new RegExp(option.name, "i") })
+          .first(),
+      ).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Reload and verify persistence
+    await page.reload();
+    await expect(boardTab).toBeVisible({ timeout: 15_000 });
+    await boardTab.click();
+
+    await expect(
+      page.locator("a").filter({ hasText: "Task Alpha" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const groupByBtnAfterReload = page.locator(
+      '[data-testid="view-config-group-by"]',
+    );
+    await expect(groupByBtnAfterReload).toContainText("Priority");
+  });
+
+  test("creating a calendar view auto-selects the first date property as date_property", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Add a calendar view via the view tabs
+    const addViewBtn = page.locator('button[aria-label="Add view"]');
+    await expect(addViewBtn).toBeVisible({ timeout: 5_000 });
+    await addViewBtn.click();
+
+    const calendarOption = page.locator('[role="menuitem"]', {
+      hasText: "Calendar view",
+    });
+    await expect(calendarOption).toBeVisible({ timeout: 5_000 });
+    await calendarOption.click();
+
+    // Wait for the calendar to render — it should auto-select "Due Date"
+    // and show the month/year header (not the placeholder message)
+    const FULL_MONTHS = [
+      "January", "February", "March", "April", "May", "June",
+      "July", "August", "September", "October", "November", "December",
+    ];
+    await expect(
+      page.locator("h2", {
+        hasText: `${FULL_MONTHS[MONTH]} ${YEAR}`,
+      }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The "Date property" toolbar button should show "Due Date"
+    const datePropBtn = page.locator(
+      '[data-testid="view-config-date-property"]',
+    );
+    await expect(datePropBtn).toBeVisible({ timeout: 5_000 });
+    await expect(datePropBtn).toContainText("Due Date");
+
+    // Items should be visible on the calendar
+    await expect(
+      page.locator("a", { hasText: "Task Alpha" }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("calendar view Date Property dropdown changes the date property", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Switch to the Calendar view tab
+    const calendarTab = page.getByRole("button", {
+      name: /Calendar view/i,
+    });
+    await expect(calendarTab).toBeVisible({ timeout: 10_000 });
+    await calendarTab.click();
+
+    const FULL_MONTHS = [
+      "January", "February", "March", "April", "May", "June",
+      "July", "August", "September", "October", "November", "December",
+    ];
+
+    // Wait for calendar to render
+    await expect(
+      page.locator("h2", {
+        hasText: `${FULL_MONTHS[MONTH]} ${YEAR}`,
+      }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Click the "Date property" dropdown
+    const datePropBtn = page.locator(
+      '[data-testid="view-config-date-property"]',
+    );
+    await expect(datePropBtn).toBeVisible({ timeout: 5_000 });
+    await datePropBtn.click();
+
+    // Select "Created Date" from the dropdown
+    const createdDateOption = page.locator('[role="menuitem"]', {
+      hasText: "Created Date",
+    });
+    await expect(createdDateOption).toBeVisible({ timeout: 5_000 });
+    await createdDateOption.click();
+
+    // Wait for the calendar to re-render
+    await page.waitForTimeout(2_000);
+
+    // The Date property button should now show "Created Date"
+    await expect(datePropBtn).toContainText("Created Date");
+
+    // Items should still be visible (they have Created Date values too)
+    await expect(
+      page.locator("a", { hasText: "Task Alpha" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Reload and verify persistence
+    await page.reload();
+    await expect(calendarTab).toBeVisible({ timeout: 15_000 });
+    await calendarTab.click();
+
+    await expect(
+      page.locator("h2", {
+        hasText: `${FULL_MONTHS[MONTH]} ${YEAR}`,
+      }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const datePropBtnAfterReload = page.locator(
+      '[data-testid="view-config-date-property"]',
+    );
+    await expect(datePropBtnAfterReload).toContainText("Created Date");
+  });
+});

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -23,6 +23,13 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown, Check } from "lucide-react";
+import {
   sortRows,
   filterRows,
   type SortRule,
@@ -52,6 +59,7 @@ import type {
   DatabaseProperty,
   DatabaseRow,
   DatabaseView,
+  DatabaseViewConfig,
   DatabaseViewType,
   PropertyType,
 } from "@/lib/types";
@@ -116,6 +124,57 @@ export interface DatabaseViewClientProps {
   workspaceId: string;
   workspaceSlug: string;
   userId: string;
+}
+
+// ---------------------------------------------------------------------------
+// ViewConfigDropdown — toolbar dropdown for selecting a property (group_by, date_property)
+// ---------------------------------------------------------------------------
+
+interface ViewConfigDropdownProps {
+  label: string;
+  selectedId: string | null;
+  options: DatabaseProperty[];
+  onSelect: (propertyId: string) => void;
+}
+
+function ViewConfigDropdown({
+  label,
+  selectedId,
+  options,
+  onSelect,
+}: ViewConfigDropdownProps) {
+  const selectedName = options.find((p) => p.id === selectedId)?.name;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="inline-flex h-7 items-center gap-1 rounded-sm px-2 text-xs text-muted-foreground outline-none transition-colors hover:bg-white/[0.06] hover:text-foreground"
+        data-testid={`view-config-${label.toLowerCase().replace(/\s+/g, "-")}`}
+      >
+        {label}: {selectedName ?? "None"}
+        <ChevronDown className="size-3" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {options.length === 0 ? (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">
+            No matching properties
+          </div>
+        ) : (
+          options.map((prop) => (
+            <DropdownMenuItem
+              key={prop.id}
+              onClick={() => onSelect(prop.id)}
+              className="gap-2 text-xs"
+            >
+              {prop.id === selectedId && <Check className="size-3" />}
+              {prop.id !== selectedId && <span className="size-3" />}
+              {prop.name}
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -272,7 +331,22 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
   const handleAddView = useCallback(
     async (type: DatabaseViewType) => {
       const name = `${VIEW_TYPE_LABELS[type]} view`;
-      const { data: newView, error } = await addView(pageId, name, type, {});
+
+      // Auto-detect a default config property for board and calendar views
+      let config: DatabaseViewConfig = {};
+      if (type === "board") {
+        const firstSelect = properties.find((p) => p.type === "select");
+        if (firstSelect) {
+          config = { group_by: firstSelect.id };
+        }
+      } else if (type === "calendar") {
+        const firstDate = properties.find((p) => p.type === "date");
+        if (firstDate) {
+          config = { date_property: firstDate.id };
+        }
+      }
+
+      const { data: newView, error } = await addView(pageId, name, type, config);
       if (error || !newView) {
         toast.error("Failed to create view", { duration: 8000 });
         return;
@@ -283,7 +357,34 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       params.set("view", newView.id);
       router.replace(`?${params.toString()}`, { scroll: false });
     },
-    [pageId, router, searchParams],
+    [pageId, properties, router, searchParams],
+  );
+
+  // Update the active view's config (used by board/calendar config dropdowns)
+  const handleViewConfigChange = useCallback(
+    async (configPatch: Partial<DatabaseViewConfig>) => {
+      if (!activeView) return;
+      const newConfig = { ...activeView.config, ...configPatch };
+
+      // Optimistic update
+      setViews((prev) =>
+        prev.map((v) =>
+          v.id === activeView.id ? { ...v, config: newConfig } : v,
+        ),
+      );
+
+      const { error } = await updateView(activeView.id, { config: newConfig });
+      if (error) {
+        toast.error("Failed to update view configuration", { duration: 8000 });
+        // Revert
+        setViews((prev) =>
+          prev.map((v) =>
+            v.id === activeView.id ? { ...v, config: activeView.config } : v,
+          ),
+        );
+      }
+    },
+    [activeView],
   );
 
   // Rename a view
@@ -859,6 +960,22 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
                   filters={activeFilters}
                   onFiltersChange={handleFiltersChange}
                 />
+                {activeView.type === "board" && (
+                  <ViewConfigDropdown
+                    label="Group by"
+                    selectedId={activeView.config.group_by ?? null}
+                    options={properties.filter((p) => p.type === "select")}
+                    onSelect={(id) => handleViewConfigChange({ group_by: id })}
+                  />
+                )}
+                {activeView.type === "calendar" && (
+                  <ViewConfigDropdown
+                    label="Date property"
+                    selectedId={activeView.config.date_property ?? null}
+                    options={properties.filter((p) => p.type === "date")}
+                    onSelect={(id) => handleViewConfigChange({ date_property: id })}
+                  />
+                )}
               </div>
             )}
 


### PR DESCRIPTION
Closes #615

## What

Board and calendar views created via the UI were unusable — `handleAddView` passed `{}` as config, so `group_by` and `date_property` were never set. Both views showed placeholder messages with no way to configure the required property.

## Changes

**Auto-detection on view creation** (`database-view-client.tsx`):
- Board view: scans properties for the first `select` type and sets it as `group_by`
- Calendar view: scans properties for the first `date` type and sets it as `date_property`
- Falls back to empty config (existing placeholder) if no suitable property exists

**Configuration dropdowns** (`database-view-client.tsx`):
- "Group by" dropdown in the toolbar when a board view is active — lists all select-type properties
- "Date property" dropdown in the toolbar when a calendar view is active — lists all date-type properties
- Selection persists via `updateView` with optimistic UI updates

**E2E tests** (`e2e/database-view-config.spec.ts`, 4 tests):
- Board view auto-selects first select property on creation
- Board view Group By dropdown changes grouping and persists after reload
- Calendar view auto-selects first date property on creation
- Calendar view Date Property dropdown changes date property and persists after reload

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 73 files, 800 tests pass
- `pnpm test:e2e -- e2e/database-view-config.spec.ts` — 4/4 pass
- `pnpm test:e2e -- e2e/database-board.spec.ts e2e/database-calendar.spec.ts` — 8/8 pass (no regressions)