### PR TITLE
fix: use custom DatePicker in filter bar instead of native date input (#645)

### DIFF
--- a/e2e/database-filter-types.spec.ts
+++ b/e2e/database-filter-types.spec.ts
@@ -224,14 +224,15 @@ test.describe("Type-specific database filter operators", () => {
     // Pick "before" operator
     await operatorDropdown.locator("button", { hasText: "before" }).click();
 
-    // Value input should be a date input
-    const dateInput = page.locator('input[type="date"]');
-    await expect(dateInput).toBeVisible({ timeout: 5_000 });
+    // Custom DatePicker calendar should appear (not a native date input)
+    const datePicker = page.locator('[data-testid="filter-date-picker"]');
+    await expect(datePicker).toBeVisible({ timeout: 5_000 });
 
-    // Fill and apply
-    await dateInput.fill("2026-06-01");
-    const applyBtn = page.locator(".z-50 button", { hasText: "Apply" });
-    await applyBtn.click();
+    // The calendar should show month/year header and day buttons
+    await expect(datePicker.locator("button", { hasText: "Today" })).toBeVisible({ timeout: 5_000 });
+
+    // Click "Today" to select today's date and apply the filter
+    await datePicker.locator("button", { hasText: "Today" }).click();
 
     // Filter badge should appear
     const badge = page.locator('[data-slot="badge"]', { hasText: "before" });

--- a/src/components/database/filter-bar.tsx
+++ b/src/components/database/filter-bar.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { PROPERTY_TYPE_ICON } from "@/lib/property-icons";
 import type { DatabaseProperty, SelectOption } from "@/lib/types";
 import { SelectOptionBadge } from "./property-types/select-option-badge";
+import { DatePicker } from "./property-types/date";
 import {
   getOperatorsForType,
   getOperatorLabel,
@@ -490,7 +491,7 @@ function SelectFilterValueEditor({
 }
 
 // ---------------------------------------------------------------------------
-// DateFilterValueEditor — native date input
+// DateFilterValueEditor — custom DatePicker matching table cell editor
 // ---------------------------------------------------------------------------
 
 function DateFilterValueEditor({
@@ -500,30 +501,13 @@ function DateFilterValueEditor({
   onSelectValue: (value: unknown) => void;
   onClose: () => void;
 }) {
-  const [dateValue, setDateValue] = useState("");
-
   return (
-    <div className="absolute left-0 top-full z-50 mt-1 w-56 rounded-sm border border-border bg-background p-2 shadow-md">
-      <Input
-        autoFocus
-        type="date"
-        value={dateValue}
-        onChange={(e) => setDateValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && dateValue) onSelectValue(dateValue);
-          if (e.key === "Escape") onClose();
-        }}
-        className="h-7 text-xs"
+    <div className="absolute left-0 top-full z-50 mt-1" data-testid="filter-date-picker">
+      <DatePicker
+        selectedDate={null}
+        onSelect={(iso) => onSelectValue(iso)}
+        onClose={onClose}
       />
-      <Button
-        size="sm"
-        className="mt-1.5 h-6 w-full text-xs"
-        onClick={() => {
-          if (dateValue) onSelectValue(dateValue);
-        }}
-      >
-        Apply
-      </Button>
     </div>
   );
 }

--- a/src/components/database/property-types/date.tsx
+++ b/src/components/database/property-types/date.tsx
@@ -91,7 +91,7 @@ export function DateRenderer({ value }: RendererProps) {
 // Date Picker
 // ---------------------------------------------------------------------------
 
-function DatePicker({
+export function DatePicker({
   selectedDate,
   onSelect,
   onClose,


### PR DESCRIPTION
Closes #645

## What

The database filter bar used a native HTML `<input type="date">` for date filters (`DateFilterValueEditor`), while the table cell date editor used a custom `DatePicker` component with a styled calendar grid. This created a visual inconsistency — the filter date input looked like a browser default control while the rest of the UI used the app's design system.

## How

Exported the existing `DatePicker` component from `src/components/database/property-types/date.tsx` (previously a private function) and replaced the native `<input type="date">` in `DateFilterValueEditor` with it. The filter now renders the same styled calendar picker used for inline table cell editing. A `data-testid="filter-date-picker"` attribute was added to the wrapper for E2E test targeting.

## Testing

- Updated the E2E test in `e2e/database-filter-types.spec.ts` to interact with the custom DatePicker calendar (clicking "Today" button) instead of filling a native date input
- `pnpm lint` — no new errors
- `pnpm typecheck` — passes
- `pnpm test` — all 815 unit tests pass
- E2E tests cannot run in this environment due to a pre-existing issue (`NEXT_PUBLIC_SUPABASE_ANON_KEY` is empty, causing `/sign-in` to 404 for all authenticated tests)