### PR TITLE
fix: add rounded-sm to filter bar dropdown menus (#635)

### DIFF
--- a/src/components/database/filter-bar.tsx
+++ b/src/components/database/filter-bar.tsx
@@ -273,7 +273,7 @@ function PropertyPicker({
   onSelect: (propertyId: string) => void;
 }) {
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background py-1 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background py-1 shadow-md">
       {properties.map((prop) => {
         const Icon = PROPERTY_TYPE_ICON[prop.type];
         return (
@@ -306,7 +306,7 @@ function OperatorPicker({
   const operators = getOperatorsForType(propertyType);
 
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-48 border border-border bg-background py-1 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-48 rounded-sm border border-border bg-background py-1 shadow-md">
       {operators.map((op) => (
         <button
           key={op}
@@ -410,7 +410,7 @@ function TextInputFilterValueEditor({
   placeholder: string;
 }) {
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background p-2 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background p-2 shadow-md">
       <Input
         autoFocus
         value={valueInput}
@@ -455,7 +455,7 @@ function SelectFilterValueEditor({
   );
 
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background shadow-md">
       <div className="p-1.5">
         <Input
           autoFocus
@@ -503,7 +503,7 @@ function DateFilterValueEditor({
   const [dateValue, setDateValue] = useState("");
 
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 border border-border bg-background p-2 shadow-md">
+    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background p-2 shadow-md">
       <Input
         autoFocus
         type="date"


### PR DESCRIPTION
Closes #635

## What
PR #633 added type-specific filter value editors to the filter bar, but all 5 floating dropdown containers were missing `rounded-sm`. The design spec requires `rounded-sm` on dropdown menus and popovers.

## How
Added `rounded-sm` to the className of all 5 dropdown containers in `filter-bar.tsx`: PropertyPicker, OperatorPicker, TextInputFilterValueEditor, SelectFilterValueEditor, and DateFilterValueEditor. This matches the pattern used by all other floating dropdowns in the database components (select-dropdown, person, relation, date, calendar-view).

## Testing
- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 812 tests pass (74 files)
- Visual regression baselines unaffected (stories render the closed filter bar state; dropdowns only appear on interaction)
- No E2E tests reference these internal dropdown components directly