### PR TITLE
chore(automations): implement W17 audit recommendations

### DIFF
--- a/.ona/automations/bug-fixer.yaml
+++ b/.ona/automations/bug-fixer.yaml
@@ -84,6 +84,21 @@ action:
                 2. Add label `needs-human`: `gh issue edit <N> --add-label "needs-human"`
                 3. Stop — do not attempt a code fix.
 
+                ## Recurring Bug Detection
+
+                Before starting a fix, check if this bug has been seen before:
+                  gh issue list --state closed --search "<key terms from issue title>" --json number,title --jq '.[0:5]'
+
+                If similar closed issues exist (same component, same symptom):
+                1. Read the closed issues and their linked PRs to understand what was already tried.
+                2. The previous fix likely addressed a symptom, not the root cause.
+                3. Trace the FULL async data flow from trigger to render before writing any code:
+                   - Identify every state mutation in the chain
+                   - Identify every async boundary (await, useEffect, callback)
+                   - Identify race conditions between concurrent operations
+                4. The fix must address the root cause. If you cannot identify it, escalate
+                   with `needs-human` rather than patching another symptom.
+
                 ## Fix (code bugs only)
 
                 1. Pull the latest main branch: `git checkout main && git pull origin main`

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -180,8 +180,11 @@ action:
                 After implementation, before committing, check if the knowledge base needs updating.
                 Include these changes in the same commit.
 
-                - **`.agents/architecture.md`** — update if you added a new database table, API route,
-                  major component, or changed entity relationships.
+                - **`.agents/architecture.md`** — update the Component Map if you added, renamed, or
+                  removed any file in `src/components/`, `src/lib/`, `src/app/api/`, or
+                  `supabase/migrations/`. Also update if you changed entity relationships in the
+                  data model. Run `ls src/components/ src/lib/` and compare against the Component
+                  Map — if any file is missing from the map, add it.
                 - **`.agents/conventions.md`** — update if you established a new coding pattern,
                   created a reusable utility/hook/component pattern, or discovered a non-obvious
                   integration pattern that future features should follow.

--- a/.ona/automations/pr-reviewer.yaml
+++ b/.ona/automations/pr-reviewer.yaml
@@ -196,8 +196,8 @@ action:
                 2. Merge:
                    gh pr merge <number> --squash --delete-branch
 
-                3. Update the linked issue:
-                   gh issue edit N --remove-label "status:in-review" --add-label "status:done"
+                3. Update the linked issue (remove all prior status labels to avoid dual-label issues):
+                   gh issue edit N --remove-label "status:backlog" --remove-label "status:in-progress" --remove-label "status:in-review" --add-label "status:done"
 
                 ---
 


### PR DESCRIPTION
Implements 3 actionable recommendations from the Week 17 automation auditor runs (`2026-W17-audit.md` and `2026-W17-audit-2026-04-23.md`).

## Changes

### PR Reviewer — fix dual status labels on issue close
The audit found 5 closed issues with both `status:in-review` and `status:done` (or `status:in-progress` and `status:done`). The merge command now removes all `status:*` labels before adding `status:done`.

### Bug Fixer — recurring bug detection
The search empty state race condition recurred 8 times because each fix patched a symptom. Added a "Recurring Bug Detection" section that instructs the Bug Fixer to search for similar closed issues and trace the full async data flow before attempting a fix.

### Feature Builder — explicit architecture.md update rule
The component map in `architecture.md` drifted significantly because the update instruction was too vague. Now explicitly requires updating the Component Map when adding files to `src/components/`, `src/lib/`, `src/app/api/`, or `supabase/migrations/`.

## Skipped recommendations
- **E2E pre-submit enforcement** — recently added to the Feature Builder prompt, monitoring before further changes
- **Database area stabilization** — informational, audit said "no action needed"
- **Closed-PR ratio** — informational, healthy at 2.7%

## Registration
All 3 automation YAML changes have been registered with live Ona automations.