### PR TITLE
fix: add status to database_properties type constraint (#662)

### DIFF
--- a/e2e/database-table-editor-portal.spec.ts
+++ b/e2e/database-table-editor-portal.spec.ts
@@ -203,4 +203,53 @@ test.describe("Table editor portals", () => {
     await page.keyboard.press("Escape");
     await expect(dropdown).not.toBeVisible({ timeout: 3_000 });
   });
+
+  test("adding a status column succeeds and renders status badges (#662)", async ({
+    authenticatedPage: page,
+  }) => {
+    await createDatabaseFromSidebar(page);
+
+    // Add a row
+    const addRowBtn = page.locator("button", { hasText: "+ New" });
+    await expect(addRowBtn).toBeVisible({ timeout: 10_000 });
+    await addRowBtn.click();
+    await expect(page.locator('[role="grid"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Add a status column — this was failing before the fix (#662)
+    await addColumnViaTypePicker(page, "Status");
+
+    // Verify the status column header appears
+    const statusHeader = page.locator('[role="columnheader"]', {
+      hasText: /status/i,
+    });
+    await expect(statusHeader.first()).toBeVisible({ timeout: 5_000 });
+
+    // Click the status cell to open the editor
+    const dataCells = page.locator('[role="gridcell"]');
+    const cells = await dataCells.all();
+    // Status is the last property column — second-to-last cell
+    const statusCell = cells[cells.length - 2];
+    await statusCell.click();
+
+    // The status dropdown should be visible with default options
+    const dropdown = page.locator(
+      ".rounded-sm.border.border-border.bg-background",
+    );
+    await expect(dropdown).toBeVisible({ timeout: 5_000 });
+
+    // Verify default status options are present
+    await expect(dropdown.getByText("Not Started")).toBeVisible();
+    await expect(dropdown.getByText("In Progress")).toBeVisible();
+    await expect(dropdown.getByText("Done")).toBeVisible();
+
+    // Select "In Progress" and verify the badge renders
+    await dropdown.getByText("In Progress").click();
+    await page.waitForTimeout(500);
+
+    // The status badge should now be visible in the cell
+    const badge = page.locator('[role="grid"]').getByText("In Progress");
+    await expect(badge).toBeVisible({ timeout: 5_000 });
+  });
 });

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -55,6 +55,7 @@ import {
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
 import { PROPERTY_TYPE_LABEL } from "@/lib/property-icons";
+import { DEFAULT_STATUS_OPTIONS } from "@/components/database/property-types/status";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -721,7 +722,9 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
           name = `${baseLabel} ${suffix}`;
           suffix++;
         }
-        const { data: newProp, error } = await addProperty(pageId, name, type);
+        const config: Record<string, unknown> =
+          type === "status" ? { options: DEFAULT_STATUS_OPTIONS } : {};
+        const { data: newProp, error } = await addProperty(pageId, name, type, config);
         if (error || !newProp) {
           toast.error("Failed to add column", { duration: 8000 });
           return;

--- a/src/components/database/property-type-picker.test.ts
+++ b/src/components/database/property-type-picker.test.ts
@@ -46,8 +46,8 @@ describe("property type selector regression (#538)", () => {
   });
 
   it("addProperty is called with the dynamic type variable", () => {
-    // Must contain addProperty(pageId, name, type) — using the parameter.
-    expect(viewClient).toMatch(/addProperty\(\s*pageId\s*,\s*name\s*,\s*type\s*\)/);
+    // Must contain addProperty(pageId, name, type, ...) — using the parameter.
+    expect(viewClient).toMatch(/addProperty\(\s*pageId\s*,\s*name\s*,\s*type\b/);
   });
 
   it("table view uses PropertyTypePicker for add-column", () => {

--- a/src/lib/database.test.ts
+++ b/src/lib/database.test.ts
@@ -261,6 +261,44 @@ describe("addProperty", () => {
     expect(tableMocks["database_properties"].calls["insert"]).toBeDefined();
   });
 
+  it("passes config through to the insert call", async () => {
+    const statusConfig = {
+      options: [
+        { id: "s1", name: "Not Started", color: "gray" },
+        { id: "s2", name: "In Progress", color: "blue" },
+        { id: "s3", name: "Done", color: "green" },
+      ],
+    };
+    mockTable("database_properties", {
+      data: { ...FAKE_PROPERTY, id: "prop-status", type: "status", config: statusConfig },
+      error: null,
+    });
+
+    const result = await addProperty("page-1", "Status", "status", statusConfig);
+
+    expect(result.error).toBeNull();
+    expect(result.data).not.toBeNull();
+    const insertCalls = tableMocks["database_properties"].calls["insert"];
+    expect(insertCalls).toBeDefined();
+    const insertedRow = insertCalls[0][0] as Record<string, unknown>;
+    expect(insertedRow.config).toEqual(statusConfig);
+    expect(insertedRow.type).toBe("status");
+  });
+
+  it("defaults config to empty object when not provided", async () => {
+    mockTable("database_properties", {
+      data: { ...FAKE_PROPERTY, id: "prop-text" },
+      error: null,
+    });
+
+    const result = await addProperty("page-1", "Notes", "text");
+
+    expect(result.error).toBeNull();
+    const insertCalls = tableMocks["database_properties"].calls["insert"];
+    const insertedRow = insertCalls[0][0] as Record<string, unknown>;
+    expect(insertedRow.config).toEqual({});
+  });
+
   it("captures error on failure", async () => {
     const dbError = new Error("duplicate name");
     mockTable("database_properties", { data: null, error: dbError });

--- a/supabase/migrations/20260424114415_add_status_to_property_type_check.sql
+++ b/supabase/migrations/20260424114415_add_status_to_property_type_check.sql
@@ -1,0 +1,13 @@
+-- Add 'status' to the allowed property types for database_properties.
+-- The original CHECK constraint omitted 'status', causing inserts to fail.
+
+alter table public.database_properties
+  drop constraint database_properties_type_check;
+
+alter table public.database_properties
+  add constraint database_properties_type_check
+  check (type in (
+    'text', 'number', 'select', 'multi_select', 'status', 'checkbox', 'date',
+    'url', 'email', 'phone', 'person', 'files', 'relation', 'formula',
+    'created_time', 'updated_time', 'created_by'
+  ));

--- a/supabase/migrations/migrations.test.ts
+++ b/supabase/migrations/migrations.test.ts
@@ -47,6 +47,22 @@ describe("database migrations", () => {
 });
 
 /**
+ * Regression test for issue #662: 'status' was missing from the
+ * database_properties.type CHECK constraint, causing status column
+ * creation to fail at the database level.
+ */
+describe("database_properties type CHECK includes status (#662)", () => {
+  const allSql = getAllMigrationsSql();
+
+  it("final schema allows 'status' in the type CHECK constraint", () => {
+    // The fix migration drops and re-adds the constraint with 'status' included.
+    expect(allSql).toMatch(
+      /database_properties_type_check[\s\S]*?'status'/
+    );
+  });
+});
+
+/**
  * Regression test for issue #595: page_versions.created_by FK lacked
  * ON DELETE SET NULL, causing delete_account RPC to fail with a FK violation.
  *


### PR DESCRIPTION
Closes #662

## What

Adding a "status" column to a database table failed silently with a "Failed to add column" toast. The root cause was that `'status'` was missing from the PostgreSQL CHECK constraint on `database_properties.type`, so the INSERT was rejected at the database level. Additionally, `handleAddColumn` did not pass default status options in the property config.

## How

1. **Migration** (`20260424114415_add_status_to_property_type_check.sql`): Drops and re-creates the `database_properties_type_check` constraint to include `'status'` in the allowed type values.
2. **Application code** (`database-view-client.tsx`): When adding a status column, `handleAddColumn` now passes `{ options: DEFAULT_STATUS_OPTIONS }` as the config to `addProperty`, seeding the column with "Not Started", "In Progress", and "Done" options.
3. **Updated existing test** (`property-type-picker.test.ts`): Relaxed the regex that checks `addProperty` is called with the dynamic type variable, since the call now includes a 4th `config` argument.

## Testing

- **Unit tests** (`database.test.ts`): Added tests verifying `addProperty` passes config through to the insert call for status type, and defaults to empty object when no config is provided.
- **Migration test** (`migrations.test.ts`): Added regression test verifying the final schema includes `'status'` in the type CHECK constraint.
- **E2E test** (`database-table-editor-portal.spec.ts`): Added test that creates a status column, opens the status dropdown, verifies default options (Not Started, In Progress, Done) are present, selects one, and verifies the badge renders. This test will pass once the migration is deployed.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (0 errors, 827 tests passing).