### PR TITLE
fix: replace hardcoded hover opacity with overlay-hover token (#642)

### DIFF
--- a/src/components/database/filter-bar.tsx
+++ b/src/components/database/filter-bar.tsx
@@ -474,7 +474,7 @@ function SelectFilterValueEditor({
             key={opt.id}
             type="button"
             onClick={() => onSelectValue(opt.id)}
-            className="flex w-full items-center gap-2 px-2 py-1 text-sm hover:bg-white/[0.04]"
+            className="flex w-full items-center gap-2 px-2 py-1 text-sm hover:bg-overlay-hover"
           >
             <SelectOptionBadge name={opt.name} color={opt.color} />
           </button>


### PR DESCRIPTION
Closes #642

## What

The filter value selector button in `filter-bar.tsx` used a hardcoded `hover:bg-white/[0.04]` class for its hover state. This was missed during PR #639 which replaced 248 hardcoded opacity values across 85+ files with semantic overlay/label tokens. The hardcoded value only works in dark mode, violating the design spec requirement to use semantic tokens.

## How

Replaced `hover:bg-white/[0.04]` with `hover:bg-overlay-hover` on line 477 of `src/components/database/filter-bar.tsx`. The `overlay-hover` token resolves to `white 4%` in dark mode and `black 4%` in light mode, matching the design spec.

## Testing

- Verified this was the only remaining hardcoded `bg-white/[` or `bg-black/[` instance in `src/` via grep
- All 812 Vitest tests pass
- Lint and typecheck pass with no new errors
- No E2E tests reference this component