### PR TITLE
fix(database): use onClick instead of onSelect on ContextMenuItem (#623)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -905,6 +905,25 @@ const [dialogOpen, setDialogOpen] = useState(false);
 </DropdownMenuItem>
 ```
 
+### Menu item click handlers — `onClick`, not `onSelect`
+
+Base UI's `MenuItem` (used by `ContextMenuItem` and `DropdownMenuItem`) uses
+`onClick` for item actions. The Radix-style `onSelect` prop does not exist on
+Base UI primitives — it is silently ignored if passed, causing menu actions to
+never fire.
+
+```typescript
+// ✅ Correct — Base UI uses onClick
+<ContextMenuItem onClick={() => handleAction("rename")}>
+  Rename
+</ContextMenuItem>
+
+// ❌ Wrong — onSelect is silently ignored by Base UI
+<ContextMenuItem onSelect={() => handleAction("rename")}>
+  Rename
+</ContextMenuItem>
+```
+
 ### Button primitives
 
 Buttons use `@base-ui/react/button` internally. The `Button` component accepts

--- a/e2e/database-views.spec.ts
+++ b/e2e/database-views.spec.ts
@@ -437,3 +437,153 @@ test.describe("Database sort, filter, and multi-view management", () => {
     await expect(prop2Cell(page, 1)).toHaveText("Alpha", { timeout: 5_000 });
   });
 });
+
+// ---------------------------------------------------------------------------
+// View tab context menu tests (regression for #623)
+// ---------------------------------------------------------------------------
+
+test.describe("Database view tab context menu actions", () => {
+  /**
+   * Add a second view (List) so context menu delete is enabled.
+   */
+  async function addListView(page: import("@playwright/test").Page) {
+    const addViewBtn = page.locator('button[aria-label="Add view"]');
+    await expect(addViewBtn).toBeVisible({ timeout: 5_000 });
+    await addViewBtn.click();
+
+    const listViewOption = page.locator('[role="menuitem"]', {
+      hasText: "List view",
+    });
+    await expect(listViewOption).toBeVisible({ timeout: 5_000 });
+    await listViewOption.click();
+    await page.waitForTimeout(2_000);
+
+    await expect(
+      page.locator("button", { hasText: "List view" }),
+    ).toBeVisible({ timeout: 5_000 });
+  }
+
+  test("context menu rename enters inline edit mode", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+    await addRow(page);
+
+    // Right-click the "Default view" tab to open context menu
+    const defaultTab = page.locator("button", { hasText: "Default view" });
+    await expect(defaultTab).toBeVisible({ timeout: 10_000 });
+    await defaultTab.click({ button: "right" });
+
+    // Click "Rename" in the context menu
+    const renameItem = page.locator('[data-slot="context-menu-item"]', {
+      hasText: "Rename",
+    });
+    await expect(renameItem).toBeVisible({ timeout: 5_000 });
+    await renameItem.click();
+
+    // The inline rename input should appear
+    const renameInput = page.locator('input[aria-label="Rename view"]');
+    await expect(renameInput).toBeVisible({ timeout: 5_000 });
+
+    // Type a new name and confirm
+    await renameInput.fill("Renamed via context menu");
+    await renameInput.press("Enter");
+    await page.waitForTimeout(2_000);
+
+    // The tab should show the new name
+    await expect(
+      page.locator("button", { hasText: "Renamed via context menu" }),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("context menu delete opens confirmation dialog and removes view", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+    await addRow(page);
+
+    // Add a second view so delete is enabled
+    await addListView(page);
+
+    // Right-click the "List view" tab
+    const listTab = page.locator("button", { hasText: "List view" });
+    await expect(listTab).toBeVisible({ timeout: 5_000 });
+    await listTab.click({ button: "right" });
+
+    // Click "Delete view" in the context menu
+    const deleteItem = page.locator('[data-slot="context-menu-item"]', {
+      hasText: "Delete view",
+    });
+    await expect(deleteItem).toBeVisible({ timeout: 5_000 });
+    await deleteItem.click();
+
+    // The delete confirmation dialog should appear
+    const dialog = page.locator('[role="alertdialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await expect(
+      dialog.locator('[data-slot="alert-dialog-title"]'),
+    ).toContainText("Delete");
+
+    // Confirm deletion
+    const confirmBtn = dialog.locator("button", { hasText: "Delete" });
+    await expect(confirmBtn).toBeVisible({ timeout: 5_000 });
+    await confirmBtn.click();
+    await page.waitForTimeout(2_000);
+
+    // The "List view" tab should be gone
+    await expect(
+      page.locator("button", { hasText: "List view" }),
+    ).toBeHidden({ timeout: 5_000 });
+
+    // The "Default view" tab should still be visible
+    await expect(
+      page.locator("button", { hasText: "Default view" }),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("context menu duplicate creates a copy of the view", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+    await addRow(page);
+
+    // Right-click the "Default view" tab
+    const defaultTab = page.locator("button", { hasText: "Default view" });
+    await expect(defaultTab).toBeVisible({ timeout: 10_000 });
+    await defaultTab.click({ button: "right" });
+
+    // Click "Duplicate" in the context menu
+    const duplicateItem = page.locator('[data-slot="context-menu-item"]', {
+      hasText: "Duplicate",
+    });
+    await expect(duplicateItem).toBeVisible({ timeout: 5_000 });
+    await duplicateItem.click();
+    await page.waitForTimeout(2_000);
+
+    // A new tab should appear (the duplicate). The exact name depends on
+    // the implementation but there should now be more than one tab.
+    const viewTabs = page.locator(
+      '[data-slot="context-menu-trigger"] button',
+    );
+    await expect(viewTabs).toHaveCount(2, { timeout: 5_000 });
+  });
+
+  test("context menu delete is disabled when only one view exists", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+    await addRow(page);
+
+    // Right-click the only view tab
+    const defaultTab = page.locator("button", { hasText: "Default view" });
+    await expect(defaultTab).toBeVisible({ timeout: 10_000 });
+    await defaultTab.click({ button: "right" });
+
+    // The "Delete view" item should be visible but disabled
+    const deleteItem = page.locator('[data-slot="context-menu-item"]', {
+      hasText: "Delete view",
+    });
+    await expect(deleteItem).toBeVisible({ timeout: 5_000 });
+    await expect(deleteItem).toHaveAttribute("data-disabled", "");
+  });
+});

--- a/src/components/database/view-tabs.tsx
+++ b/src/components/database/view-tabs.tsx
@@ -358,7 +358,7 @@ export function ViewTabs({
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                   <ContextMenuItem
-                    onSelect={() =>
+                    onClick={() =>
                       handleContextMenuAction(view.id, "rename")
                     }
                   >
@@ -366,7 +366,7 @@ export function ViewTabs({
                     <span>Rename</span>
                   </ContextMenuItem>
                   <ContextMenuItem
-                    onSelect={() =>
+                    onClick={() =>
                       handleContextMenuAction(view.id, "duplicate")
                     }
                   >
@@ -385,7 +385,7 @@ export function ViewTabs({
                   ) : (
                     <ContextMenuItem
                       variant="destructive"
-                      onSelect={() =>
+                      onClick={() =>
                         handleContextMenuAction(view.id, "delete")
                       }
                     >


### PR DESCRIPTION
Closes #623

## What

Right-clicking a database view tab and selecting "Delete", "Rename", or "Duplicate" from the context menu had no effect. The context menu appeared but all actions silently failed. Double-click rename still worked because it uses a separate `onDoubleClick` handler.

## How

The `ContextMenuItem` components in `view-tabs.tsx` used `onSelect` callbacks — a Radix UI convention. This project uses shadcn/ui v4 with the `base-nova` style, which wraps `@base-ui/react` primitives instead of Radix. Base UI's `MenuItem` uses `onClick`, not `onSelect`. The `onSelect` prop was silently passed through to the DOM and ignored.

Replaced `onSelect` with `onClick` on all three `ContextMenuItem` elements (rename, duplicate, delete). Also added a convention to `.agents/conventions.md` documenting this Base UI difference to prevent recurrence.

## Testing

- Added 4 E2E tests in `e2e/database-views.spec.ts` covering:
  - Context menu "Rename" enters inline edit mode
  - Context menu "Delete" opens confirmation dialog and removes the view
  - Context menu "Duplicate" creates a copy of the view
  - Context menu "Delete" is disabled when only one view exists (last-view protection)
- `pnpm lint && pnpm typecheck && pnpm test` all pass
- All 4 new E2E tests pass; pre-existing sort/filter E2E flakes are unrelated (reproduced on main)