### PR TITLE
fix(database): left-align add-column button, remove toolbar bg-muted

### DIFF
--- a/.agents/design.md
+++ b/.agents/design.md
@@ -341,7 +341,7 @@ Database views render structured data within the existing page layout. When a pa
 ### Filter & Sort Bar
 
 - Position: between view tabs and the database grid.
-- Background: `bg-muted p-2`, sharp corners.
+- Background: transparent (no `bg-muted`), `p-2`, sharp corners.
 - Active filters: `Badge` components with property name, operator, value. `variant="secondary"`, `text-xs`.
 - Remove filter: `X` icon (12px) on each badge, hover `text-destructive`.
 - `+ Add filter` button: `ghost` variant, `text-xs text-muted-foreground`.

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -949,7 +949,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
 
             {/* Sort & filter toolbar */}
             {activeView && (
-              <div className="flex items-center gap-1 bg-muted p-2">
+              <div className="flex items-center gap-1 p-2">
                 <SortMenu
                   properties={properties}
                   sorts={activeSorts}

--- a/src/components/database/filter-sort-toolbar-design-spec.test.ts
+++ b/src/components/database/filter-sort-toolbar-design-spec.test.ts
@@ -3,10 +3,10 @@ import { readFileSync } from "fs";
 import { resolve } from "path";
 
 /**
- * Regression test for issue #524: filter/sort toolbar design spec compliance.
+ * Regression test for filter/sort toolbar design spec compliance.
  *
  * The design spec (.agents/design.md → Filter & Sort Bar) requires:
- * - Background: bg-muted p-2, sharp corners.
+ * - Background: transparent (no bg-muted), p-2, sharp corners.
  */
 
 function readSource(): string {
@@ -19,18 +19,17 @@ function readSource(): string {
 describe("filter/sort toolbar design spec compliance", () => {
   const source = readSource();
 
-  it("toolbar container has bg-muted background", () => {
-    // Design spec: "Background: bg-muted p-2, sharp corners."
-    // The sort/filter toolbar div must include bg-muted.
+  it("toolbar container does not have bg-muted background", () => {
+    // Design spec: toolbar uses transparent background (same as page).
     const toolbarMatch = source.match(
       /Sort & filter toolbar[\s\S]*?<div className="([^"]*)"/,
     );
     expect(toolbarMatch).not.toBeNull();
-    expect(toolbarMatch![1]).toContain("bg-muted");
+    expect(toolbarMatch![1]).not.toContain("bg-muted");
   });
 
   it("toolbar container has p-2 padding", () => {
-    // Design spec: "Background: bg-muted p-2, sharp corners."
+    // Design spec: "p-2, sharp corners."
     const toolbarMatch = source.match(
       /Sort & filter toolbar[\s\S]*?<div className="([^"]*)"/,
     );

--- a/src/components/database/property-type-picker.tsx
+++ b/src/components/database/property-type-picker.tsx
@@ -26,7 +26,7 @@ export function PropertyTypePicker({ onSelect }: PropertyTypePickerProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        className="flex h-full w-full items-center justify-center text-muted-foreground hover:text-foreground"
+        className="flex h-full items-center text-muted-foreground hover:text-foreground"
         aria-label="Add column"
       >
         <Plus className="h-3.5 w-3.5" />

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -592,7 +592,7 @@ export function TableView({
         })}
 
         {/* Add column header button */}
-        <div className="sticky top-0 z-10 flex items-center justify-start border-b border-white/[0.06] bg-background pl-2">
+        <div className="sticky top-0 z-10 flex items-center border-b border-white/[0.06] bg-background px-2">
           {onAddColumn && (
             <PropertyTypePicker onSelect={onAddColumn} />
           )}


### PR DESCRIPTION
## Changes

**Add-column `+` button** — The `PropertyTypePicker` trigger had `w-full justify-center`, which caused the `+` icon to center across the full `1fr` trailing column. Removed those classes so the icon sits left-aligned.

**Filter/sort toolbar** — Removed `bg-muted` from the toolbar wrapper in `database-view-client.tsx` to match Notion's transparent toolbar style. Updated the design spec and the corresponding regression test.

## Files changed

- `src/components/database/property-type-picker.tsx` — trigger alignment
- `src/components/database/views/table-view.tsx` — header cell cleanup (`px-2`)
- `src/components/database/database-view-client.tsx` — removed `bg-muted`
- `.agents/design.md` — updated toolbar spec
- `src/components/database/filter-sort-toolbar-design-spec.test.ts` — updated assertion