### PR TITLE
fix: add rounded-sm to filter bar dropdown menus (#635)

### DIFF
--- a/src/components/database/filter-bar.tsx
+++ b/src/components/database/filter-bar.tsx
@@ -273,7 +273,7 @@ function PropertyPicker({
   onSelect: (propertyId: string) => void;
 }) {
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background py-1 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background py-1 shadow-md">
       {properties.map((prop) => {
         const Icon = PROPERTY_TYPE_ICON[prop.type];
         return (
@@ -306,7 +306,7 @@ function OperatorPicker({
   const operators = getOperatorsForType(propertyType);
 
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-48 border border-border bg-background py-1 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-48 rounded-sm border border-border bg-background py-1 shadow-md">
       {operators.map((op) => (
         <button
           key={op}
@@ -410,7 +410,7 @@ function TextInputFilterValueEditor({
   placeholder: string;
 }) {
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background p-2 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background p-2 shadow-md">
       <Input
         autoFocus
         value={valueInput}
@@ -455,7 +455,7 @@ function SelectFilterValueEditor({
   );
 
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background shadow-md">
       <div className="p-1.5">
         <Input
           autoFocus
@@ -503,7 +503,7 @@ function DateFilterValueEditor({
   const [dateValue, setDateValue] = useState("");
 
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background p-2 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background p-2 shadow-md">
       <Input
         autoFocus
         type="date"


### PR DESCRIPTION
Closes #635

## What
The 5 floating dropdown containers in the filter bar (`PropertyPicker`, `OperatorPicker`, `TextInputFilterValueEditor`, `SelectFilterValueEditor`, `DateFilterValueEditor`) were missing `rounded-sm`, violating the design spec which requires all dropdown menus and popovers to use `rounded-sm`.

## How
Added `rounded-sm` to each of the 5 dropdown container `className` strings in `src/components/database/filter-bar.tsx`, matching the pattern used by all other floating dropdowns in the database components.

## Testing
- Verified all 5 containers now include `rounded-sm` via grep
- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — all 812 tests pass
- Confirmed no E2E tests use selectors affected by this change (filter E2E tests use `.z-50`, not `.rounded-sm`)
- Visual regression baselines unaffected (screenshots capture static filter chips, not open dropdowns)