### PR TITLE
fix: align drag handle with first line of block text (#654)

### DIFF
--- a/e2e/editor-drag.spec.ts
+++ b/e2e/editor-drag.spec.ts
@@ -125,4 +125,39 @@ test.describe("Editor drag-and-drop", () => {
       expect(Math.abs(handleBox.y - blockBox.y)).toBeLessThan(20);
     }
   });
+
+  test("drag handle bottom aligns with first line bottom for paragraph blocks", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToEditorPage(page);
+
+    const editor = page.locator('[contenteditable="true"]');
+    await expect(editor).toBeVisible({ timeout: 10_000 });
+
+    const uid = Date.now().toString();
+    const marker = `AlignTest ${uid}`;
+    await moveToParagraphBlock(page, editor);
+    await page.keyboard.type(marker);
+
+    const block = editor.locator("p").filter({ hasText: marker });
+    await expect(block).toBeVisible({ timeout: 3_000 });
+    await block.hover();
+
+    const dragHandle = page.locator(".memo-draggable-block-menu");
+    await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
+
+    const handleBox = await dragHandle.boundingBox();
+    const blockBox = await block.boundingBox();
+    if (!handleBox || !blockBox) {
+      test.skip(true, "Could not get bounding boxes");
+      return;
+    }
+
+    // For a single-line paragraph (text-sm, line-height 20px), the handle
+    // (h-5 = 20px) should start at the block top so its bottom aligns with
+    // the first line bottom. Allow 4px tolerance for sub-pixel rendering.
+    const handleBottom = handleBox.y + handleBox.height;
+    const blockFirstLineBottom = blockBox.y + 20; // text-sm line-height
+    expect(Math.abs(handleBottom - blockFirstLineBottom)).toBeLessThan(4);
+  });
 });

--- a/src/components/editor/draggable-block-plugin.tsx
+++ b/src/components/editor/draggable-block-plugin.tsx
@@ -20,6 +20,8 @@ const DROP_INDICATOR_CLASSNAME = "memo-drop-indicator";
 const HANDLE_LEFT_OFFSET = 0;
 // Vertical dead zone — mouse must be within this distance of a block to show handle
 const HANDLE_DEAD_ZONE = 16;
+// Height of the drag handle icon (h-5 = 20px)
+const HANDLE_HEIGHT = 20;
 
 function getTopLevelBlockElements(
   anchorElem: HTMLElement
@@ -123,7 +125,18 @@ function setMenuPosition(
   const targetRect = targetElem.getBoundingClientRect();
   const anchorRect = anchorElem.getBoundingClientRect();
 
-  menuRef.style.top = `${targetRect.top - anchorRect.top + targetRect.height / 2 - 12}px`;
+  // Align the handle with the first line of text in the block.
+  // For blocks with padding (code, callout), offset by paddingTop so the
+  // handle aligns with the text, not the block border.
+  const style = getComputedStyle(targetElem);
+  const paddingTop = parseFloat(style.paddingTop) || 0;
+  const lineHeight = parseFloat(style.lineHeight) || HANDLE_HEIGHT;
+
+  // Position so the handle's bottom edge meets the first line's bottom edge
+  const firstLineTop = targetRect.top - anchorRect.top + paddingTop;
+  const offset = Math.max(0, lineHeight - HANDLE_HEIGHT);
+
+  menuRef.style.top = `${firstLineTop + offset}px`;
   menuRef.style.left = `${HANDLE_LEFT_OFFSET}px`;
   menuRef.style.opacity = "1";
 }


### PR DESCRIPTION
Closes #654

## What
The editor drag handle was positioned too high on the Y axis. The `setMenuPosition` function used `targetRect.height / 2 - 12` to center the handle on the block's vertical midpoint with a hardcoded magic number. For single-line paragraphs (height ≈ 20px), this placed the handle 2px above the block top. For multi-line blocks, it placed the handle at the block center instead of aligned with the first line.

## How
Replaced the block-center-based positioning with first-line-based positioning. The handle's top is now computed as `targetRect.top + paddingTop + offset`, where `paddingTop` accounts for blocks with padding (code blocks, callouts) and `offset = max(0, lineHeight - HANDLE_HEIGHT)` ensures the handle's bottom edge aligns with the bottom of the first line of text. This works correctly for all block types: paragraphs, headings (with larger line-heights), code blocks, blockquotes, and callouts.

## Testing
- Added E2E regression test `drag handle bottom aligns with first line bottom for paragraph blocks` that verifies the handle's bottom edge is within 4px of the first line's bottom edge
- All 4 editor-drag E2E tests pass
- All 6 editor-turn-into E2E tests pass (these also use the drag handle)
- `pnpm lint && pnpm typecheck && pnpm test` all pass