### PR TITLE
fix: database filter date picker uses custom DatePicker component (#645)

### DIFF
--- a/e2e/database-filter-types.spec.ts
+++ b/e2e/database-filter-types.spec.ts
@@ -224,14 +224,23 @@ test.describe("Type-specific database filter operators", () => {
     // Pick "before" operator
     await operatorDropdown.locator("button", { hasText: "before" }).click();
 
-    // Value input should be a date input
-    const dateInput = page.locator('input[type="date"]');
-    await expect(dateInput).toBeVisible({ timeout: 5_000 });
+    // Custom DatePicker calendar should appear (not a native date input)
+    const calendarPicker = page.locator(".z-50").first();
+    await expect(calendarPicker).toBeVisible({ timeout: 5_000 });
 
-    // Fill and apply
-    await dateInput.fill("2026-06-01");
-    const applyBtn = page.locator(".z-50 button", { hasText: "Apply" });
-    await applyBtn.click();
+    // Should show month navigation and a "Today" button
+    const prevMonthBtn = calendarPicker.getByRole("button", { name: "Previous month" });
+    const nextMonthBtn = calendarPicker.getByRole("button", { name: "Next month" });
+    const todayBtn = calendarPicker.locator("button", { hasText: "Today" });
+    await expect(prevMonthBtn).toBeVisible({ timeout: 5_000 });
+    await expect(nextMonthBtn).toBeVisible({ timeout: 5_000 });
+    await expect(todayBtn).toBeVisible({ timeout: 5_000 });
+
+    // Native date input should NOT be present
+    await expect(page.locator('input[type="date"]')).toBeHidden();
+
+    // Click "Today" to select today's date and apply the filter
+    await todayBtn.click();
 
     // Filter badge should appear
     const badge = page.locator('[data-slot="badge"]', { hasText: "before" });

--- a/src/components/database/filter-bar.tsx
+++ b/src/components/database/filter-bar.tsx
@@ -16,6 +16,7 @@ import {
   type FilterOperator,
   type FilterRule,
 } from "@/lib/database-filters";
+import { DatePicker } from "./property-types/date";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -490,7 +491,7 @@ function SelectFilterValueEditor({
 }
 
 // ---------------------------------------------------------------------------
-// DateFilterValueEditor — native date input
+// DateFilterValueEditor — custom DatePicker calendar
 // ---------------------------------------------------------------------------
 
 function DateFilterValueEditor({
@@ -500,30 +501,13 @@ function DateFilterValueEditor({
   onSelectValue: (value: unknown) => void;
   onClose: () => void;
 }) {
-  const [dateValue, setDateValue] = useState("");
-
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background p-2 shadow-md">
-      <Input
-        autoFocus
-        type="date"
-        value={dateValue}
-        onChange={(e) => setDateValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && dateValue) onSelectValue(dateValue);
-          if (e.key === "Escape") onClose();
-        }}
-        className="h-7 text-xs"
+    <div className="absolute left-0 top-full z-50 mt-1">
+      <DatePicker
+        selectedDate={null}
+        onSelect={(iso) => onSelectValue(iso)}
+        onClose={onClose}
       />
-      <Button
-        size="sm"
-        className="mt-1.5 h-6 w-full text-xs"
-        onClick={() => {
-          if (dateValue) onSelectValue(dateValue);
-        }}
-      >
-        Apply
-      </Button>
     </div>
   );
 }

--- a/src/components/database/property-types/date.tsx
+++ b/src/components/database/property-types/date.tsx
@@ -91,7 +91,7 @@ export function DateRenderer({ value }: RendererProps) {
 // Date Picker
 // ---------------------------------------------------------------------------
 
-function DatePicker({
+export function DatePicker({
   selectedDate,
   onSelect,
   onClose,


### PR DESCRIPTION
Closes #645

## What
The date picker in the database filter bar used a native HTML `<input type="date">` instead of the custom `DatePicker` calendar component used for inline table cell editing. This created a visual inconsistency — the filter date input looked like a browser default control while the table cell date picker matched the app's design system.

## How
Exported the existing `DatePicker` component from `src/components/database/property-types/date.tsx` and replaced the native date input in `DateFilterValueEditor` (`filter-bar.tsx`) with it. The custom picker handles date selection and close via its existing `onSelect`/`onClose` callbacks, removing the need for the separate "Apply" button and local state.

## Testing
Updated the E2E test in `e2e/database-filter-types.spec.ts` to verify the custom calendar picker appears (with month navigation and "Today" button) instead of a native date input. The test clicks "Today" to apply the filter and confirms the filter badge appears. All 4 filter-type E2E tests pass. Lint, typecheck, and 815 unit tests pass.