### PR TITLE
fix: add error boundaries for settings routes (#648)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/settings/error.test.ts
+++ b/src/app/(app)/[workspaceSlug]/settings/error.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("settings route error boundary", () => {
+  it("error.tsx exists for the settings route segment", () => {
+    expect(existsSync(resolve(DIR, "error.tsx"))).toBe(true);
+  });
+
+  it("is a client component (required by Next.js error boundaries)", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toMatch(/^"use client"/);
+  });
+
+  it("uses the shared RouteError component", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("RouteError");
+  });
+
+  it("passes error and reset props through", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("error={error}");
+    expect(source).toContain("reset={reset}");
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/settings/error.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/route-error";
+
+export default function SettingsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <RouteError error={error} reset={reset} />;
+}

--- a/src/app/(app)/[workspaceSlug]/settings/members/error.test.ts
+++ b/src/app/(app)/[workspaceSlug]/settings/members/error.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("settings/members route error boundary", () => {
+  it("error.tsx exists for the members route segment", () => {
+    expect(existsSync(resolve(DIR, "error.tsx"))).toBe(true);
+  });
+
+  it("is a client component (required by Next.js error boundaries)", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toMatch(/^"use client"/);
+  });
+
+  it("uses the shared RouteError component", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("RouteError");
+  });
+
+  it("passes error and reset props through", () => {
+    const source = readFileSync(resolve(DIR, "error.tsx"), "utf-8");
+    expect(source).toContain("error={error}");
+    expect(source).toContain("reset={reset}");
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/settings/members/error.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/route-error";
+
+export default function MembersError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <RouteError error={error} reset={reset} />;
+}


### PR DESCRIPTION
Closes #648

## What

React throws "Rendered more hooks than during the previous render" when navigating to the `/:workspaceSlug/settings/members` page via client-side RSC navigation. The error crashes the page render with no recovery path — the settings and settings/members route segments had no `error.tsx` error boundaries, so the error propagated up to the workspace-level boundary and wiped the entire page content.

Investigation confirmed all hooks in the members components (`MembersPage`, `MemberList`, `InviteForm`, `PendingInviteList`, `RoleSelect`) and sidebar components (`PageTree`, `FavoritesSection`, `AppSidebar`) are unconditionally called at the top level. The single occurrence (Chrome Mobile 148, Android 10, Thai locale) with an entirely minified React-internals stack trace points to a transient React/Next.js RSC hydration race condition during client-side navigation, likely involving the `dynamic()` import boundary in `app-shell.tsx`.

## How

Added `error.tsx` error boundaries at both the `settings` and `settings/members` route segments, following the existing pattern used by `[workspaceSlug]/error.tsx` and `[pageId]/error.tsx`. Both delegate to the shared `RouteError` component which reports to Sentry and shows a recoverable "Try again" UI. This ensures that if the transient React hooks error recurs, it is caught at the narrowest possible scope and the user can recover without losing the rest of the page.

## Testing

- Added `error.test.ts` for both route segments verifying: file existence, `"use client"` directive, `RouteError` usage, and prop forwarding — matching the existing test pattern for `[workspaceSlug]/error.test.ts` and `[pageId]/error.test.ts`.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (823 tests, 0 failures).
- No existing E2E tests are affected — the fix adds new files only and changes no selectors, text, or interaction flows.