### PR TITLE
fix(metrics): correct issue counts and add SQL to LOC breakdown

### DIFF
--- a/.ona/automations/daily-metrics.yaml
+++ b/.ona/automations/daily-metrics.yaml
@@ -24,7 +24,7 @@ action:
                 {
                   "date": "YYYY-MM-DD",
                   "day_number": N,
-                  "loc": { "total": N, "delta": N, "by_language": { "TypeScript": N, "CSS": N } },
+                  "loc": { "total": N, "delta": N, "by_language": { "TypeScript": N, "SQL": N, "CSS": N } },
                   "files": { "total": N, "delta": N },
                   "prs": { "total": N, "delta": N, "currently_open": N },
                   "commits": { "total": N, "delta": N },
@@ -113,10 +113,10 @@ action:
 
                 **GitHub Issues:**
                 ```
-                gh issue list --label "status:backlog" --state open --json number --jq 'length'
-                gh issue list --label "status:in-progress" --state open --json number --jq 'length'
-                gh issue list --label "status:in-review" --state open --json number --jq 'length'
-                gh issue list --label "status:done" --state closed --json number --jq 'length'
+                gh issue list --label "status:backlog" --state open --limit 500 --json number --jq 'length'
+                gh issue list --label "status:in-progress" --state open --limit 500 --json number --jq 'length'
+                gh issue list --label "status:in-review" --state open --limit 500 --json number --jq 'length'
+                gh issue list --label "status:done" --state closed --limit 500 --json number --jq 'length'
                 ```
 
                 **Delta fields (loc, files):**
@@ -132,7 +132,9 @@ action:
                 3. Confirm `commits.total >= commits.delta`.
                 4. Confirm `prs.total` is >= yesterday's `prs.total` (cumulative never decreases).
                 5. Confirm `commits.total` is >= yesterday's `commits.total`.
-                6. If any check fails, re-collect the data for that field.
+                6. Confirm `issues.done` is >= yesterday's `issues.done` (closed issues never decrease).
+                7. Confirm `by_language` values sum to `loc.total`. If they don't, a language is missing from the extraction.
+                8. If any check fails, re-collect the data for that field.
 
                 ## 4. Commit and PR
 


### PR DESCRIPTION
## Problem

The Daily Metrics automation had three bugs producing inaccurate snapshots:

1. **`issues.done` capped at 30** — The four `gh issue list` commands lacked `--limit 500`. The `gh` CLI defaults to 30 results, so `issues.done` has reported 30 since ~Apr 17 when the actual count exceeded that threshold (currently 258).

2. **SQL missing from `by_language`** — `cloc` includes SQL from `supabase/migrations/` in `SUM.code` (used for `loc.total`), but the schema only extracted TypeScript and CSS. Starting Apr 22, this caused a ~1,324 line gap between `loc.total` and the sum of `by_language` values.

3. **No validation for regressions** — Nothing caught these issues because the validation step didn't check that `issues.done` is monotonically non-decreasing or that `by_language` sums to `loc.total`.

## Changes

- Add `--limit 500` to all four `gh issue list` commands
- Add `SQL` to the `by_language` schema
- Add two validation rules:
  - `issues.done` must be >= yesterday's value
  - `by_language` values must sum to `loc.total`

The live Ona automation (`019d8d98-3977-772e-b93a-8d94d0878a8f`) has already been updated.

Historical daily JSON files are **not** backfilled — they retain the incorrect values.