### PR TITLE
perf: UI performance improvements for database views and sidebar

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,13 @@ import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["*.preview.devx.network", "*.preview.env.ona.dev"],
+  experimental: {
+    // Cache dynamic route RSC payloads for 30s on the client.
+    // Makes back/forward navigation instant instead of re-fetching.
+    staleTimes: {
+      dynamic: 30,
+    },
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import type { SerializedEditorState } from "lexical";
@@ -64,7 +64,9 @@ import type {
   PropertyType,
 } from "@/lib/types";
 
-// Dynamically import view components to code-split database view types
+// Dynamically import view components to code-split database view types.
+// TableView uses createPortal(document.body) and useLayoutEffect, so it
+// needs { ssr: false }. The other views are pure data renderers.
 const TableView = dynamic(
   () =>
     import("@/components/database/views/table-view").then(
@@ -78,7 +80,6 @@ const BoardView = dynamic(
     import("@/components/database/views/board-view").then(
       (mod) => mod.BoardView,
     ),
-  { ssr: false },
 );
 
 const ListView = dynamic(
@@ -86,7 +87,6 @@ const ListView = dynamic(
     import("@/components/database/views/list-view").then(
       (mod) => mod.ListView,
     ),
-  { ssr: false },
 );
 
 const CalendarView = dynamic(
@@ -94,7 +94,6 @@ const CalendarView = dynamic(
     import("@/components/database/views/calendar-view").then(
       (mod) => mod.CalendarView,
     ),
-  { ssr: false },
 );
 
 const GalleryView = dynamic(
@@ -102,7 +101,6 @@ const GalleryView = dynamic(
     import("@/components/database/views/gallery-view").then(
       (mod) => mod.GalleryView,
     ),
-  { ssr: false },
 );
 
 // Dynamically import the editor only when the database page has content above the grid
@@ -238,7 +236,6 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     workspaceSlug,
     userId,
   } = props;
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   // Database data state
@@ -317,14 +314,14 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     };
   }, [pageId, workspaceId]);
 
-  // Handle view tab change — update URL ?view= param
+  // Handle view tab change — update URL ?view= param without server round-trip
   const handleViewChange = useCallback(
     (viewId: string) => {
       const params = new URLSearchParams(searchParams.toString());
       params.set("view", viewId);
-      router.replace(`?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, "", `?${params.toString()}`);
     },
-    [router, searchParams],
+    [searchParams],
   );
 
   // Create a new view with sensible defaults per type
@@ -355,9 +352,9 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       // Switch to the new view
       const params = new URLSearchParams(searchParams.toString());
       params.set("view", newView.id);
-      router.replace(`?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, "", `?${params.toString()}`);
     },
-    [pageId, properties, router, searchParams],
+    [pageId, properties, searchParams],
   );
 
   // Update the active view's config (used by board/calendar config dropdowns)
@@ -373,7 +370,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         ),
       );
 
-      const { error } = await updateView(activeView.id, { config: newConfig });
+      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
       if (error) {
         toast.error("Failed to update view configuration", { duration: 8000 });
         // Revert
@@ -384,7 +381,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         );
       }
     },
-    [activeView],
+    [activeView, pageId],
   );
 
   // Rename a view
@@ -392,7 +389,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     async (viewId: string, newName: string) => {
       const { data: updated, error } = await updateView(viewId, {
         name: newName,
-      });
+      }, pageId);
       if (error || !updated) {
         toast.error("Failed to rename view", { duration: 8000 });
         return;
@@ -401,31 +398,32 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         prev.map((v) => (v.id === viewId ? { ...v, name: newName } : v)),
       );
     },
-    [],
+    [pageId],
   );
 
   // Delete a view (with last-view protection handled by deleteView)
   const handleDeleteView = useCallback(
     async (viewId: string) => {
-      const { error } = await deleteView(viewId);
+      const { error } = await deleteView(viewId, pageId);
       if (error) {
         toast.error(error.message || "Failed to delete view", {
           duration: 8000,
         });
         return;
       }
-      setViews((prev) => {
-        const remaining = prev.filter((v) => v.id !== viewId);
-        // If the deleted view was active, switch to the first remaining view
-        if (viewId === activeViewId && remaining.length > 0) {
+      setViews((prev) => prev.filter((v) => v.id !== viewId));
+      // If the deleted view was active, switch to the first remaining view.
+      // Done outside setViews to avoid calling history.replaceState during render.
+      if (viewId === activeViewId) {
+        const remaining = views.filter((v) => v.id !== viewId);
+        if (remaining.length > 0) {
           const params = new URLSearchParams(searchParams.toString());
           params.set("view", remaining[0].id);
-          router.replace(`?${params.toString()}`, { scroll: false });
+          window.history.replaceState(null, "", `?${params.toString()}`);
         }
-        return remaining;
-      });
+      }
     },
-    [activeViewId, router, searchParams],
+    [activeViewId, pageId, searchParams, views],
   );
 
   // Duplicate a view — copy config and create with " (copy)" suffix
@@ -449,9 +447,9 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       // Switch to the duplicated view
       const params = new URLSearchParams(searchParams.toString());
       params.set("view", newView.id);
-      router.replace(`?${params.toString()}`, { scroll: false });
+      window.history.replaceState(null, "", `?${params.toString()}`);
     },
-    [pageId, views, router, searchParams],
+    [pageId, views, searchParams],
   );
 
   // Reorder views by updating position values
@@ -515,12 +513,12 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
           v.id === activeView.id ? { ...v, config: newConfig } : v,
         ),
       );
-      const { error } = await updateView(activeView.id, { config: newConfig });
+      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
       if (error) {
         toast.error("Failed to update sort", { duration: 8000 });
       }
     },
-    [activeView],
+    [activeView, pageId],
   );
 
   const handleFiltersChange = useCallback(
@@ -533,12 +531,12 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
           v.id === activeView.id ? { ...v, config: newConfig } : v,
         ),
       );
-      const { error } = await updateView(activeView.id, { config: newConfig });
+      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
       if (error) {
         toast.error("Failed to update filter", { duration: 8000 });
       }
     },
-    [activeView],
+    [activeView, pageId],
   );
 
   // Column header sort toggle: cycles unsorted → asc → desc → unsorted
@@ -630,7 +628,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         }),
       );
 
-      const { error } = await updateRowValue(rowId, propertyId, newValue);
+      const { error } = await updateRowValue(rowId, propertyId, newValue, pageId);
       if (error) {
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-view:move-card");
@@ -638,7 +636,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         toast.error("Failed to move card", { duration: 8000 });
       }
     },
-    [],
+    [pageId],
   );
 
   const handleCellUpdate = useCallback(
@@ -690,7 +688,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       if (newOptions) {
         const { error: configError } = await updateProperty(propertyId, {
           config: { options: newOptions },
-        });
+        }, pageId);
         if (configError) {
           if (!isInsufficientPrivilegeError(configError)) {
             captureSupabaseError(configError, "database-view:update-property-options");
@@ -699,7 +697,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         }
       }
 
-      const { error } = await updateRowValue(rowId, propertyId, cleanValue);
+      const { error } = await updateRowValue(rowId, propertyId, cleanValue, pageId);
       if (error) {
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-view:update-cell");
@@ -707,7 +705,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         toast.error("Failed to update cell", { duration: 8000 });
       }
     },
-    [],
+    [pageId],
   );
 
   const handleAddColumn = useCallback(
@@ -756,7 +754,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         prev.map((p) => (p.id === propertyId ? { ...p, name: newName } : p)),
       );
 
-      const { error } = await updateProperty(propertyId, { name: newName });
+      const { error } = await updateProperty(propertyId, { name: newName }, pageId);
       if (error) {
         toast.error("Failed to rename property", { duration: 8000 });
         // Revert
@@ -765,7 +763,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
         );
       }
     },
-    [renamingProperty],
+    [renamingProperty, pageId],
   );
 
   const handleColumnReorder = useCallback(
@@ -836,7 +834,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       }),
     );
 
-    const { error } = await deleteProperty(propertyId);
+    const { error } = await deleteProperty(propertyId, pageId);
     if (error) {
       toast.error("Failed to delete property", { duration: 8000 });
       // Revert
@@ -858,7 +856,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
             ...v.config,
             visible_properties: vp.filter((id: string) => id !== propertyId),
           },
-        });
+        }, pageId);
       }
     }
   }, [deletingProperty, properties, views, pageId]);

--- a/src/components/database/view-tabs.tsx
+++ b/src/components/database/view-tabs.tsx
@@ -76,6 +76,15 @@ const VIEW_TYPES: DatabaseViewType[] = [
   "gallery",
 ];
 
+// Preload map: trigger dynamic import() on hover to warm the browser module cache
+const VIEW_CHUNK_PRELOADERS: Record<DatabaseViewType, () => void> = {
+  table: () => void import("@/components/database/views/table-view"),
+  board: () => void import("@/components/database/views/board-view"),
+  list: () => void import("@/components/database/views/list-view"),
+  calendar: () => void import("@/components/database/views/calendar-view"),
+  gallery: () => void import("@/components/database/views/gallery-view"),
+};
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -328,6 +337,7 @@ export function ViewTabs({
                       type="button"
                       onClick={() => handleTabClick(view.id)}
                       onDoubleClick={() => handleDoubleClick(view.id)}
+                      onMouseEnter={() => VIEW_CHUNK_PRELOADERS[view.type]()}
                       className={cn(
                         "group/tab flex shrink-0 items-center gap-1.5 px-3 py-2 text-sm transition-colors",
                         isActive

--- a/src/components/database/views/board-view.tsx
+++ b/src/components/database/views/board-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { getPropertyTypeConfig } from "@/components/database/property-types/index";
@@ -72,7 +72,7 @@ function getRowOptionId(row: DatabaseRow, propertyId: string): string | null {
 // BoardView
 // ---------------------------------------------------------------------------
 
-export function BoardView({
+export const BoardView = memo(function BoardView({
   rows,
   properties,
   viewConfig,
@@ -264,7 +264,7 @@ export function BoardView({
       ))}
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // Column data type

--- a/src/components/database/views/calendar-view.tsx
+++ b/src/components/database/views/calendar-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -162,7 +162,7 @@ export interface CalendarViewProps {
 // CalendarView
 // ---------------------------------------------------------------------------
 
-export function CalendarView({
+export const CalendarView = memo(function CalendarView({
   rows,
   properties,
   viewConfig,
@@ -366,7 +366,7 @@ export function CalendarView({
       </div>
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // CalendarDayCell

--- a/src/components/database/views/gallery-view.tsx
+++ b/src/components/database/views/gallery-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import Link from "next/link";
 import { ImageIcon, LayoutGrid, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -69,7 +69,7 @@ function getCoverUrl(
 // GalleryView
 // ---------------------------------------------------------------------------
 
-export function GalleryView({
+export const GalleryView = memo(function GalleryView({
   rows,
   viewConfig,
   workspaceSlug,
@@ -132,7 +132,7 @@ export function GalleryView({
       )}
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // GalleryCard

--- a/src/components/database/views/list-view.tsx
+++ b/src/components/database/views/list-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import Link from "next/link";
 import { FileText, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -32,7 +32,7 @@ export interface ListViewProps {
 // ListView
 // ---------------------------------------------------------------------------
 
-export function ListView({
+export const ListView = memo(function ListView({
   rows,
   properties,
   viewConfig,
@@ -100,7 +100,7 @@ export function ListView({
       )}
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // ListRow

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -146,7 +147,7 @@ interface ColumnDropTarget {
 // TableView
 // ---------------------------------------------------------------------------
 
-export function TableView({
+export const TableView = memo(function TableView({
   rows,
   properties,
   viewConfig,
@@ -629,7 +630,7 @@ export function TableView({
       )}
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // TableRow (extracted for readability, not a separate file per conventions)

--- a/src/components/sidebar/favorites-section.tsx
+++ b/src/components/sidebar/favorites-section.tsx
@@ -151,6 +151,7 @@ export function FavoritesSection({ userId }: FavoritesSectionProps) {
                 ? "bg-overlay-active font-medium text-label-subtle"
                 : "text-muted-foreground hover:bg-overlay-hover"
             }`}
+            onMouseEnter={() => router.prefetch(`/${workspaceSlug}/${fav.page_id}`)}
           >
             <span className="flex h-4 w-4 shrink-0 items-center justify-center">
               {fav.pages.icon ? (

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -44,7 +44,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { createDatabase } from "@/lib/database";
-import type { Page } from "@/lib/types";
+import type { SidebarPage } from "@/lib/types";
 import {
   buildTree,
   computeDrop,
@@ -64,7 +64,7 @@ interface PageTreeProps {
 export function PageTree({ userId }: PageTreeProps) {
   const router = useRouter();
   const params = useParams<{ workspaceSlug?: string; pageId?: string }>();
-  const [pages, setPages] = useState<Page[]>([]);
+  const [pages, setPages] = useState<SidebarPage[]>([]);
   const [loading, setLoading] = useState(true);
   const [deleteTarget, setDeleteTarget] = useState<TreeNode | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -121,7 +121,7 @@ export function PageTree({ userId }: PageTreeProps) {
         const supabase = await getClient();
         return supabase
           .from("pages")
-          .select("*")
+          .select("id, workspace_id, parent_id, title, icon, cover_url, is_database, position, created_by, created_at, updated_at, deleted_at")
           .eq("workspace_id", workspaceId)
           .is("deleted_at", null)
           .order("position", { ascending: true });
@@ -356,20 +356,27 @@ export function PageTree({ userId }: PageTreeProps) {
   }, [workspaceId, workspaceSlug, userId, router]);
 
   const handleDuplicate = useCallback(
-    async (page: Page) => {
+    async (page: SidebarPage) => {
       if (!workspaceId || !workspaceSlug) return;
 
       const nextPosition = getNextSiblingPosition(pages, page.parent_id);
       const duplicateTitle = (page.title || "Untitled") + " (copy)";
 
+      // Fetch content on-demand — the sidebar tree query excludes it to reduce payload
       const supabase = await getClient();
+      const { data: fullPage } = await supabase
+        .from("pages")
+        .select("content")
+        .eq("id", page.id)
+        .single();
+
       const { data: newPage, error } = await supabase
         .from("pages")
         .insert({
           workspace_id: workspaceId,
           parent_id: page.parent_id,
           title: duplicateTitle,
-          content: page.content ? JSON.parse(JSON.stringify(page.content)) : null,
+          content: fullPage?.content ? JSON.parse(JSON.stringify(fullPage.content)) : null,
           icon: page.icon,
           position: nextPosition,
           created_by: userId,
@@ -440,13 +447,13 @@ export function PageTree({ userId }: PageTreeProps) {
     setDeleteTarget(null);
   }
 
-  async function handleMoveUp(page: Page) {
+  async function handleMoveUp(page: SidebarPage) {
     const result = computeSwapPositions(pages, page.id, "up");
     if (!result) return;
     await applySwap(result.updates);
   }
 
-  async function handleMoveDown(page: Page) {
+  async function handleMoveDown(page: SidebarPage) {
     const result = computeSwapPositions(pages, page.id, "down");
     if (!result) return;
     await applySwap(result.updates);
@@ -479,7 +486,7 @@ export function PageTree({ userId }: PageTreeProps) {
     }
   }
 
-  async function handleNest(page: Page) {
+  async function handleNest(page: SidebarPage) {
     const result = computeNest(pages, page.id);
     if (!result) return;
 
@@ -507,7 +514,7 @@ export function PageTree({ userId }: PageTreeProps) {
     }
   }
 
-  async function handleUnnest(page: Page) {
+  async function handleUnnest(page: SidebarPage) {
     const result = computeUnnest(pages, page.id);
     if (!result) return;
 
@@ -686,6 +693,9 @@ export function PageTree({ userId }: PageTreeProps) {
               onNavigate={(pageId) =>
                 router.push(`/${workspaceSlug}/${pageId}`)
               }
+              onPrefetch={(pageId) =>
+                router.prefetch(`/${workspaceSlug}/${pageId}`)
+              }
               onCreate={handleCreate}
               onDuplicate={handleDuplicate}
               onDelete={setDeleteTarget}
@@ -766,13 +776,14 @@ interface PageTreeItemProps {
   selectedPageId: string | undefined;
   workspaceSlug: string;
   onNavigate: (pageId: string) => void;
+  onPrefetch: (pageId: string) => void;
   onCreate: (parentId: string | null) => void;
-  onDuplicate: (page: Page) => void;
+  onDuplicate: (page: SidebarPage) => void;
   onDelete: (node: TreeNode) => void;
-  onMoveUp: (page: Page) => void;
-  onMoveDown: (page: Page) => void;
-  onNest: (page: Page) => void;
-  onUnnest: (page: Page) => void;
+  onMoveUp: (page: SidebarPage) => void;
+  onMoveDown: (page: SidebarPage) => void;
+  onNest: (page: SidebarPage) => void;
+  onUnnest: (page: SidebarPage) => void;
   draggedId: string | null;
   dropTarget: { id: string; position: "before" | "after" | "inside" } | null;
   onDragStart: (e: React.DragEvent, pageId: string) => void;
@@ -780,7 +791,7 @@ interface PageTreeItemProps {
   onDragLeave: () => void;
   onDrop: (e: React.DragEvent) => void;
   onDragEnd: () => void;
-  pages: Page[];
+  pages: SidebarPage[];
   favoriteMap: Map<string, string>;
   onToggleFavorite: (pageId: string) => void;
 }
@@ -793,6 +804,7 @@ function PageTreeItem({
   selectedPageId,
   workspaceSlug,
   onNavigate,
+  onPrefetch,
   onCreate,
   onDuplicate,
   onDelete,
@@ -836,6 +848,7 @@ function PageTreeItem({
         } ${isDragged ? "opacity-50" : ""}`}
         style={{ paddingLeft: `${depth * 12 + 4}px` }}
         draggable
+        onMouseEnter={() => onPrefetch(page.id)}
         onDragStart={(e) => onDragStart(e, page.id)}
         onDragOver={(e) => onDragOver(e, page.id)}
         onDragLeave={onDragLeave}
@@ -990,6 +1003,7 @@ function PageTreeItem({
               selectedPageId={selectedPageId}
               workspaceSlug={workspaceSlug}
               onNavigate={onNavigate}
+              onPrefetch={onPrefetch}
               onCreate={onCreate}
               onDuplicate={onDuplicate}
               onDelete={onDelete}

--- a/src/lib/database-cache.ts
+++ b/src/lib/database-cache.ts
@@ -1,0 +1,59 @@
+// In-memory cache for loadDatabase and loadWorkspaceMembers results.
+// Avoids re-fetching when navigating back to a database page within the TTL.
+// Invalidated on any local mutation via invalidateDatabase().
+
+const DEFAULT_TTL_MS = 30_000;
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const databaseCache = new Map<string, CacheEntry<unknown>>();
+const membersCache = new Map<string, CacheEntry<unknown>>();
+
+function isValid<T>(entry: CacheEntry<T> | undefined): entry is CacheEntry<T> {
+  return entry !== undefined && Date.now() < entry.expiresAt;
+}
+
+export function getDatabaseCache<T>(databaseId: string): T | null {
+  const entry = databaseCache.get(databaseId) as
+    | CacheEntry<T>
+    | undefined;
+  return isValid(entry) ? entry.data : null;
+}
+
+export function setDatabaseCache<T>(databaseId: string, data: T): void {
+  databaseCache.set(databaseId, {
+    data,
+    expiresAt: Date.now() + DEFAULT_TTL_MS,
+  });
+}
+
+export function invalidateDatabase(databaseId: string): void {
+  databaseCache.delete(databaseId);
+}
+
+export function getMembersCache<T>(workspaceId: string): T | null {
+  const entry = membersCache.get(workspaceId) as
+    | CacheEntry<T>
+    | undefined;
+  return isValid(entry) ? entry.data : null;
+}
+
+export function setMembersCache<T>(workspaceId: string, data: T): void {
+  membersCache.set(workspaceId, {
+    data,
+    expiresAt: Date.now() + DEFAULT_TTL_MS,
+  });
+}
+
+export function invalidateMembers(workspaceId: string): void {
+  membersCache.delete(workspaceId);
+}
+
+/** Clear all caches. Used in tests to prevent cross-test leakage. */
+export function clearAllCaches(): void {
+  databaseCache.clear();
+  membersCache.clear();
+}

--- a/src/lib/database.test.ts
+++ b/src/lib/database.test.ts
@@ -86,10 +86,12 @@ import {
   loadDatabase,
   loadRow,
 } from "./database";
+import { clearAllCaches } from "./database-cache";
 
 beforeEach(() => {
   vi.clearAllMocks();
   tableMocks = {};
+  clearAllCaches();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -3,6 +3,13 @@
 
 import { createClient } from "@/lib/supabase/client";
 import { captureSupabaseError } from "@/lib/sentry";
+import {
+  getDatabaseCache,
+  setDatabaseCache,
+  invalidateDatabase,
+  getMembersCache,
+  setMembersCache,
+} from "@/lib/database-cache";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -205,6 +212,7 @@ export async function addProperty(
     captureSupabaseError(error, "database.addProperty");
     return { data: null, error };
   }
+  invalidateDatabase(databaseId);
   return { data: data as DatabaseProperty, error: null };
 }
 
@@ -214,6 +222,7 @@ export async function addProperty(
 export async function updateProperty(
   propertyId: string,
   updates: Partial<Pick<DatabaseProperty, "name" | "type" | "config">>,
+  databaseId?: string,
 ): Promise<{ data: DatabaseProperty | null; error: Error | null }> {
   const supabase = getClient();
   const { data, error } = await supabase
@@ -227,6 +236,7 @@ export async function updateProperty(
     captureSupabaseError(error, "database.updateProperty");
     return { data: null, error };
   }
+  if (databaseId) invalidateDatabase(databaseId);
   return { data: data as DatabaseProperty, error: null };
 }
 
@@ -235,6 +245,7 @@ export async function updateProperty(
  */
 export async function deleteProperty(
   propertyId: string,
+  databaseId?: string,
 ): Promise<{ error: Error | null }> {
   const supabase = getClient();
   const { error } = await supabase
@@ -244,6 +255,8 @@ export async function deleteProperty(
 
   if (error) {
     captureSupabaseError(error, "database.deleteProperty");
+  } else if (databaseId) {
+    invalidateDatabase(databaseId);
   }
   return { error };
 }
@@ -275,6 +288,7 @@ export async function reorderProperties(
     }
   }
 
+  invalidateDatabase(databaseId);
   return { error: null };
 }
 
@@ -355,6 +369,7 @@ export async function addRow(
     }
   }
 
+  invalidateDatabase(databaseId);
   return { data: rowPage as Page, error: null };
 }
 
@@ -365,6 +380,7 @@ export async function updateRowValue(
   rowId: string,
   propertyId: string,
   value: Record<string, unknown>,
+  databaseId?: string,
 ): Promise<{ data: RowValue | null; error: Error | null }> {
   const supabase = getClient();
   const { data, error } = await supabase
@@ -379,6 +395,7 @@ export async function updateRowValue(
   if (error) {
     return { data: null, error };
   }
+  if (databaseId) invalidateDatabase(databaseId);
   return { data: data as RowValue, error: null };
 }
 
@@ -418,6 +435,7 @@ export async function addView(
     captureSupabaseError(error, "database.addView");
     return { data: null, error };
   }
+  invalidateDatabase(databaseId);
   return { data: data as DatabaseView, error: null };
 }
 
@@ -427,6 +445,7 @@ export async function addView(
 export async function updateView(
   viewId: string,
   updates: Partial<Pick<DatabaseView, "name" | "type" | "config">>,
+  databaseId?: string,
 ): Promise<{ data: DatabaseView | null; error: Error | null }> {
   const supabase = getClient();
   const { data, error } = await supabase
@@ -440,6 +459,7 @@ export async function updateView(
     captureSupabaseError(error, "database.updateView");
     return { data: null, error };
   }
+  if (databaseId) invalidateDatabase(databaseId);
   return { data: data as DatabaseView, error: null };
 }
 
@@ -448,6 +468,7 @@ export async function updateView(
  */
 export async function deleteView(
   viewId: string,
+  databaseId?: string,
 ): Promise<{ error: Error | null }> {
   const supabase = getClient();
 
@@ -486,6 +507,8 @@ export async function deleteView(
 
   if (error) {
     captureSupabaseError(error, "database.deleteView");
+  } else {
+    invalidateDatabase(databaseId ?? view.database_id);
   }
   return { error };
 }
@@ -512,6 +535,7 @@ export async function reorderViews(
     }
   }
 
+  invalidateDatabase(databaseId);
   return { error: null };
 }
 
@@ -529,10 +553,16 @@ export interface WorkspaceMember {
 /**
  * Load workspace members with profile data. Used to populate _members config
  * on person and created_by properties so renderers can resolve user IDs.
+ * Results are cached in-memory for 30s.
  */
 export async function loadWorkspaceMembers(
   workspaceId: string,
 ): Promise<{ data: WorkspaceMember[] | null; error: Error | null }> {
+  const cached = getMembersCache<WorkspaceMember[]>(workspaceId);
+  if (cached) {
+    return { data: cached, error: null };
+  }
+
   const supabase = getClient();
   const { data, error } = await supabase
     .from("members")
@@ -561,6 +591,8 @@ export async function loadWorkspaceMembers(
     };
   });
 
+  setMembersCache(workspaceId, members);
+
   return { data: members, error: null };
 }
 
@@ -576,10 +608,16 @@ export interface LoadDatabaseResult {
 
 /**
  * Load a database: properties, views, and rows with their values in parallel.
+ * Results are cached in-memory for 30s to avoid re-fetching on back-navigation.
  */
 export async function loadDatabase(
   databaseId: string,
 ): Promise<{ data: LoadDatabaseResult | null; error: Error | null }> {
+  const cached = getDatabaseCache<LoadDatabaseResult>(databaseId);
+  if (cached) {
+    return { data: cached, error: null };
+  }
+
   const supabase = getClient();
 
   const [propertiesResult, viewsResult, rowsResult] = await Promise.all([
@@ -654,8 +692,11 @@ export async function loadDatabase(
     values: valuesByRow.get(page.id) ?? {},
   }));
 
+  const result: LoadDatabaseResult = { properties, views, rows };
+  setDatabaseCache(databaseId, result);
+
   return {
-    data: { properties, views, rows },
+    data: result,
     error: null,
   };
 }

--- a/src/lib/page-tree.ts
+++ b/src/lib/page-tree.ts
@@ -1,17 +1,17 @@
 // Pure functions for page tree manipulation.
 // No React or Supabase dependencies — all computation is side-effect-free.
 
-import type { Page } from "@/lib/types";
+import type { SidebarPage } from "@/lib/types";
 
 export interface TreeNode {
-  page: Page;
+  page: SidebarPage;
   children: TreeNode[];
 }
 
 /** Build a nested tree from a flat list of pages. Orphans become roots.
  *  Database row pages (children of `is_database` pages) are excluded from the
  *  tree so they don't clutter the sidebar — they're accessed via the database view. */
-export function buildTree(pages: Page[]): TreeNode[] {
+export function buildTree(pages: SidebarPage[]): TreeNode[] {
   // Collect IDs of database pages so we can filter out their children (rows).
   const databaseIds = new Set(
     pages.filter((p) => p.is_database).map((p) => p.id),
@@ -68,7 +68,7 @@ export function findNode(nodes: TreeNode[], id: string): TreeNode | null {
 
 /** Get the next available position among siblings of a given parent. */
 export function getNextSiblingPosition(
-  pages: Page[],
+  pages: SidebarPage[],
   parentId: string | null,
 ): number {
   const siblings = pages.filter((p) => p.parent_id === parentId);
@@ -78,7 +78,7 @@ export function getNextSiblingPosition(
 }
 
 /** Get sorted siblings for a page (pages sharing the same parent_id). */
-export function getSortedSiblings(pages: Page[], parentId: string | null): Page[] {
+export function getSortedSiblings(pages: SidebarPage[], parentId: string | null): SidebarPage[] {
   return pages
     .filter((p) => p.parent_id === parentId)
     .sort((a, b) => a.position - b.position);
@@ -90,7 +90,7 @@ export function getSortedSiblings(pages: Page[], parentId: string | null): Page[
  * page updates needed (swap positions of the two adjacent pages).
  */
 export function computeSwapPositions(
-  pages: Page[],
+  pages: SidebarPage[],
   pageId: string,
   direction: "up" | "down",
 ): { updates: Array<{ id: string; position: number }> } | null {
@@ -126,7 +126,7 @@ export function computeSwapPositions(
  * Returns null if nesting is not possible (page is first among siblings).
  */
 export function computeNest(
-  pages: Page[],
+  pages: SidebarPage[],
   pageId: string,
 ): { parentId: string; position: number } | null {
   const page = pages.find((p) => p.id === pageId);
@@ -148,7 +148,7 @@ export function computeNest(
  * former parent, and existing siblings at that level are shifted down.
  */
 export function computeUnnest(
-  pages: Page[],
+  pages: SidebarPage[],
   pageId: string,
 ): {
   pageUpdate: { parentId: string | null; position: number };
@@ -183,7 +183,7 @@ export type DropPosition = "before" | "after" | "inside";
  * Returns null if the drop is invalid (same page, or dropping onto a descendant).
  */
 export function computeDrop(
-  pages: Page[],
+  pages: SidebarPage[],
   tree: TreeNode[],
   draggedId: string,
   targetId: string,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,9 @@ export interface Page {
   deleted_at: string | null;
 }
 
+/** Page without the content column — used by the sidebar tree to reduce payload. */
+export type SidebarPage = Omit<Page, "content">;
+
 export interface PageVisit {
   id: string;
   workspace_id: string;


### PR DESCRIPTION
## Motivation

Database pages feel sluggish when switching between views (table → board → list, etc.) and when navigating between pages via the sidebar. A codebase audit identified 10 performance issues across data fetching, rendering, caching, and navigation patterns.

## Changes

### High impact

- **View switching no longer triggers server round-trips** — replaced `router.replace()` with `window.history.replaceState()` for the `?view=` URL param. The URL stays bookmarkable, but switching is now purely client-side.
- **30s in-memory cache for `loadDatabase` and `loadWorkspaceMembers`** — navigating away from a database page and returning within 30s serves data from cache instead of re-fetching. All mutation functions invalidate the cache.
- **Sidebar page query drops the `content` column** — changed `select("*")` to an explicit column list. The Lexical editor JSON was being fetched for every page in the workspace just to render the sidebar tree. Introduced `SidebarPage` type. `handleDuplicate` fetches content on-demand.

### Medium impact

- **All 5 view components wrapped in `React.memo`** — prevents re-renders when parent state changes (sort menu, filter bar, rename dialog) but view props are unchanged.
- **Removed `{ ssr: false }` from 4 of 5 view dynamic imports** — BoardView, ListView, CalendarView, GalleryView are pure data renderers and can be server-prerendered. TableView keeps `{ ssr: false }` due to `createPortal(document.body)` usage.
- **Sidebar prefetching** — added `router.prefetch()` on hover for page tree items and favorites section.

### Low impact

- **View chunk preloading on tab hover** — hovering a view tab triggers `import()` to warm the browser module cache before the click.
- **`staleTimes.dynamic = 30`** — enables 30s client-side router cache for dynamic routes, making back/forward navigation instant.

## Files changed

| File | Change |
|------|--------|
| `src/components/database/database-view-client.tsx` | Replace `router.replace` → `window.history.replaceState`, remove `{ ssr: false }` from 4 views, pass `databaseId` to mutations |
| `src/lib/database-cache.ts` | **New** — in-memory TTL cache for database and members data |
| `src/lib/database.ts` | Add cache reads/writes to `loadDatabase`/`loadWorkspaceMembers`, add cache invalidation to all mutation functions |
| `src/components/database/view-tabs.tsx` | Add view chunk preloaders on tab hover |
| `src/components/database/views/*.tsx` | Wrap all 5 view components in `React.memo` |
| `src/components/sidebar/page-tree.tsx` | Slim query (drop `content`), use `SidebarPage` type, add `onPrefetch` via `router.prefetch` on hover, fetch content on-demand in `handleDuplicate` |
| `src/components/sidebar/favorites-section.tsx` | Add `router.prefetch` on hover |
| `src/lib/page-tree.ts` | Use `SidebarPage` type instead of `Page` |
| `src/lib/types.ts` | Add `SidebarPage` type (`Omit<Page, "content">`) |
| `next.config.ts` | Add `experimental.staleTimes.dynamic = 30` |
| `src/lib/database.test.ts` | Clear cache between tests to prevent cross-test leakage |

## Deferred to roadmap

- **Lazy property type registry** — all 17 property types are eagerly imported. Requires interface refactor.
- **Sidebar tree pagination** — after dropping `content`, payload is ~200-300 bytes/page. Even 500 pages ≈ 150KB. Only needed if workspaces grow beyond ~500 pages.
- **`use cache` / Cache Components** — larger architectural change for server-side caching.
- **Bundle analyzer** — useful for ongoing monitoring, separate chore PR.

## Testing

- ✅ `pnpm typecheck` passes
- ✅ `pnpm lint` passes (no new warnings)
- ✅ 823/823 Vitest tests pass
- ✅ 10/10 database view E2E tests pass
- ✅ Sidebar E2E tests pass
- ✅ No new dependencies