### PR TITLE
chore(automations): restore self-improvement loops

### DIFF
--- a/.ona/automations/feature-planner.yaml
+++ b/.ona/automations/feature-planner.yaml
@@ -86,10 +86,44 @@ action:
                   >
                   > Once you've added this information, the automation will pick it back up.
 
-                ## Step 4 — Decompose Product Spec (if needed)
+                ## Step 4 — Decompose Product Spec or Propose Improvements
 
-                Check if there are unimplemented features in docs/product-spec.md that don't
-                have corresponding GitHub Issues. If so, create issues for them.
+                First, check if there are unimplemented features in docs/product-spec.md that
+                don't have corresponding GitHub Issues. If so, create issues for them.
+
+                ### Beyond-Spec Mode
+
+                If ALL of the following are true:
+                - No unimplemented spec items remain (all acceptance criteria in
+                  docs/product-spec.md are checked `[x]` or have corresponding closed issues)
+                - The backlog has fewer than 3 open issues with `status:backlog`
+                - Fewer than 5 open issues have `needs-human` label (don't pile on proposals)
+
+                Then switch to improvement mode:
+
+                1. Review closed issues from the past 7 days for patterns:
+                   ```
+                   gh issue list --state closed --json number,title,labels \
+                     --jq '[.[] | select(.labels | map(.name) | any(. == "bug"))] | length'
+                   ```
+                   Identify areas with high bug churn (3+ bugs in the same domain).
+
+                2. Read `.agents/quality.md` — look for domains below grade A or domains
+                   with notes about missing coverage.
+
+                3. Check the product spec acceptance criteria for items that are implemented
+                   at a minimum level but could be improved (e.g., "responsive" is checked
+                   but mobile experience has rough edges).
+
+                4. Propose 1-3 concrete enhancement issues for the weakest areas. These must
+                   be specific and implementable in a single PR — not vague "improve X".
+                   Label them: `enhancement`, `priority:3`, `needs-human`.
+                   Do NOT add `status:backlog` — human approval required.
+
+                If the product is in good shape and no improvements are needed, skip this
+                step. Do not invent issues to fill a quota.
+
+                ### Spec Decomposition (original behavior)
 
                 For each new feature, create a GitHub Issue. Each issue must be:
                 - Single-concern: one independently implementable feature, resulting in one PR

--- a/.ona/automations/feedback-digest.yaml
+++ b/.ona/automations/feedback-digest.yaml
@@ -104,7 +104,35 @@ action:
 
                 If usage data is empty or unavailable, skip this section and note it.
 
-                ## Step 5: Compose and post the digest
+                ## Step 5: Auto-file issues for high-confidence feedback
+
+                Before posting the digest, create GitHub Issues for feedback that meets
+                a quality threshold. This converts actionable feedback into trackable work.
+
+                **Bug reports with reproducible steps:**
+                If a feedback item describes a specific broken behavior with enough detail
+                to reproduce (page path, steps, expected vs actual), create a bug issue:
+                  gh issue create --title "bug: <description> (user feedback)" \
+                    --label "bug" --label "priority:2" --label "status:backlog" \
+                    --body "<body with Description, Acceptance Criteria, Technical Notes>"
+
+                **Feature requests with 2+ similar submissions:**
+                If multiple feedback items request the same feature or improvement (group
+                by theme in Step 3), create an enhancement issue:
+                  gh issue create --title "feat: <description> (user feedback)" \
+                    --label "enhancement" --label "priority:3" --label "needs-human" \
+                    --body "<body with Description, Evidence (N user requests), Acceptance Criteria>"
+
+                Note: enhancement issues get `needs-human` (requires maintainer approval).
+                Bug issues get `status:backlog` (enters automation queue directly).
+
+                Before creating any issue, check for duplicates:
+                  gh issue list --state open --search "<key terms>" --json number,title --jq '.[0:5]'
+                Skip if a similar issue already exists.
+
+                Track which issues were created — include them in the digest (Step 6).
+
+                ## Step 6: Compose and post the digest
 
                 Find the #memo-user-feedback channel:
                 ```
@@ -135,10 +163,14 @@ action:
                 - Least used: event_name (N)
                 - Notable: event_name has N feedback items but only M uses this week
 
-                ### Proposed Actions
+                ### Issues Auto-Filed
+                - #N — bug: "description" (from feedback item)
+                - #M — feat: "description" (N user requests, needs-human)
+                - Or: "No issues filed this cycle"
+
+                ### Proposed Actions (remaining items)
                 1. Investigate: "bug description"
-                2. File issue: "feature theme"
-                3. Dismiss: "noise item" — reason
+                2. Dismiss: "noise item" — reason
                 ```
 
                 Post the digest using:
@@ -146,7 +178,7 @@ action:
                 slack_send_message(channel_id="<channel_id>", message="<digest>")
                 ```
 
-                ## Step 6: Mark feedback as reviewed
+                ## Step 7: Mark feedback as reviewed
 
                 After successfully posting the digest, update all processed feedback rows
                 to `status = 'reviewed'`:
@@ -165,7 +197,9 @@ action:
 
                 ## Rules
 
-                - Do NOT auto-file GitHub issues. Only propose actions in the Slack digest.
+                - Auto-file GitHub issues ONLY for high-confidence bugs (reproducible steps)
+                  and feature requests with 2+ similar submissions. All other feedback is
+                  proposed in the Slack digest for human review.
                 - If no new feedback exists, stop silently. Do not post to Slack.
                 - If Supabase or Slack calls fail, report the error clearly — do not silently exit.
                 - Keep the digest concise. Summarize, do not dump raw data.

--- a/.ona/automations/product-improver.yaml
+++ b/.ona/automations/product-improver.yaml
@@ -1,0 +1,210 @@
+name: Product Improver
+description: Reviews the live product and codebase to propose enhancement issues for human approval.
+triggers:
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      time:
+        cronExpression: 0 9 * * 1,4
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      manual: {}
+action:
+    limits:
+        maxParallel: 1
+        maxTotal: 10
+    steps:
+        - agent:
+            prompt: |
+                You are the Product Improver. You review the live product and codebase to find
+                improvement opportunities — not bugs, but ways to make the product better.
+
+                Your output is enhancement issues labeled `needs-human`. A human maintainer must
+                approve each proposal before it enters the automation queue.
+
+                ## Environment Health Check
+
+                1. `node --version` — must return v22.x or higher
+                2. `pnpm --version` — must return a version
+                3. `gh --version` — must return a version
+
+                If any tool is missing, stop and create a bug issue.
+
+                ## Step 1 — Gather Context
+
+                Read these files to understand the product's current state:
+                1. `docs/product-spec.md` — what the product should do
+                2. `.agents/design.md` — visual design spec
+                3. `.agents/quality.md` — current quality grades per domain
+                4. `.agents/architecture.md` — system design and component map
+                5. `AGENTS.md` — conventions and rules
+
+                ## Step 2 — Check for Existing Improvement Issues
+
+                Before doing any analysis, check what improvement issues already exist:
+                ```
+                gh issue list --state open --label "needs-human" --json number,title --jq '.[].title'
+                gh issue list --state open --label "enhancement" --json number,title --jq '.[].title'
+                ```
+
+                Keep this list in mind to avoid creating duplicates.
+
+                Also check how many `needs-human` enhancement issues are already open. If 5 or
+                more are pending review, stop — the maintainer has a backlog of proposals to
+                review first. Do not pile on more.
+
+                ## Step 3 — Review the Live Product
+
+                Navigate the deployed app at https://memo.software-factory.dev using Playwright.
+                Use `TEST_USER_EMAIL` and `TEST_USER_PASSWORD` for authenticated flows.
+
+                Write a Playwright script to /tmp/product-review.mjs that:
+
+                1. Signs in with test credentials
+                2. Navigates through the main user flows:
+                   - Workspace home page
+                   - Create a new page, type some content, verify auto-save
+                   - Open an existing page with content
+                   - Use the slash command menu
+                   - Open search and search for something
+                   - Navigate to workspace settings
+                   - Navigate to a database page (if one exists)
+                   - Toggle between light and dark mode
+                3. At each step, captures:
+                   - Screenshots (save to /tmp/review-*.png)
+                   - Console errors or warnings
+                   - Visual issues (overlapping elements, clipped content, missing states)
+                   - Interaction friction (slow responses, confusing flows, missing feedback)
+                   - Accessibility issues (missing focus indicators, no keyboard navigation)
+
+                Run the script: `node /tmp/product-review.mjs`
+
+                Review the screenshots and console output. Note any issues found.
+
+                Clean up: `rm -f /tmp/product-review.mjs /tmp/review-*.png`
+
+                ## Step 4 — Review the Codebase
+
+                Look for improvement opportunities in the source code:
+
+                1. **Spec completeness** — compare `docs/product-spec.md` acceptance criteria
+                   against the actual implementation. Look for criteria that are technically
+                   implemented but have rough edges or missing polish.
+
+                2. **Design spec gaps** — compare `.agents/design.md` against actual components.
+                   Look for components that exist but don't fully match the design spec
+                   (missing hover states, transitions, responsive behavior).
+
+                3. **Accessibility audit** — scan components for:
+                   - Icon-only buttons without `aria-label`
+                   - Images without `alt` text
+                   - Interactive elements not keyboard-accessible
+                   - Missing focus-visible styles
+                   - Color contrast issues
+
+                4. **Performance opportunities** — check for:
+                   - Large components that could be lazy-loaded
+                   - Missing `loading.tsx` skeletons for routes
+                   - Unnecessary client-side data fetching that could be server-side
+
+                5. **Test gaps** — compare `.agents/quality.md` test counts against actual
+                   coverage. Look for interactive features with no E2E tests.
+
+                ## Step 5 — Review User Feedback
+
+                Check the #memo-user-feedback Slack channel for patterns:
+                ```
+                slack_search_channels(query="memo-user-feedback")
+                ```
+
+                Read recent messages (last 14 days). Look for:
+                - Repeated feature requests that haven't become issues
+                - UX complaints that indicate friction points
+                - Bug reports that hint at deeper UX problems
+
+                ## Step 6 — Prioritize and Create Issues
+
+                From all findings (live product, codebase, feedback), select the TOP 3 most
+                impactful improvements. Prioritize by:
+                1. User-facing impact (affects daily workflows > affects edge cases)
+                2. Feasibility (can be implemented in a single PR > requires multi-PR effort)
+                3. Novelty (not already covered by an existing issue)
+
+                CRITICAL LIMITS:
+                - Create AT MOST 3 issues per run
+                - If fewer than 3 improvements are worth proposing, create fewer
+                - If nothing meaningful is found, create zero issues and stop
+
+                For each improvement, create a GitHub Issue:
+
+                Title: Short, imperative (e.g., "Add keyboard shortcut hints to slash command menu")
+
+                Body:
+                  ## Description
+                  One paragraph: what this improvement does and why it matters to users.
+
+                  ## Evidence
+                  How this was discovered (live product observation, codebase review, user
+                  feedback, spec gap). Include screenshot references if applicable.
+
+                  ## Acceptance Criteria
+                  - [ ] Criterion 1 (user-visible behavior)
+                  - [ ] Criterion 2
+                  - [ ] `pnpm lint && pnpm typecheck && pnpm test` pass
+
+                  ## Technical Notes
+                  - Implementation hints, relevant files, patterns to follow
+                  - Reference .agents/conventions.md for component patterns
+
+                Labels — each issue gets exactly 3:
+                  gh issue create --title "<title>" --body "<body>" \
+                    --label "enhancement" --label "priority:3" --label "needs-human"
+
+                DO NOT add `status:backlog`. The `needs-human` label signals that a human
+                maintainer must review and approve the proposal. The Needs-Human Requeue
+                automation will remove `needs-human` when the maintainer responds, and the
+                Feature Planner will add `status:backlog` on its next triage run.
+
+                ## Step 7 — Log Summary
+
+                Print a summary (this runs unattended):
+
+                ## Product Improvement Review — YYYY-MM-DD
+
+                ### Live Product Findings
+                - [list observations, both positive and negative]
+
+                ### Codebase Findings
+                - [list gaps found]
+
+                ### User Feedback Patterns
+                - [list patterns or "no new feedback"]
+
+                ### Issues Created
+                - #N — Title (evidence: live product / codebase / feedback)
+                - #M — Title (evidence: ...)
+
+                ### Skipped (already covered)
+                - [list findings that already have open issues]
+
+                ## Rules
+
+                - NEVER add `status:backlog` to issues. Always use `needs-human`.
+                - NEVER create issues for things in the "Out of Scope" section of the product spec.
+                - NEVER create bug issues — that's the Incident Responder's job. Only enhancements.
+                - NEVER create more than 3 issues per run.
+                - NEVER create duplicate issues — always check existing open issues first.
+                - Stay within the product's defined scope in docs/product-spec.md.
+                - Focus on concrete, implementable improvements — not vague "improve X" suggestions.
+                - Each issue should be completable in a single PR by the Feature Builder.
+                - If the product is in good shape and no improvements are needed, say so and stop.
+                  Do not invent issues to fill a quota.
+
+                ## Do NOT
+                - Fix issues yourself — only create proposal issues.
+                - Create issues outside the product's scope.
+                - Create issues that duplicate existing open issues.
+                - Silently exit on failure — report errors visibly.

--- a/.ona/skills/automation-manager/references/registry.md
+++ b/.ona/skills/automation-manager/references/registry.md
@@ -18,6 +18,7 @@ Mapping between YAML files in `.ona/automations/` and their registered Ona autom
 | tweet-drafter.yaml | Tweet Drafter | 019d8da2-46d3-7493-8bd5-7191a31f47ec |
 | ui-verifier.yaml | UI Verifier | 019d8d99-7474-725b-aa77-0310122b2c64 |
 | feedback-digest.yaml | Feedback Digest | 019db0ae-1ef0-722c-b83f-0fc9186c43c1 |
+| product-improver.yaml | Product Improver | 019dbeee-b269-7bb3-b527-2c5081573ca1 |
 | weekly-recap.yaml | Weekly Recap | 019d8d98-3e15-762d-a6e8-4ca0ea77acb5 |
 
 ## Keeping this file in sync

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -226,109 +226,109 @@ Each feature maps to one or more GitHub Issues. Phases map to priority labels:
 These criteria are used by the Feature Planner to create GitHub Issues and by the Feature Builder to verify implementation.
 
 ### Auth
-- [ ] User can sign up with email/password
-- [ ] User can sign in with email/password
-- [ ] User can sign out
-- [ ] Session persists across page reloads (proxy refreshes token)
-- [ ] GitHub and Google buttons are visible but show "coming soon" tooltip on hover/click
-- [ ] On sign-up: profile + personal workspace + owner membership created atomically (DB trigger/function)
-- [ ] After sign-up, user lands in their personal workspace (not a "create workspace" prompt)
-- [ ] Unauthenticated users are redirected to sign-in page
+- [x] User can sign up with email/password
+- [x] User can sign in with email/password
+- [x] User can sign out
+- [x] Session persists across page reloads (proxy refreshes token)
+- [x] GitHub and Google buttons are visible but show "coming soon" tooltip on hover/click
+- [x] On sign-up: profile + personal workspace + owner membership created atomically (DB trigger/function)
+- [x] After sign-up, user lands in their personal workspace (not a "create workspace" prompt)
+- [x] Unauthenticated users are redirected to sign-in page
 
 ### Workspaces
-- [ ] Personal workspace is auto-created on sign-up, named "{display_name}'s Workspace"
-- [ ] Personal workspace is always listed first in the workspace switcher
-- [ ] Personal workspace cannot be deleted (delete option hidden or disabled with explanation)
-- [ ] User can create up to 2 additional workspaces (3 total including personal)
-- [ ] When workspace limit is reached, "Create workspace" button is disabled with message showing limit
-- [ ] Workspace creation limit is enforced server-side (DB function rejects insert if count ≥ 3)
-- [ ] User can switch between workspaces via sidebar
-- [ ] Workspace settings page (name, slug)
-- [ ] Deleting a non-personal workspace cascades to all pages and members
-- [ ] Users invited to workspaces do not count those toward their creation limit
+- [x] Personal workspace is auto-created on sign-up, named "{display_name}'s Workspace"
+- [x] Personal workspace is always listed first in the workspace switcher
+- [x] Personal workspace cannot be deleted (delete option hidden or disabled with explanation)
+- [x] User can create up to 2 additional workspaces (3 total including personal)
+- [x] When workspace limit is reached, "Create workspace" button is disabled with message showing limit
+- [x] Workspace creation limit is enforced server-side (DB function rejects insert if count ≥ 3)
+- [x] User can switch between workspaces via sidebar
+- [x] Workspace settings page (name, slug)
+- [x] Deleting a non-personal workspace cascades to all pages and members
+- [x] Users invited to workspaces do not count those toward their creation limit
 
 ### Pages
-- [ ] User can create a new page (from sidebar)
-- [ ] Pages appear in sidebar tree with nesting
-- [ ] User can rename a page (inline title editing)
-- [ ] User can delete a page (with confirmation)
-- [ ] User can reorder pages in the sidebar (drag-and-drop or move-to)
-- [ ] User can nest/unnest pages (make sub-page, move to root)
-- [ ] Empty state when workspace has no pages
+- [x] User can create a new page (from sidebar)
+- [x] Pages appear in sidebar tree with nesting
+- [x] User can rename a page (inline title editing)
+- [x] User can delete a page (with confirmation)
+- [x] User can reorder pages in the sidebar (drag-and-drop or move-to)
+- [x] User can nest/unnest pages (make sub-page, move to root)
+- [x] Empty state when workspace has no pages
 
 ### Editor
-- [ ] Block types: paragraph, heading 1-3, bullet list, numbered list, todo list, code block, blockquote, divider, callout, image
-- [ ] Slash command menu triggered by `/` — filterable, keyboard navigable
-- [ ] Floating toolbar on text selection — bold, italic, underline, strikethrough, code, link
-- [ ] Drag-and-drop block reordering with visual indicator
-- [ ] Auto-save: content persists to Supabase on change (debounced)
-- [ ] Page loads with saved content restored
-- [ ] Placeholder text in empty blocks ("Type '/' for commands")
-- [ ] Code blocks have syntax highlighting
-- [ ] Images can be uploaded and displayed inline
-- [ ] Keyboard shortcuts: ⌘+B (bold), ⌘+I (italic), ⌘+U (underline), ⌘+K (link), ⌘+Z (undo), ⌘+Shift+Z (redo)
+- [x] Block types: paragraph, heading 1-3, bullet list, numbered list, todo list, code block, blockquote, divider, callout, image
+- [x] Slash command menu triggered by `/` — filterable, keyboard navigable
+- [x] Floating toolbar on text selection — bold, italic, underline, strikethrough, code, link
+- [x] Drag-and-drop block reordering with visual indicator
+- [x] Auto-save: content persists to Supabase on change (debounced)
+- [x] Page loads with saved content restored
+- [x] Placeholder text in empty blocks ("Type '/' for commands")
+- [x] Code blocks have syntax highlighting
+- [x] Images can be uploaded and displayed inline
+- [x] Keyboard shortcuts: ⌘+B (bold), ⌘+I (italic), ⌘+U (underline), ⌘+K (link), ⌘+Z (undo), ⌘+Shift+Z (redo)
 
 ### Search
-- [ ] Search input in sidebar
-- [ ] Results show matching page titles and content snippets
-- [ ] Clicking a result navigates to the page
-- [ ] Search is scoped to the current workspace
-- [ ] Empty state when no results found
+- [x] Search input in sidebar
+- [x] Results show matching page titles and content snippets
+- [x] Clicking a result navigates to the page
+- [x] Search is scoped to the current workspace
+- [x] Empty state when no results found
 
 ### Import/Export
-- [ ] User can export a page as Markdown (.md file download)
-- [ ] User can import a Markdown file to create a new page
-- [ ] Import preserves headings, lists, code blocks, links, images (as URLs)
+- [x] User can export a page as Markdown (.md file download)
+- [x] User can import a Markdown file to create a new page
+- [x] Import preserves headings, lists, code blocks, links, images (as URLs)
 
 ### Members
-- [ ] Workspace owner or admin can invite users by email
-- [ ] Only owner/admin roles can manage members (member role cannot invite or remove)
-- [ ] Invited user receives an invite (in-app notification or email link)
-- [ ] Invited user can accept and join the workspace (no limit on joined workspaces)
-- [ ] Roles: owner (full control), admin (manage members + pages), member (read/write pages)
-- [ ] Owner/admin can change member roles
-- [ ] Owner/admin can remove members
-- [ ] Member list visible in workspace settings
-- [ ] Personal workspace owner cannot be removed from their own personal workspace
+- [x] Workspace owner or admin can invite users by email
+- [x] Only owner/admin roles can manage members (member role cannot invite or remove)
+- [x] Invited user receives an invite (in-app notification or email link)
+- [x] Invited user can accept and join the workspace (no limit on joined workspaces)
+- [x] Roles: owner (full control), admin (manage members + pages), member (read/write pages)
+- [x] Owner/admin can change member roles
+- [x] Owner/admin can remove members
+- [x] Member list visible in workspace settings
+- [x] Personal workspace owner cannot be removed from their own personal workspace
 
 ### Database Views
-- [ ] User can create a database from the sidebar ("New Database" button)
-- [ ] Database pages show a grid icon in the sidebar page tree
-- [ ] User can define properties (columns) with name and type
-- [ ] User can add, edit, and delete rows in table view
-- [ ] Inline cell editing works for all basic property types
-- [ ] Select/multi-select properties support creating new options inline
-- [ ] Database page shows optional rich text content above the database grid
-- [ ] Clicking a row opens it as a full page with properties header + Lexical editor
-- [ ] Row page shows breadcrumb: workspace → database → row
-- [ ] Created time, Updated time, Created by properties auto-derive from page metadata
-- [ ] User can create multiple views per database (table, board, list, calendar, gallery)
-- [ ] View tabs appear above the database, active view highlighted
-- [ ] Each view stores independent configuration (visible properties, sort, filter)
-- [ ] Table view: resizable columns, column reorder, add row/column
-- [ ] Board view: Kanban grouped by select property, drag cards between columns
-- [ ] List view: compact rows with title + visible properties
-- [ ] Calendar view: month grid, items on date cells, prev/next month navigation
-- [ ] Gallery view: card grid with cover image + title
-- [ ] User can sort by any property (ascending/descending), multiple sort rules
-- [ ] User can filter by property value with type-appropriate operators
-- [ ] Active filters shown as pills in filter bar, persisted per-view
-- [ ] User can insert a database block via slash command (`/database`)
-- [ ] Inline database renders a compact view with expand-to-full-page button
-- [ ] Person property shows member avatars, picker searches workspace members
-- [ ] Files property supports upload and renders thumbnails
-- [ ] Relation property links to rows in another database, renders as pills
-- [ ] Formula property evaluates simple expressions referencing other properties
-- [ ] All database data respects workspace RLS policies
+- [x] User can create a database from the sidebar ("New Database" button)
+- [x] Database pages show a grid icon in the sidebar page tree
+- [x] User can define properties (columns) with name and type
+- [x] User can add, edit, and delete rows in table view
+- [x] Inline cell editing works for all basic property types
+- [x] Select/multi-select properties support creating new options inline
+- [x] Database page shows optional rich text content above the database grid
+- [x] Clicking a row opens it as a full page with properties header + Lexical editor
+- [x] Row page shows breadcrumb: workspace → database → row
+- [x] Created time, Updated time, Created by properties auto-derive from page metadata
+- [x] User can create multiple views per database (table, board, list, calendar, gallery)
+- [x] View tabs appear above the database, active view highlighted
+- [x] Each view stores independent configuration (visible properties, sort, filter)
+- [x] Table view: resizable columns, column reorder, add row/column
+- [x] Board view: Kanban grouped by select property, drag cards between columns
+- [x] List view: compact rows with title + visible properties
+- [x] Calendar view: month grid, items on date cells, prev/next month navigation
+- [x] Gallery view: card grid with cover image + title
+- [x] User can sort by any property (ascending/descending), multiple sort rules
+- [x] User can filter by property value with type-appropriate operators
+- [x] Active filters shown as pills in filter bar, persisted per-view
+- [x] User can insert a database block via slash command (`/database`)
+- [x] Inline database renders a compact view with expand-to-full-page button
+- [x] Person property shows member avatars, picker searches workspace members
+- [x] Files property supports upload and renders thumbnails
+- [x] Relation property links to rows in another database, renders as pills
+- [x] Formula property evaluates simple expressions referencing other properties
+- [x] All database data respects workspace RLS policies
 
 ### App Shell
-- [ ] Sidebar: workspace switcher, search, page tree, settings, user menu
-- [ ] Sidebar collapses on mobile (Sheet component)
-- [ ] Responsive: works on desktop (≥1024px), tablet (768-1023px), mobile (<768px)
-- [ ] Keyboard shortcut: ⌘+\ to toggle sidebar
+- [x] Sidebar: workspace switcher, search, page tree, settings, user menu
+- [x] Sidebar collapses on mobile (Sheet component)
+- [x] Responsive: works on desktop (≥1024px), tablet (768-1023px), mobile (<768px)
+- [x] Keyboard shortcut: ⌘+\ to toggle sidebar
 - [x] Light and dark mode with theme toggle and system preference detection
-- [ ] JetBrains Mono font throughout
-- [ ] Sharp corners on all components (per design spec)
+- [x] JetBrains Mono font throughout
+- [x] Sharp corners on all components (per design spec)
 
 ## URL Structure
 


### PR DESCRIPTION
The automation factory stopped generating self-improvement work after the product spec was fully decomposed. Feature/enhancement issue creation dropped from 50/day (Apr 21) to 0/day (Apr 24) with an empty backlog.

## Root cause

1. Feature Planner only decomposes the product spec — once done, it idles
2. Existing automations observe the product for defects (bugs) but not improvement opportunities
3. Feedback Digest posts to Slack but never creates issues
4. Product spec checkboxes were 86/87 unchecked despite full implementation — no signal for \"spec complete\"

## Changes

### New: Product Improver automation
Twice-weekly (Mon/Thu 9 AM UTC) review of the live site (Playwright) and codebase to find enhancement opportunities. Creates max 3 issues per run, all labeled `needs-human` — requires maintainer approval before entering the automation queue. Looks for UX polish, accessibility gaps, performance opportunities, and spec completeness.

### Updated: Feedback Digest
Now auto-files GitHub issues for high-confidence bugs (reproducible steps) and feature requests with 2+ similar submissions. Enhancement issues get `needs-human`. Bug issues go directly to `status:backlog`.

### Updated: Feature Planner — beyond-spec mode
When the spec is fully decomposed and the backlog has <3 open issues, the Feature Planner reviews closed issue patterns and quality grades to propose 1-3 enhancement issues (labeled `needs-human`).

### Updated: Product spec checkboxes
All 87 acceptance criteria marked `[x]` to reflect current implementation state. This signals to the Feature Planner that spec decomposition is complete and beyond-spec mode should activate.

## Registration
- Product Improver: created (`019dbeee-b269-7bb3-b527-2c5081573ca1`)
- Feedback Digest: updated
- Feature Planner: updated
- Registry updated with new automation ID