### PR TITLE
chore(automations): use risk-based labeling for improvement issues

### DIFF
--- a/.ona/automations/feature-planner.yaml
+++ b/.ona/automations/feature-planner.yaml
@@ -117,8 +117,16 @@ action:
 
                 4. Propose 1-3 concrete enhancement issues for the weakest areas. These must
                    be specific and implementable in a single PR — not vague "improve X".
-                   Label them: `enhancement`, `priority:3`, `needs-human`.
-                   Do NOT add `status:backlog` — human approval required.
+
+                   Classify each as LOW or HIGH risk using the same criteria as the
+                   Product Improver:
+                   - **LOW risk** (UI polish, accessibility, test gaps, performance tweaks
+                     that don't change behavior): label `enhancement`, `priority:3`,
+                     `status:backlog` — enters the automation queue directly.
+                   - **HIGH risk** (new features, schema changes, auth/security changes,
+                     scope expansion): label `enhancement`, `priority:3`, `needs-human`.
+                     Include an "Approval Required" section in the issue body explaining
+                     why it's high-risk. Comment "approved" to release it to the queue.
 
                 If the product is in good shape and no improvements are needed, skip this
                 step. Do not invent issues to fill a quota.

--- a/.ona/automations/feedback-digest.yaml
+++ b/.ona/automations/feedback-digest.yaml
@@ -121,9 +121,17 @@ action:
                 by theme in Step 3), create an enhancement issue:
                   gh issue create --title "feat: <description> (user feedback)" \
                     --label "enhancement" --label "priority:3" --label "needs-human" \
-                    --body "<body with Description, Evidence (N user requests), Acceptance Criteria>"
+                    --body "<body with Description, Evidence (N user requests), Acceptance Criteria,
+                    and an Approval Required section>"
 
-                Note: enhancement issues get `needs-human` (requires maintainer approval).
+                User feature requests are scope expansion, so they always get `needs-human`.
+                The issue body MUST include this section at the end:
+
+                  ## Approval Required
+                  This issue was auto-filed from N user feedback submissions requesting
+                  the same feature. To approve, comment "approved" and the automation
+                  will pick it up. To reject, close the issue.
+
                 Bug issues get `status:backlog` (enters automation queue directly).
 
                 Before creating any issue, check for duplicates:

--- a/.ona/automations/product-improver.yaml
+++ b/.ona/automations/product-improver.yaml
@@ -22,8 +22,9 @@ action:
                 You are the Product Improver. You review the live product and codebase to find
                 improvement opportunities — not bugs, but ways to make the product better.
 
-                Your output is enhancement issues labeled `needs-human`. A human maintainer must
-                approve each proposal before it enters the automation queue.
+                Your output is enhancement issues. Low-risk improvements go directly to
+                `status:backlog` for the Feature Builder. High-risk improvements get
+                `needs-human` and require maintainer approval first.
 
                 ## Environment Health Check
 
@@ -52,9 +53,9 @@ action:
 
                 Keep this list in mind to avoid creating duplicates.
 
-                Also check how many `needs-human` enhancement issues are already open. If 5 or
-                more are pending review, stop — the maintainer has a backlog of proposals to
-                review first. Do not pile on more.
+                Also check how many open enhancement issues exist (both `status:backlog` and
+                `needs-human`). If 5 or more are open, stop — the backlog has enough
+                improvement work queued. Do not pile on more.
 
                 ## Step 3 — Review the Live Product
 
@@ -159,14 +160,41 @@ action:
                   - Implementation hints, relevant files, patterns to follow
                   - Reference .agents/conventions.md for component patterns
 
-                Labels — each issue gets exactly 3:
+                ### Risk Classification
+
+                Before creating each issue, classify it as LOW or HIGH risk:
+
+                **LOW risk** — safe for the Feature Builder to implement autonomously:
+                - UI polish (spacing, hover states, transitions, empty states)
+                - Accessibility improvements (aria-labels, focus styles, alt text)
+                - Missing Storybook stories or test coverage
+                - Performance optimizations that don't change behavior
+                - Adding loading/error states to existing components
+
+                **HIGH risk** — requires maintainer approval:
+                - New user-facing features or workflows not in the product spec
+                - Database schema changes
+                - Changes to auth, RLS policies, or security-sensitive code
+                - Changes that could break existing E2E tests
+                - Scope expansion beyond what docs/product-spec.md defines
+
+                ### Labels
+
+                For LOW-risk issues:
+                  gh issue create --title "<title>" --body "<body>" \
+                    --label "enhancement" --label "priority:3" --label "status:backlog"
+
+                For HIGH-risk issues, add `needs-human` and include an approval section
+                in the issue body so the Needs-Human Requeue automation can process it:
                   gh issue create --title "<title>" --body "<body>" \
                     --label "enhancement" --label "priority:3" --label "needs-human"
 
-                DO NOT add `status:backlog`. The `needs-human` label signals that a human
-                maintainer must review and approve the proposal. The Needs-Human Requeue
-                automation will remove `needs-human` when the maintainer responds, and the
-                Feature Planner will add `status:backlog` on its next triage run.
+                HIGH-risk issue bodies MUST include this section at the end:
+
+                  ## Approval Required
+                  This improvement was flagged as high-risk because: <reason>.
+                  To approve, comment "approved" and the automation will pick it up.
+                  To reject, close the issue.
 
                 ## Step 7 — Log Summary
 
@@ -184,15 +212,15 @@ action:
                 - [list patterns or "no new feedback"]
 
                 ### Issues Created
-                - #N — Title (evidence: live product / codebase / feedback)
-                - #M — Title (evidence: ...)
+                - #N — Title (LOW risk → status:backlog, evidence: live product / codebase / feedback)
+                - #M — Title (HIGH risk → needs-human, evidence: ...)
 
                 ### Skipped (already covered)
                 - [list findings that already have open issues]
 
                 ## Rules
 
-                - NEVER add `status:backlog` to issues. Always use `needs-human`.
+                - Use `status:backlog` for low-risk issues, `needs-human` for high-risk issues.
                 - NEVER create issues for things in the "Out of Scope" section of the product spec.
                 - NEVER create bug issues — that's the Incident Responder's job. Only enhancements.
                 - NEVER create more than 3 issues per run.


### PR DESCRIPTION
Replaces blanket `needs-human` on all improvement issues with risk-based classification.

## Problem

All improvement issues from the Product Improver and Feature Planner were labeled `needs-human`, requiring manual approval for every proposal — including trivial UI polish and accessibility fixes. This bottlenecks the self-improvement loop on human review bandwidth.

## Changes

### Risk classification (Product Improver + Feature Planner)

**LOW risk → `status:backlog`** (autonomous implementation):
- UI polish (spacing, hover states, transitions, empty states)
- Accessibility (aria-labels, focus styles, alt text)
- Missing Storybook stories or test coverage
- Performance optimizations that don't change behavior
- Adding loading/error states to existing components

**HIGH risk → `needs-human`** (requires maintainer approval):
- New user-facing features not in the product spec
- Database schema changes
- Auth, RLS, or security-sensitive changes
- Changes that could break existing E2E tests
- Scope expansion beyond `docs/product-spec.md`

### Approval flow for high-risk issues

High-risk issues now include an \"Approval Required\" section in the issue body explaining why it's high-risk and how to approve (comment \"approved\"). This lets the Needs-Human Requeue automation process it automatically when the maintainer responds.

### Feedback Digest

User feature requests stay `needs-human` (scope expansion by definition) but now include the same \"Approval Required\" section for consistent processing.

## Registration

All 3 automations updated live (Product Improver, Feature Planner, Feedback Digest).