### PR TITLE
feat: add ARIA roles and labels to board, calendar, and gallery views (#659)

### DIFF
--- a/src/components/database/views/board-view.tsx
+++ b/src/components/database/views/board-view.tsx
@@ -244,7 +244,11 @@ export const BoardView = memo(function BoardView({
   }
 
   return (
-    <div className="flex gap-3 overflow-x-auto pb-4">
+    <div
+      className="flex gap-3 overflow-x-auto pb-4"
+      role="region"
+      aria-label="Database board"
+    >
       {columns.map((column) => (
         <BoardColumn
           key={column.id}
@@ -347,6 +351,8 @@ function BoardColumn({
     <div
       ref={columnRef}
       className="w-72 shrink-0 bg-muted/50 p-2"
+      role="group"
+      aria-label={column.label}
       data-testid={`board-column-${column.id}`}
       data-column-label={column.label}
       onDragOver={handleColumnDragOver}
@@ -365,7 +371,7 @@ function BoardColumn({
       </div>
 
       {/* Cards */}
-      <div className="flex flex-col">
+      <div className="flex flex-col" role="list">
         {column.rows.map((row, index) => (
           <BoardCard
             key={row.page.id}
@@ -396,6 +402,7 @@ function BoardColumn({
         <button
           type="button"
           onClick={() => onAddCard(column.id)}
+          aria-label={`Add card to ${column.label}`}
           className="mt-1 w-full p-1.5 text-left text-xs text-muted-foreground hover:bg-overlay-hover"
         >
           + New
@@ -452,6 +459,8 @@ function BoardCard({
       <Link
         href={`/${workspaceSlug}/${row.page.id}`}
         draggable
+        role="listitem"
+        aria-label={title}
         onDragStart={(e) => onDragStart(e, row.page.id, columnId)}
         onDragEnd={onDragEnd}
         onDragOver={handleCardDragOver}

--- a/src/components/database/views/calendar-view.tsx
+++ b/src/components/database/views/calendar-view.tsx
@@ -342,10 +342,11 @@ export const CalendarView = memo(function CalendarView({
       </div>
 
       {/* Day headers */}
-      <div className="grid grid-cols-7">
+      <div className="grid grid-cols-7" role="row">
         {DAY_HEADERS.map((day) => (
           <div
             key={day}
+            role="columnheader"
             className="border border-overlay-border p-1 text-center text-xs uppercase tracking-widest text-muted-foreground"
           >
             {day}
@@ -354,7 +355,11 @@ export const CalendarView = memo(function CalendarView({
       </div>
 
       {/* Calendar grid */}
-      <div className="grid grid-cols-7">
+      <div
+        className="grid grid-cols-7"
+        role="grid"
+        aria-label={`${FULL_MONTHS[viewMonth]} ${viewYear} calendar`}
+      >
         {cells.map((cell) => (
           <CalendarDayCell
             key={cell.date}
@@ -416,6 +421,8 @@ function CalendarDayCell({ cell, workspaceSlug, onClick }: CalendarDayCellProps)
 
   return (
     <div
+      role="gridcell"
+      aria-label={cell.date}
       className={cn(
         "relative min-h-24 border border-overlay-border p-1",
         cell.isToday && "bg-accent/10",
@@ -452,6 +459,7 @@ function CalendarDayCell({ cell, workspaceSlug, onClick }: CalendarDayCellProps)
                 e.stopPropagation();
                 setShowAll(true);
               }}
+              aria-label={`Show ${overflowCount} more items for ${cell.date}`}
               className="w-full px-1 py-0.5 text-left text-xs text-muted-foreground hover:text-foreground"
             >
               +{overflowCount} more

--- a/src/components/database/views/gallery-view.tsx
+++ b/src/components/database/views/gallery-view.tsx
@@ -101,7 +101,11 @@ export const GalleryView = memo(function GalleryView({
   }
 
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4">
+    <div
+      className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-4"
+      role="list"
+      aria-label="Database gallery"
+    >
       {rows.map((row) => (
         <GalleryCard
           key={row.page.id}
@@ -160,6 +164,8 @@ function GalleryCard({
   return (
     <Link
       href={`/${workspaceSlug}/${row.page.id}`}
+      role="listitem"
+      aria-label={title}
       className={cn(
         "group/card flex flex-col overflow-hidden border border-overlay-border bg-muted",
         cardSizeClass,


### PR DESCRIPTION
Closes #659

## What

Adds ARIA roles and labels to the board, calendar, and gallery database views so screen readers can navigate and understand their structure. The table view and list view already had proper ARIA markup — this brings the remaining three views to parity.

## How

Markup-only changes across three files, no behavioral changes:

**Board view** (`board-view.tsx`):
- Container: `role="region"` + `aria-label="Database board"`
- Each column: `role="group"` + `aria-label` set to the column name
- Cards container: `role="list"`; each card: `role="listitem"` + `aria-label` with title
- "Add card" buttons: `aria-label="Add card to {column}"`

**Calendar view** (`calendar-view.tsx`):
- Month grid: `role="grid"` + `aria-label="{Month} {Year} calendar"`
- Day header row: `role="row"`; each header: `role="columnheader"`
- Day cells: `role="gridcell"` + `aria-label` with ISO date
- Overflow buttons: `aria-label="Show N more items for {date}"`

**Gallery view** (`gallery-view.tsx`):
- Card grid: `role="list"` + `aria-label="Database gallery"`
- Each card: `role="listitem"` + `aria-label` with title

## Testing

- `pnpm lint` — 0 errors (all warnings pre-existing)
- `pnpm typecheck` — passes
- `pnpm test` — 823 tests pass
- Verified existing E2E selectors are unaffected by these changes