### PR TITLE
fix: sort ignores type-specific value keys and color picker test missing step (#640)

### DIFF
--- a/e2e/database-select-options.spec.ts
+++ b/e2e/database-select-options.spec.ts
@@ -464,6 +464,11 @@ test.describe("Select/Multi-select option persistence", () => {
     const reloadedDropdown = page.locator('input[placeholder="Search or create…"]');
     await expect(reloadedDropdown).toBeVisible({ timeout: 5_000 });
 
+    // Click the color dot to open the color picker panel
+    const reloadedColorDot = page.locator('button[aria-label="Change color"]').first();
+    await expect(reloadedColorDot).toBeVisible({ timeout: 3_000 });
+    await reloadedColorDot.click();
+
     // The red color button should have the active indicator (ring)
     const activeRedBtn = page.locator('button[aria-label="Color: red"]');
     await expect(activeRedBtn).toBeVisible({ timeout: 3_000 });

--- a/src/lib/database-filters.test.ts
+++ b/src/lib/database-filters.test.ts
@@ -236,6 +236,42 @@ describe("sortRows", () => {
     sortRows(rows, sorts, allProps);
     expect(rows.map((r) => r.page.id)).toEqual(original.map((r) => r.page.id));
   });
+
+  it("sorts text stored with type-specific key (not legacy value key)", () => {
+    const prop = makeProp("p-t2", "Label", "text");
+    const typedRows = [
+      makeRow("t1", "Row1", { "p-t2": { text: "Cherry" } }),
+      makeRow("t2", "Row2", { "p-t2": { text: "Apple" } }),
+      makeRow("t3", "Row3", { "p-t2": { text: "Banana" } }),
+    ];
+    const sorts: SortRule[] = [{ property_id: "p-t2", direction: "asc" }];
+    const result = sortRows(typedRows, sorts, [prop]);
+    expect(result.map((r) => r.page.id)).toEqual(["t2", "t3", "t1"]);
+  });
+
+  it("sorts numbers stored with type-specific key", () => {
+    const prop = makeProp("p-n2", "Score", "number");
+    const typedRows = [
+      makeRow("n1", "Row1", { "p-n2": { number: 30 } }),
+      makeRow("n2", "Row2", { "p-n2": { number: 10 } }),
+      makeRow("n3", "Row3", { "p-n2": { number: 20 } }),
+    ];
+    const sorts: SortRule[] = [{ property_id: "p-n2", direction: "asc" }];
+    const result = sortRows(typedRows, sorts, [prop]);
+    expect(result.map((r) => r.page.id)).toEqual(["n2", "n3", "n1"]);
+  });
+
+  it("null-sorts rows with type-specific keys correctly", () => {
+    const prop = makeProp("p-t3", "Name", "text");
+    const mixedRows = [
+      makeRow("m1", "Row1", { "p-t3": { text: "Zebra" } }),
+      makeRow("m2", "Row2", {}),
+      makeRow("m3", "Row3", { "p-t3": { text: "Aardvark" } }),
+    ];
+    const sorts: SortRule[] = [{ property_id: "p-t3", direction: "asc" }];
+    const result = sortRows(mixedRows, sorts, [prop]);
+    expect(result.map((r) => r.page.id)).toEqual(["m3", "m1", "m2"]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/database-filters.ts
+++ b/src/lib/database-filters.ts
@@ -356,12 +356,7 @@ function isValueNull(row: DatabaseRow, prop: DatabaseProperty): boolean {
     return getComputedValue(row, prop.type) === null;
   }
 
-  const rv = row.values[prop.id];
-  if (!rv) return true;
-  const inner = rv.value?.value;
-  if (inner === undefined || inner === null || inner === "") return true;
-  if (Array.isArray(inner) && inner.length === 0) return true;
-  return false;
+  return isEmpty(row.values[prop.id]);
 }
 
 /**


### PR DESCRIPTION
Closes #640

## What

Database sort was not reordering rows because `isValueNull` in `database-filters.ts` only checked the legacy `rv.value?.value` key. The UI stores values with type-specific keys (e.g., `{ text: "Cherry" }` instead of `{ value: "Cherry" }`), so all text/number/date values were treated as null — making sort treat every row as equal and preserving the original order.

Separately, the color picker E2E test was missing a step to click the color dot after page reload, so the color picker panel was never opened and the `button[aria-label="Color: red"]` assertion failed.

## How

- **Sort fix:** Replaced the inline null-check in `isValueNull` with the existing `isEmpty()` helper, which already checks all type-specific keys (`text`, `number`, `checked`, `date`, `url`, `email`, `phone`, `option_id`, `option_ids`, `value`).
- **Color picker test fix:** Added the missing click on `button[aria-label="Change color"]` after reload to open the color picker panel before asserting the red color button is visible.

## Testing

- Added 3 regression unit tests in `database-filters.test.ts` that use type-specific value keys (`{ text: "..." }`, `{ number: ... }`) to verify sort works correctly with the format the UI actually produces.
- All 815 unit tests pass (`pnpm test`).
- All 10 `database-views.spec.ts` E2E tests pass, including the two that were failing (sort and multi-view sort).
- All 6 `database-select-options.spec.ts` E2E tests pass, including the color picker test.
- `pnpm lint` and `pnpm typecheck` pass with no errors.