### PR TITLE
feat(database): Notion-style table headers, expandable last column, status property type

### DIFF
--- a/.agents/design.md
+++ b/.agents/design.md
@@ -350,7 +350,7 @@ Database views render structured data within the existing page layout. When a pa
 ### Table View
 
 - Full-width spreadsheet grid within `max-w-3xl` content area (can overflow with horizontal scroll).
-- Column headers: `bg-muted`, `text-xs font-medium text-muted-foreground`, `uppercase tracking-widest`, `p-2`, `border-b border-white/[0.06]`.
+- Column headers: `bg-background` (same as data rows), `text-xs font-medium text-muted-foreground`, `uppercase tracking-widest`, `p-2`, `border-b border-white/[0.06]`. Trailing column uses `minmax(48px, 1fr)` to fill remaining width.
 - Column resize: drag handle on right edge of header, `cursor-col-resize`, 2px `bg-accent` indicator while dragging.
 - Cells: `p-2 text-sm`, `border-b border-white/[0.06]`. Click to edit inline.
 - Row hover: `bg-white/[0.02]`.
@@ -409,6 +409,7 @@ Inline cell rendering and editing patterns for each property type:
 | Number | Right-aligned, formatted | Input `type="number"` |
 | Select | Colored badge | Dropdown with options, create new inline |
 | Multi-select | Multiple colored badges, wrapping | Dropdown with checkboxes, create new inline |
+| Status | Colored badge (select variant with defaults: Not Started / In Progress / Done) | Same dropdown as Select; new statuses can be added inline |
 | Checkbox | Centered checkbox icon | Toggle on click (no separate edit mode) |
 | Date | Formatted date string (`MMM D, YYYY`) | Date picker popover |
 | URL | Truncated link, `text-accent`, external icon | Input field |

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -31,6 +31,15 @@ const config: StorybookConfig = {
       clientPort: 443,
       protocol: "wss",
     };
+
+    // Next.js CJS modules (e.g. next/link) reference `process.env` at
+    // import-time. Vite doesn't provide a Node-style `process` global, so we
+    // inject a minimal shim via `define`.
+    config.define = {
+      ...config.define,
+      "process.env": JSON.stringify({}),
+    };
+
     return config;
   },
 };

--- a/src/components/database/property-types/index.ts
+++ b/src/components/database/property-types/index.ts
@@ -20,6 +20,7 @@ import {
 } from "./computed";
 import { RelationRenderer, RelationEditor } from "./relation";
 import { FormulaRenderer } from "./formula";
+import { StatusRenderer, StatusEditor } from "./status";
 
 // ---------------------------------------------------------------------------
 // Shared prop interfaces
@@ -90,6 +91,7 @@ const registry: Partial<Record<PropertyType, PropertyTypeConfig>> = {
   number: { Renderer: NumberRenderer, Editor: NumberEditor },
   select: { Renderer: SelectRenderer, Editor: SelectEditor },
   multi_select: { Renderer: MultiSelectRenderer, Editor: MultiSelectEditor },
+  status: { Renderer: StatusRenderer, Editor: StatusEditor },
   checkbox: { Renderer: CheckboxRenderer, Editor: CheckboxEditor },
   date: { Renderer: DateRenderer, Editor: DateEditor },
   url: { Renderer: UrlRenderer, Editor: UrlEditor },
@@ -125,6 +127,7 @@ export const STANDARD_PROPERTY_TYPES: readonly PropertyType[] = [
   "number",
   "select",
   "multi_select",
+  "status",
   "checkbox",
   "date",
   "url",

--- a/src/components/database/property-types/status.stories.tsx
+++ b/src/components/database/property-types/status.stories.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { DatabaseProperty } from "@/lib/types";
+import { StatusRenderer, StatusEditor, DEFAULT_STATUS_OPTIONS } from "./status";
+
+function makeProp(
+  options = DEFAULT_STATUS_OPTIONS,
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Stage",
+    type: "status",
+    config: { options },
+    position: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+const meta: Meta<typeof StatusRenderer> = {
+  title: "Database/PropertyTypes/Status/Renderer",
+  component: StatusRenderer,
+  decorators: [
+    (Story) => (
+      <div className="w-48 bg-background p-2">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export { meta as default };
+type Story = StoryObj<typeof StatusRenderer>;
+
+export const NotStarted: Story = {
+  args: {
+    value: { option_id: "status-not-started" },
+    property: makeProp(),
+  },
+};
+
+export const InProgress: Story = {
+  args: {
+    value: { option_id: "status-in-progress" },
+    property: makeProp(),
+  },
+};
+
+export const Done: Story = {
+  args: {
+    value: { option_id: "status-done" },
+    property: makeProp(),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: {},
+    property: makeProp(),
+  },
+};
+
+export const DefaultsWithNoConfig: Story = {
+  name: "Defaults (empty config)",
+  args: {
+    value: { option_id: "status-in-progress" },
+    property: makeProp([]),
+  },
+};
+
+function StatusEditorDemo() {
+  const prop = makeProp();
+  const [value, setValue] = useState<Record<string, unknown>>({
+    option_id: "status-not-started",
+  });
+  return (
+    <div className="w-64 bg-background p-2">
+      <StatusEditor
+        value={value}
+        property={prop}
+        onChange={setValue}
+        onBlur={() => {}}
+      />
+    </div>
+  );
+}
+
+export const Editor: Story = {
+  render: () => <StatusEditorDemo />,
+};

--- a/src/components/database/property-types/status.tsx
+++ b/src/components/database/property-types/status.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { SelectOption } from "@/lib/types";
+import type { RendererProps, EditorProps } from "./index";
+import { nextOptionColor } from "./index";
+import { SelectOptionBadge } from "./select-option-badge";
+import { SelectDropdown } from "./select-dropdown";
+
+// ---------------------------------------------------------------------------
+// Default status options — seeded when a status property has no options yet.
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_STATUS_OPTIONS: SelectOption[] = [
+  { id: "status-not-started", name: "Not Started", color: "gray" },
+  { id: "status-in-progress", name: "In Progress", color: "blue" },
+  { id: "status-done", name: "Done", color: "green" },
+];
+
+function getOptions(config: Record<string, unknown>): SelectOption[] {
+  if (Array.isArray(config.options) && config.options.length > 0) {
+    return config.options as SelectOption[];
+  }
+  return DEFAULT_STATUS_OPTIONS;
+}
+
+function getSelectedId(value: Record<string, unknown>): string | null {
+  return typeof value.option_id === "string" ? value.option_id : null;
+}
+
+export function StatusRenderer({ value, property }: RendererProps) {
+  const options = getOptions(property.config);
+  const selectedId = getSelectedId(value);
+  if (!selectedId) return null;
+
+  const option = options.find((o) => o.id === selectedId);
+  if (!option) return null;
+
+  return <SelectOptionBadge name={option.name} color={option.color} />;
+}
+
+export function StatusEditor({
+  value,
+  property,
+  onChange,
+  onBlur,
+}: EditorProps) {
+  const [localOptions, setLocalOptions] = useState<SelectOption[]>(() =>
+    getOptions(property.config),
+  );
+  const selectedId = getSelectedId(value);
+  const selected = selectedId ? [selectedId] : [];
+
+  const handleSelect = useCallback(
+    (optionId: string) => {
+      onChange({ option_id: optionId });
+    },
+    [onChange],
+  );
+
+  const handleDeselect = useCallback(() => {
+    onChange({ option_id: null });
+  }, [onChange]);
+
+  const handleCreate = useCallback(
+    (name: string) => {
+      const color = nextOptionColor(localOptions.length);
+      const newOption: SelectOption = {
+        id: crypto.randomUUID(),
+        name,
+        color,
+      };
+      const updated = [...localOptions, newOption];
+      setLocalOptions(updated);
+      onChange({ option_id: newOption.id, _newOptions: updated });
+    },
+    [localOptions, onChange],
+  );
+
+  const handleColorChange = useCallback(
+    (optionId: string, color: string) => {
+      const updated = localOptions.map((o) =>
+        o.id === optionId ? { ...o, color } : o,
+      );
+      setLocalOptions(updated);
+      const currentId = getSelectedId(value);
+      onChange({
+        option_id: currentId,
+        _newOptions: updated,
+      });
+    },
+    [localOptions, value, onChange],
+  );
+
+  return (
+    <div className="w-full">
+      <SelectDropdown
+        options={localOptions}
+        selected={selected}
+        multi={false}
+        onSelect={handleSelect}
+        onDeselect={handleDeselect}
+        onCreate={handleCreate}
+        onClose={onBlur}
+        onColorChange={handleColorChange}
+      />
+    </div>
+  );
+}

--- a/src/components/database/views/table-view.stories.tsx
+++ b/src/components/database/views/table-view.stories.tsx
@@ -72,6 +72,16 @@ const mockProperties: DatabaseProperty[] = [
     created_at: "2026-04-01T00:00:00Z",
     updated_at: "2026-04-01T00:00:00Z",
   },
+  {
+    id: "prop-stage",
+    database_id: "db-1",
+    name: "Stage",
+    type: "status",
+    config: {},
+    position: 6,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
 ];
 
 function makeRow(
@@ -112,6 +122,7 @@ const mockRows: DatabaseRow[] = [
     "prop-due": { value: "2026-04-30" },
     "prop-url": { value: "https://example.com/design" },
     "prop-done": { value: false },
+    "prop-stage": { option_id: "status-in-progress" },
   }),
   makeRow("row-2", "API authentication", "🔐", {
     "prop-status": { value: "Done", color: "green" },
@@ -119,12 +130,14 @@ const mockRows: DatabaseRow[] = [
     "prop-due": { value: "2026-04-15" },
     "prop-url": { value: "https://example.com/auth" },
     "prop-done": { value: true },
+    "prop-stage": { option_id: "status-done" },
   }),
   makeRow("row-3", "Database migrations", null, {
     "prop-status": { value: "To Do", color: "gray" },
     "prop-priority": { value: "Medium", color: "yellow" },
     "prop-due": { value: "2026-05-10" },
     "prop-done": { value: false },
+    "prop-stage": { option_id: "status-not-started" },
   }),
   makeRow("row-4", "User onboarding flow", "🚀", {
     "prop-status": { value: "In Review", color: "purple" },
@@ -132,6 +145,7 @@ const mockRows: DatabaseRow[] = [
     "prop-due": { value: "2026-05-01" },
     "prop-url": { value: "https://example.com/onboarding" },
     "prop-done": { value: false },
+    "prop-stage": { option_id: "status-in-progress" },
   }),
   makeRow("row-5", "", null, {
     "prop-status": { value: "To Do", color: "gray" },

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -44,6 +44,7 @@ import {
   getPropertyTypeConfig,
 } from "@/components/database/property-types";
 import { evaluateFormulaForRow } from "@/components/database/property-types/formula";
+import { DEFAULT_STATUS_OPTIONS } from "@/components/database/property-types/status";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -206,12 +207,14 @@ export function TableView({
     return properties;
   }, [properties, viewConfig.visible_properties]);
 
-  // Grid template: title column + property columns + add-column button
+  // Grid template: title column + property columns + flexible trailing column.
+  // The trailing column uses 1fr so it stretches to fill remaining viewport
+  // width instead of creating a hard cutoff (matches Notion behaviour).
   const gridTemplateColumns = useMemo(() => {
     const cols = [
       `${TITLE_COLUMN_WIDTH}px`,
       ...visibleProperties.map((p) => `${columnWidths[p.id] ?? DEFAULT_COLUMN_WIDTH}px`),
-      "48px", // add column button
+      "minmax(48px, 1fr)",
     ];
     return cols.join(" ");
   }, [visibleProperties, columnWidths]);
@@ -397,7 +400,7 @@ export function TableView({
           style={{ gridTemplateColumns }}
         >
           {/* Header row */}
-          <div className="border-b border-white/[0.06] bg-muted p-2">
+          <div className="border-b border-white/[0.06] p-2">
             <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
               Title
             </span>
@@ -417,7 +420,7 @@ export function TableView({
               <div
                 key={prop.id}
                 className={cn(
-                  "relative border-b border-white/[0.06] bg-muted p-2",
+                  "relative border-b border-white/[0.06] p-2",
                   onColumnReorder && "cursor-grab",
                   isDragging && "opacity-50",
                 )}
@@ -440,7 +443,7 @@ export function TableView({
               </div>
             );
           })}
-          <div className="border-b border-white/[0.06] bg-muted p-2" />
+          <div className="border-b border-white/[0.06] p-2" />
         </div>
         <div className="flex flex-col items-center justify-center py-12 text-center">
           <FileText className="mb-3 h-10 w-10 text-muted-foreground/30" />
@@ -472,7 +475,7 @@ export function TableView({
       >
         {/* --- Header row --- */}
         <div
-          className="sticky top-0 z-10 border-b border-white/[0.06] bg-muted p-2"
+          className="sticky top-0 z-10 border-b border-white/[0.06] bg-background p-2"
           role="columnheader"
         >
           <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
@@ -496,7 +499,7 @@ export function TableView({
             <div
               key={prop.id}
               className={cn(
-                "group/header relative sticky top-0 z-10 border-b border-white/[0.06] bg-muted p-2",
+                "group/header relative sticky top-0 z-10 border-b border-white/[0.06] bg-background p-2",
                 onColumnReorder && "cursor-grab",
                 isDragging && "opacity-50",
               )}
@@ -589,7 +592,7 @@ export function TableView({
         })}
 
         {/* Add column header button */}
-        <div className="sticky top-0 z-10 flex items-center justify-center border-b border-white/[0.06] bg-muted">
+        <div className="sticky top-0 z-10 flex items-center justify-start border-b border-white/[0.06] bg-background pl-2">
           {onAddColumn && (
             <PropertyTypePicker onSelect={onAddColumn} />
           )}
@@ -942,6 +945,7 @@ const PORTALED_EDITOR_TYPES: ReadonlySet<PropertyType> = new Set([
   "date",
   "select",
   "multi_select",
+  "status",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -1066,11 +1070,12 @@ interface CellRendererProps {
 
 function CellRenderer({ value, property, propertyType, displayValue }: CellRendererProps) {
   switch (propertyType) {
-    case "select": {
+    case "select":
+    case "status": {
       const raw = value?.value as Record<string, unknown> | undefined;
       const optionId = typeof raw?.option_id === "string" ? raw.option_id : null;
       if (!optionId) return null;
-      const options = getSelectOptions(property.config);
+      const options = getSelectOptions(property.config, propertyType);
       const option = options.find((o) => o.id === optionId);
       if (!option) return null;
       return <SelectBadge label={option.name} color={option.color} />;
@@ -1082,7 +1087,7 @@ function CellRenderer({ value, property, propertyType, displayValue }: CellRende
         ? (raw.option_ids as string[])
         : [];
       if (optionIds.length === 0) return null;
-      const options = getSelectOptions(property.config);
+      const options = getSelectOptions(property.config, propertyType);
       const optionMap = new Map(options.map((o) => [o.id, o]));
       return (
         <div className="flex flex-wrap gap-1">
@@ -1204,10 +1209,11 @@ function SelectBadge({ label, color }: { label: string; color?: string }) {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getSelectOptions(config: Record<string, unknown>): SelectOption[] {
-  if (Array.isArray(config.options)) {
+function getSelectOptions(config: Record<string, unknown>, type?: PropertyType): SelectOption[] {
+  if (Array.isArray(config.options) && config.options.length > 0) {
     return config.options as SelectOption[];
   }
+  if (type === "status") return DEFAULT_STATUS_OPTIONS;
   return [];
 }
 
@@ -1230,7 +1236,8 @@ function extractDisplayValue(value: RowValue | undefined, propertyType: Property
     }
     case "select":
     case "multi_select":
-      // Select/multi-select rendering is handled directly by CellRenderer
+    case "status":
+      // Select/multi-select/status rendering is handled directly by CellRenderer
       // using option IDs from the raw value and the property config.
       return "";
     default: {
@@ -1275,7 +1282,7 @@ function TableSkeleton({ rowHeight, columnCount }: TableSkeletonProps) {
   return (
     <div className="w-full">
       {/* Header skeleton */}
-      <div className="flex border-b border-white/[0.06] bg-muted">
+      <div className="flex border-b border-white/[0.06]">
         {cols.map((i) => (
           <div key={i} className="flex-1 p-2">
             <div className="h-3 w-16 animate-pulse bg-white/[0.06]" />

--- a/src/lib/database-filters.ts
+++ b/src/lib/database-filters.ts
@@ -89,6 +89,7 @@ const OPERATORS_BY_TYPE: Record<PropertyType, FilterOperator[]> = {
   number: NUMBER_OPERATORS,
   select: SELECT_OPERATORS,
   multi_select: MULTI_SELECT_OPERATORS,
+  status: SELECT_OPERATORS,
   checkbox: CHECKBOX_OPERATORS,
   date: DATE_OPERATORS,
   url: STRING_LIKE_OPERATORS,

--- a/src/lib/property-icons.ts
+++ b/src/lib/property-icons.ts
@@ -4,6 +4,7 @@
 import {
   Calendar,
   CheckSquare,
+  CircleDot,
   Clock,
   FileText,
   Hash,
@@ -25,6 +26,7 @@ export const PROPERTY_TYPE_ICON: Record<
   number: Hash,
   select: List,
   multi_select: List,
+  status: CircleDot,
   checkbox: CheckSquare,
   date: Calendar,
   url: LinkIcon,
@@ -44,6 +46,7 @@ export const PROPERTY_TYPE_LABEL: Record<PropertyType, string> = {
   number: "Number",
   select: "Select",
   multi_select: "Multi-select",
+  status: "Status",
   checkbox: "Checkbox",
   date: "Date",
   url: "URL",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -127,6 +127,7 @@ export type PropertyType =
   | "number"
   | "select"
   | "multi_select"
+  | "status"
   | "checkbox"
   | "date"
   | "url"


### PR DESCRIPTION
## Changes

**Table header styling** — Removed `bg-muted` from all table header cells so headers share the same background as data rows (Notion-style). Sticky headers use `bg-background` to remain opaque on scroll.

**Last column expansion** — Changed the trailing grid column from fixed `48px` to `minmax(48px, 1fr)` so it stretches to fill remaining viewport width instead of creating a hard cutoff. The add-column `+` button is left-aligned.

**Status property type** — New `status` type that behaves like `select` but seeds three default options (Not Started / In Progress / Done) when the property config is empty. Users can add custom statuses via the dropdown.

**Storybook fix** — Shimmed `process.env` in the Vite config to fix `ReferenceError: process is not defined` caused by Next.js CJS modules (e.g. `next/link`).

## Files changed

- `.storybook/main.ts` — process.env shim
- `src/components/database/views/table-view.tsx` — header bg, grid template, add-column alignment, status type handling
- `src/components/database/views/table-view.stories.tsx` — added status column to mock data
- `src/components/database/property-types/status.tsx` — renderer + editor
- `src/components/database/property-types/status.stories.tsx` — stories
- `src/components/database/property-types/index.ts` — registry entry
- `src/lib/types.ts` — `status` in PropertyType union
- `src/lib/property-icons.ts` — CircleDot icon + label
- `src/lib/database-filters.ts` — filter operators
- `.agents/design.md` — updated spec