### PR TITLE
feat: add arrow key cell navigation in database table view (#660)

### DIFF
--- a/e2e/database-crud.spec.ts
+++ b/e2e/database-crud.spec.ts
@@ -221,10 +221,12 @@ test.describe("Database CRUD", () => {
     // Add a text property column via the type picker dropdown
     await addColumnViaTypePicker(page, "Text");
 
-    // Click on the property cell to start editing.
-    // Editable cells have tabindex="0" and cursor-text styling.
+    // Click on a property cell to start editing.
+    // Property cells use roving tabindex (focused cell gets tabindex=0,
+    // others get tabindex=-1). Click the first data cell with a data-col
+    // attribute (property cells, not the title cell).
     const editableCells = page.locator(
-      '[role="gridcell"][tabindex="0"]',
+      '[role="gridcell"][data-col]',
     );
     await expect(editableCells.first()).toBeVisible({ timeout: 5_000 });
     await editableCells.first().click();

--- a/e2e/database-row-page.spec.ts
+++ b/e2e/database-row-page.spec.ts
@@ -337,7 +337,7 @@ test.describe("Database Row Page", () => {
     await addColumnViaTypePicker(page, "Text");
 
     // Click the first editable cell to start inline editing
-    const editableCells = page.locator('[role="gridcell"][tabindex="0"]');
+    const editableCells = page.locator('[role="gridcell"][data-col]');
     await expect(editableCells.first()).toBeVisible({ timeout: 5_000 });
     await editableCells.first().click();
 

--- a/e2e/database-select-options.spec.ts
+++ b/e2e/database-select-options.spec.ts
@@ -206,7 +206,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await navigateToDatabase(page);
 
     // Click the first editable cell (Priority select) to enter editing mode
-    const selectCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    const selectCell = page.locator('[role="gridcell"][data-col]').first();
     await expect(selectCell).toBeVisible({ timeout: 10_000 });
     await selectCell.click();
 
@@ -228,7 +228,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
 
     // Click the select cell again to open the dropdown
-    const reloadedCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    const reloadedCell = page.locator('[role="gridcell"][data-col]').first();
     await expect(reloadedCell).toBeVisible({ timeout: 10_000 });
     await reloadedCell.click();
 
@@ -252,7 +252,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await navigateToDatabase(page);
 
     // Click the second editable cell (Tags multi-select)
-    const multiSelectCell = page.locator('[role="gridcell"][tabindex="0"]').nth(1);
+    const multiSelectCell = page.locator('[role="gridcell"][data-col]').nth(1);
     await expect(multiSelectCell).toBeVisible({ timeout: 10_000 });
     await multiSelectCell.click();
 
@@ -268,7 +268,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await page.waitForTimeout(1_500);
 
     // Re-click to create the second tag
-    const multiSelectCellAgain = page.locator('[role="gridcell"][tabindex="0"]').nth(1);
+    const multiSelectCellAgain = page.locator('[role="gridcell"][data-col]').nth(1);
     await expect(multiSelectCellAgain).toBeVisible({ timeout: 5_000 });
     await multiSelectCellAgain.click();
 
@@ -287,7 +287,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
 
     // Click the multi-select cell to verify options persisted
-    const reloadedCell = page.locator('[role="gridcell"][tabindex="0"]').nth(1);
+    const reloadedCell = page.locator('[role="gridcell"][data-col]').nth(1);
     await expect(reloadedCell).toBeVisible({ timeout: 10_000 });
     await reloadedCell.click();
 
@@ -309,7 +309,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await navigateToDatabase(page);
 
     // Create a new option in the select cell
-    const selectCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    const selectCell = page.locator('[role="gridcell"][data-col]').first();
     await expect(selectCell).toBeVisible({ timeout: 10_000 });
     await selectCell.click();
 
@@ -343,7 +343,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await navigateToDatabase(page);
 
     // Click the select cell to open the dropdown
-    const selectCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    const selectCell = page.locator('[role="gridcell"][data-col]').first();
     await expect(selectCell).toBeVisible({ timeout: 10_000 });
     await selectCell.click();
 
@@ -376,7 +376,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await navigateToDatabase(page);
 
     // Click the multi-select cell
-    const multiSelectCell = page.locator('[role="gridcell"][tabindex="0"]').nth(1);
+    const multiSelectCell = page.locator('[role="gridcell"][data-col]').nth(1);
     await expect(multiSelectCell).toBeVisible({ timeout: 10_000 });
     await multiSelectCell.click();
 
@@ -413,7 +413,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await navigateToDatabase(page);
 
     // Click the select cell to open the dropdown
-    const selectCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    const selectCell = page.locator('[role="gridcell"][data-col]').first();
     await expect(selectCell).toBeVisible({ timeout: 10_000 });
     await selectCell.click();
 
@@ -428,7 +428,7 @@ test.describe("Select/Multi-select option persistence", () => {
 
     // Wait for persistence, then re-open the dropdown
     await page.waitForTimeout(1_500);
-    const selectCellAgain = page.locator('[role="gridcell"][tabindex="0"]').first();
+    const selectCellAgain = page.locator('[role="gridcell"][data-col]').first();
     await expect(selectCellAgain).toBeVisible({ timeout: 5_000 });
     await selectCellAgain.click();
 
@@ -457,7 +457,7 @@ test.describe("Select/Multi-select option persistence", () => {
     await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
 
     // Re-open the dropdown and check the option has a red color
-    const reloadedCell = page.locator('[role="gridcell"][tabindex="0"]').first();
+    const reloadedCell = page.locator('[role="gridcell"][data-col]').first();
     await expect(reloadedCell).toBeVisible({ timeout: 10_000 });
     await reloadedCell.click();
 

--- a/e2e/database-table-keyboard.spec.ts
+++ b/e2e/database-table-keyboard.spec.ts
@@ -1,0 +1,273 @@
+import { test, expect } from "./fixtures/auth";
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Admin client for cleanup
+// ---------------------------------------------------------------------------
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+const createdDatabaseIds: string[] = [];
+
+test.afterAll(async () => {
+  if (createdDatabaseIds.length === 0) return;
+  const admin = getAdminClient();
+  for (const id of createdDatabaseIds) {
+    await admin.from("pages").delete().eq("parent_id", id);
+    await admin.from("pages").delete().eq("id", id);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function waitForSidebarTree(page: import("@playwright/test").Page) {
+  const sidebar = page.getByRole("complementary");
+  const treeLoaded = sidebar
+    .locator('[role="treeitem"], :text("No pages yet")')
+    .first();
+  await expect(treeLoaded).toBeVisible({ timeout: 15_000 });
+  return sidebar;
+}
+
+async function createDatabaseFromSidebar(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  const sidebar = await waitForSidebarTree(page);
+
+  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
+  await newDbBtn.click();
+
+  await page.waitForURL(
+    (url) => url.pathname.split("/").filter(Boolean).length >= 2,
+    { timeout: 15_000 },
+  );
+
+  const dbLoaded = page
+    .locator('[role="grid"], :text("No rows yet")')
+    .first();
+  await expect(dbLoaded).toBeVisible({ timeout: 15_000 });
+
+  const pathParts = new URL(page.url()).pathname.split("/").filter(Boolean);
+  const pageId = pathParts[pathParts.length - 1];
+  createdDatabaseIds.push(pageId);
+  return pageId;
+}
+
+async function addColumnViaTypePicker(
+  page: import("@playwright/test").Page,
+  typeName = "Text",
+) {
+  const addColumnBtn = page.locator('button[aria-label="Add column"]');
+  await expect(addColumnBtn).toBeVisible({ timeout: 5_000 });
+  await addColumnBtn.click();
+
+  const menuItem = page.getByRole("menuitem", { name: typeName });
+  await expect(menuItem).toBeVisible({ timeout: 5_000 });
+  await menuItem.click();
+
+  await page.waitForTimeout(1_500);
+}
+
+/**
+ * Set up a database with 2 rows and 2 property columns (Text + Number).
+ */
+async function setupGridWith2x2(page: import("@playwright/test").Page) {
+  await createDatabaseFromSidebar(page);
+
+  // Add first row
+  const addRowBtn = page.locator("button", { hasText: "+ New" });
+  await expect(addRowBtn).toBeVisible({ timeout: 10_000 });
+  await addRowBtn.click();
+
+  // Wait for grid
+  await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 10_000 });
+
+  // Add second row
+  await addRowBtn.click();
+  await page.waitForTimeout(1_000);
+
+  // Add Text column
+  await addColumnViaTypePicker(page, "Text");
+
+  // Add Number column
+  await addColumnViaTypePicker(page, "Number");
+}
+
+function getCell(page: import("@playwright/test").Page, row: number, col: number) {
+  return page.locator(`[data-row="${row}"][data-col="${col}"]`);
+}
+
+/**
+ * Enter focused (non-editing) mode on a cell by clicking it (starts editing)
+ * then pressing Escape (exits editing, enters focused navigation mode).
+ */
+async function focusCell(page: import("@playwright/test").Page, row: number, col: number) {
+  const cell = getCell(page, row, col);
+  await cell.click();
+  // Click starts editing — press Escape to exit editing and enter focused mode
+  await page.keyboard.press("Escape");
+  await expect(cell).toBeFocused({ timeout: 3_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Database table keyboard navigation", () => {
+  test("arrow keys navigate between cells in focused mode", async ({
+    authenticatedPage: page,
+  }) => {
+    await setupGridWith2x2(page);
+
+    // Enter focused mode on first property cell (row 0, col 0)
+    await focusCell(page, 0, 0);
+
+    // Press ArrowDown — should move to row 1, col 0
+    await page.keyboard.press("ArrowDown");
+    const cellBelow = getCell(page, 1, 0);
+    await expect(cellBelow).toBeFocused({ timeout: 3_000 });
+
+    // Press ArrowRight — should move to row 1, col 1
+    await page.keyboard.press("ArrowRight");
+    const cellRight = getCell(page, 1, 1);
+    await expect(cellRight).toBeFocused({ timeout: 3_000 });
+
+    // Press ArrowUp — should move to row 0, col 1
+    await page.keyboard.press("ArrowUp");
+    const cellAbove = getCell(page, 0, 1);
+    await expect(cellAbove).toBeFocused({ timeout: 3_000 });
+
+    // Press ArrowLeft — should move to row 0, col 0
+    await page.keyboard.press("ArrowLeft");
+    const firstCell = getCell(page, 0, 0);
+    await expect(firstCell).toBeFocused({ timeout: 3_000 });
+  });
+
+  test("Enter starts editing from focused mode, Escape returns to focused mode", async ({
+    authenticatedPage: page,
+  }) => {
+    await setupGridWith2x2(page);
+
+    // Enter focused mode
+    await focusCell(page, 0, 0);
+
+    // Press Enter to start editing
+    await page.keyboard.press("Enter");
+
+    // An input should appear
+    const cellInput = page.locator(
+      '[role="gridcell"] input[type="text"], [role="gridcell"] input[type="number"]',
+    );
+    await expect(cellInput.first()).toBeVisible({ timeout: 5_000 });
+
+    // Press Escape to exit editing — should return to focused mode on same cell
+    await page.keyboard.press("Escape");
+    const firstCell = getCell(page, 0, 0);
+    await expect(firstCell).toBeFocused({ timeout: 3_000 });
+
+    // The input should no longer be visible
+    await expect(cellInput).not.toBeVisible({ timeout: 3_000 });
+  });
+
+  test("Enter while editing commits and moves focus down", async ({
+    authenticatedPage: page,
+  }) => {
+    await setupGridWith2x2(page);
+
+    // Enter focused mode then start editing
+    await focusCell(page, 0, 0);
+    await page.keyboard.press("Enter");
+
+    const cellInput = page.locator(
+      '[role="gridcell"] input[type="text"], [role="gridcell"] input[type="number"]',
+    );
+    await expect(cellInput.first()).toBeVisible({ timeout: 5_000 });
+
+    // Type a value and press Enter to commit
+    await cellInput.first().fill("Hello");
+    await page.keyboard.press("Enter");
+
+    // Focus should move to the cell below (row 1, col 0)
+    const cellBelow = getCell(page, 1, 0);
+    await expect(cellBelow).toBeFocused({ timeout: 3_000 });
+  });
+
+  test("ArrowRight wraps to next row, ArrowLeft wraps to previous row", async ({
+    authenticatedPage: page,
+  }) => {
+    await setupGridWith2x2(page);
+
+    // Grid has 3 property columns: Title (0), Text (1), Number (2)
+    // Focus (0, 0) then navigate right to reach the last column (0, 2)
+    await focusCell(page, 0, 0);
+    await page.keyboard.press("ArrowRight"); // → (0, 1)
+    await page.keyboard.press("ArrowRight"); // → (0, 2)
+    const lastColFirstRow = getCell(page, 0, 2);
+    await expect(lastColFirstRow).toBeFocused({ timeout: 3_000 });
+
+    // Press ArrowRight — should wrap to first column of next row (row 1, col 0)
+    await page.keyboard.press("ArrowRight");
+    const firstColSecondRow = getCell(page, 1, 0);
+    await expect(firstColSecondRow).toBeFocused({ timeout: 3_000 });
+
+    // Press ArrowLeft — should wrap back to last column of previous row (row 0, col 2)
+    await page.keyboard.press("ArrowLeft");
+    await expect(lastColFirstRow).toBeFocused({ timeout: 3_000 });
+  });
+
+  test("navigation stops at grid boundaries", async ({
+    authenticatedPage: page,
+  }) => {
+    await setupGridWith2x2(page);
+
+    // Grid has 3 property columns: Title (0), Text (1), Number (2)
+    // Focus the first cell (row 0, col 0)
+    await focusCell(page, 0, 0);
+
+    // Press ArrowUp at top row — should stay on same cell
+    await page.keyboard.press("ArrowUp");
+    const firstCell = getCell(page, 0, 0);
+    await expect(firstCell).toBeFocused({ timeout: 3_000 });
+
+    // Navigate to last cell (row 1, col 2) using arrow keys
+    await page.keyboard.press("ArrowDown");  // → (1, 0)
+    await page.keyboard.press("ArrowRight"); // → (1, 1)
+    await page.keyboard.press("ArrowRight"); // → (1, 2)
+    const lastCell = getCell(page, 1, 2);
+    await expect(lastCell).toBeFocused({ timeout: 3_000 });
+
+    // Press ArrowDown at bottom row — should stay on same cell
+    await page.keyboard.press("ArrowDown");
+    await expect(lastCell).toBeFocused({ timeout: 3_000 });
+
+    // Press ArrowRight at last column of last row — should stay (boundary)
+    await page.keyboard.press("ArrowRight");
+    await expect(lastCell).toBeFocused({ timeout: 3_000 });
+  });
+
+  test("Escape from focused mode clears focus", async ({
+    authenticatedPage: page,
+  }) => {
+    await setupGridWith2x2(page);
+
+    // Enter focused mode
+    await focusCell(page, 0, 0);
+    const firstCell = getCell(page, 0, 0);
+    await expect(firstCell).toBeFocused({ timeout: 3_000 });
+
+    // Press Escape — should clear focus
+    await page.keyboard.press("Escape");
+
+    // The cell should no longer be focused
+    await expect(firstCell).not.toBeFocused({ timeout: 3_000 });
+  });
+});

--- a/e2e/database-views.spec.ts
+++ b/e2e/database-views.spec.ts
@@ -89,7 +89,7 @@ async function fillCell(
   cellIndex: number,
   value: string,
 ) {
-  const cell = page.locator('[role="gridcell"][tabindex="0"]').nth(cellIndex);
+  const cell = page.locator('[role="gridcell"][data-col]').nth(cellIndex);
   await cell.click();
   const cellInput = page.locator(
     '[role="gridcell"] input[type="text"], [role="gridcell"] input[type="number"]',
@@ -134,7 +134,7 @@ function prop2Cell(
   page: import("@playwright/test").Page,
   rowIndex: number,
 ) {
-  return page.locator('[role="gridcell"][tabindex="0"]').nth(rowIndex * 2 + 1);
+  return page.locator('[role="gridcell"][data-col]').nth(rowIndex * 2 + 1);
 }
 
 /**

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -121,12 +121,17 @@ export interface TableViewProps {
 }
 
 // ---------------------------------------------------------------------------
-// Editing state
+// Editing / focus state
 // ---------------------------------------------------------------------------
 
 interface EditingCell {
   rowId: string;
   propertyId: string;
+}
+
+interface FocusedCell {
+  rowIndex: number;
+  colIndex: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -189,6 +194,10 @@ export const TableView = memo(function TableView({
 
   // Editing state
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
+
+  // Focused cell state (navigation without editing)
+  const [focusedCell, setFocusedCell] = useState<FocusedCell | null>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
 
   // Resize state
   const [resizingColumn, setResizingColumn] = useState<string | null>(null);
@@ -335,21 +344,84 @@ export const TableView = memo(function TableView({
 
   const startEditing = useCallback((rowId: string, propertyId: string) => {
     setEditingCell({ rowId, propertyId });
+    setFocusedCell(null);
   }, []);
 
   const stopEditing = useCallback(() => {
     setEditingCell(null);
   }, []);
 
+  // Focus a cell in the DOM by its grid coordinates.
+  const focusCellElement = useCallback(
+    (rowIndex: number, colIndex: number) => {
+      if (!gridRef.current) return;
+      const selector = `[data-row="${rowIndex}"][data-col="${colIndex}"]`;
+      const el = gridRef.current.querySelector<HTMLElement>(selector);
+      if (el) {
+        el.focus();
+      }
+    },
+    [],
+  );
+
+  // Navigate to a specific cell. Clamps to grid boundaries.
+  const navigateToCell = useCallback(
+    (rowIndex: number, colIndex: number) => {
+      if (rows.length === 0 || visibleProperties.length === 0) return;
+      if (rowIndex < 0 || rowIndex >= rows.length) return;
+      if (colIndex < 0 || colIndex >= visibleProperties.length) return;
+      setFocusedCell({ rowIndex, colIndex });
+      setEditingCell(null);
+    },
+    [rows, visibleProperties],
+  );
+
+  // Move focus with horizontal wrapping across rows. Stays put at grid edges.
+  const moveFocus = useCallback(
+    (fromRow: number, fromCol: number, dRow: number, dCol: number) => {
+      const totalCols = visibleProperties.length;
+      let nextRow = fromRow + dRow;
+      let nextCol = fromCol + dCol;
+
+      // Horizontal wrapping
+      if (nextCol >= totalCols) {
+        nextCol = 0;
+        nextRow = nextRow + 1;
+      } else if (nextCol < 0) {
+        nextCol = totalCols - 1;
+        nextRow = nextRow - 1;
+      }
+
+      // At grid boundary — re-focus current cell to prevent focus drift
+      if (nextRow < 0 || nextRow >= rows.length || nextCol < 0 || nextCol >= totalCols) {
+        focusCellElement(fromRow, fromCol);
+        return;
+      }
+
+      navigateToCell(nextRow, nextCol);
+    },
+    [visibleProperties, rows, navigateToCell, focusCellElement],
+  );
+
+  // Keyboard handler for cells in editing mode
   const handleCellKeyDown = useCallback(
     (e: React.KeyboardEvent, rowIndex: number, colIndex: number) => {
       if (e.key === "Escape") {
-        stopEditing();
+        // Exit edit mode, return to focused navigation mode
+        setEditingCell(null);
+        setFocusedCell({ rowIndex, colIndex });
         return;
       }
 
       if (e.key === "Enter") {
+        // Commit edit and move focus down one row (spreadsheet convention)
         stopEditing();
+        const nextRow = rowIndex + 1;
+        if (nextRow < rows.length) {
+          setFocusedCell({ rowIndex: nextRow, colIndex });
+        } else {
+          setFocusedCell({ rowIndex, colIndex });
+        }
         return;
       }
 
@@ -377,12 +449,95 @@ export const TableView = memo(function TableView({
     [visibleProperties, rows, startEditing, stopEditing],
   );
 
+  // Keyboard handler for cells in focused (non-editing) mode
+  const handleFocusedCellKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!focusedCell) return;
+      const { rowIndex, colIndex } = focusedCell;
+
+      switch (e.key) {
+        case "ArrowUp":
+          e.preventDefault();
+          if (rowIndex - 1 >= 0) {
+            navigateToCell(rowIndex - 1, colIndex);
+          } else {
+            focusCellElement(rowIndex, colIndex);
+          }
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          if (rowIndex + 1 < rows.length) {
+            navigateToCell(rowIndex + 1, colIndex);
+          } else {
+            focusCellElement(rowIndex, colIndex);
+          }
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          moveFocus(rowIndex, colIndex, 0, -1);
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          moveFocus(rowIndex, colIndex, 0, 1);
+          break;
+        case "Enter": {
+          e.preventDefault();
+          // Start editing the focused cell
+          const prop = visibleProperties[colIndex];
+          const row = rows[rowIndex];
+          if (prop && row) {
+            const isReadOnly =
+              prop.type === "formula" ||
+              prop.type === "created_time" ||
+              prop.type === "updated_time" ||
+              prop.type === "created_by";
+            if (!isReadOnly) {
+              startEditing(row.page.id, prop.id);
+            }
+          }
+          break;
+        }
+        case "Escape":
+          e.preventDefault();
+          setFocusedCell(null);
+          // Blur the active element so DOM focus leaves the grid
+          if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur();
+          }
+          break;
+        case "Tab": {
+          e.preventDefault();
+          const direction = e.shiftKey ? -1 : 1;
+          moveFocus(rowIndex, colIndex, 0, direction);
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [focusedCell, visibleProperties, rows, navigateToCell, moveFocus, startEditing],
+  );
+
+  // Focus the DOM element when focusedCell changes
+  useEffect(() => {
+    if (!focusedCell) return;
+    focusCellElement(focusedCell.rowIndex, focusedCell.colIndex);
+  }, [focusedCell, focusCellElement]);
+
   const handleCellBlur = useCallback(
     (rowId: string, propertyId: string, newValue: Record<string, unknown>) => {
       onCellUpdate?.(rowId, propertyId, newValue);
       stopEditing();
     },
     [onCellUpdate, stopEditing],
+  );
+
+  // When a cell is clicked in non-editing mode, set it as focused
+  const handleCellFocus = useCallback(
+    (rowIndex: number, colIndex: number) => {
+      setFocusedCell({ rowIndex, colIndex });
+    },
+    [],
   );
 
   // --- Loading skeleton ---
@@ -469,10 +624,12 @@ export const TableView = memo(function TableView({
   return (
     <div className="w-full overflow-x-auto">
       <div
+        ref={gridRef}
         className="grid w-max min-w-full"
         style={{ gridTemplateColumns }}
         role="grid"
         aria-label="Database table"
+        onKeyDown={handleFocusedCellKeyDown}
       >
         {/* --- Header row --- */}
         <div
@@ -610,9 +767,11 @@ export const TableView = memo(function TableView({
             rowHeightClass={rowHeightClass}
             workspaceSlug={workspaceSlug}
             editingCell={editingCell}
+            focusedCell={focusedCell}
             onStartEditing={startEditing}
             onCellKeyDown={handleCellKeyDown}
             onCellBlur={handleCellBlur}
+            onCellFocus={handleCellFocus}
             onDeleteRow={onDeleteRow}
           />
         ))}
@@ -644,9 +803,11 @@ interface TableRowProps {
   rowHeightClass: string;
   workspaceSlug: string;
   editingCell: EditingCell | null;
+  focusedCell: FocusedCell | null;
   onStartEditing: (rowId: string, propertyId: string) => void;
   onCellKeyDown: (e: React.KeyboardEvent, rowIndex: number, colIndex: number) => void;
   onCellBlur: (rowId: string, propertyId: string, newValue: Record<string, unknown>) => void;
+  onCellFocus: (rowIndex: number, colIndex: number) => void;
   onDeleteRow?: (rowId: string) => void;
 }
 
@@ -658,9 +819,11 @@ function TableRow({
   rowHeightClass,
   workspaceSlug,
   editingCell,
+  focusedCell,
   onStartEditing,
   onCellKeyDown,
   onCellBlur,
+  onCellFocus,
   onDeleteRow,
 }: TableRowProps) {
   return (
@@ -697,6 +860,9 @@ function TableRow({
         const isEditing =
           editingCell?.rowId === row.page.id &&
           editingCell?.propertyId === prop.id;
+        const isFocused =
+          focusedCell?.rowIndex === rowIndex &&
+          focusedCell?.colIndex === colIndex;
 
         // Computed types derive values from page metadata, not row_values.
         // Formula types evaluate expressions against the row's property values.
@@ -720,12 +886,14 @@ function TableRow({
             value={cellValue}
             computedValue={computedValue}
             isEditing={isEditing}
+            isFocused={isFocused}
             rowHeightClass={rowHeightClass}
             rowIndex={rowIndex}
             colIndex={colIndex}
             onStartEditing={onStartEditing}
             onKeyDown={onCellKeyDown}
             onBlur={onCellBlur}
+            onFocus={onCellFocus}
           />
         );
       })}
@@ -755,12 +923,14 @@ interface TableCellProps {
   /** Synthetic value for computed types (created_time, updated_time, created_by). */
   computedValue?: Record<string, unknown>;
   isEditing: boolean;
+  isFocused: boolean;
   rowHeightClass: string;
   rowIndex: number;
   colIndex: number;
   onStartEditing: (rowId: string, propertyId: string) => void;
   onKeyDown: (e: React.KeyboardEvent, rowIndex: number, colIndex: number) => void;
   onBlur: (rowId: string, propertyId: string, newValue: Record<string, unknown>) => void;
+  onFocus: (rowIndex: number, colIndex: number) => void;
 }
 
 function TableCell({
@@ -771,12 +941,14 @@ function TableCell({
   value,
   computedValue,
   isEditing,
+  isFocused,
   rowHeightClass,
   rowIndex,
   colIndex,
   onStartEditing,
   onKeyDown,
   onBlur,
+  onFocus,
 }: TableCellProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const displayValue = extractDisplayValue(value, propertyType);
@@ -855,9 +1027,14 @@ function TableCell({
       <div
         className={cn(
           "flex items-center justify-center border-b border-overlay-border p-2 hover:bg-overlay-subtle",
+          isFocused && "ring-1 ring-inset ring-ring",
           rowHeightClass,
         )}
         role="gridcell"
+        data-row={rowIndex}
+        data-col={colIndex}
+        tabIndex={isFocused ? 0 : -1}
+        onFocus={() => onFocus(rowIndex, colIndex)}
       >
         <button
           type="button"
@@ -896,9 +1073,14 @@ function TableCell({
           className={cn(
             "flex items-center border-b border-overlay-border p-2",
             "cursor-default",
+            isFocused && "ring-1 ring-inset ring-ring",
             rowHeightClass,
           )}
           role="gridcell"
+          data-row={rowIndex}
+          data-col={colIndex}
+          tabIndex={isFocused ? 0 : -1}
+          onFocus={() => onFocus(rowIndex, colIndex)}
         >
           <Renderer value={computedValue} property={property} />
         </div>
@@ -911,21 +1093,15 @@ function TableCell({
       className={cn(
         "flex items-center border-b border-overlay-border p-2 hover:bg-overlay-subtle",
         isReadOnly ? "cursor-default" : "cursor-text",
+        isFocused && "ring-1 ring-inset ring-ring",
         rowHeightClass,
       )}
       role="gridcell"
+      data-row={rowIndex}
+      data-col={colIndex}
+      tabIndex={isFocused ? 0 : -1}
       onClick={isReadOnly ? undefined : () => onStartEditing(rowId, propertyId)}
-      onKeyDown={
-        isReadOnly
-          ? undefined
-          : (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onStartEditing(rowId, propertyId);
-              }
-            }
-      }
-      tabIndex={isReadOnly ? undefined : 0}
+      onFocus={() => onFocus(rowIndex, colIndex)}
     >
       <CellRenderer
         value={value}


### PR DESCRIPTION
Closes #660

## What

Adds spreadsheet-style arrow key navigation to the database table view. Users can now navigate between cells using Arrow Up/Down/Left/Right without entering edit mode.

## How

- Added `FocusedCell` state (`{ rowIndex, colIndex }`) parallel to the existing `editingCell` state
- Implemented `handleFocusedCellKeyDown` on the grid container for arrow key navigation in focused (non-editing) mode
- Added roving tabindex pattern: focused cell gets `tabIndex={0}`, others get `tabIndex={-1}`
- Added `data-row` and `data-col` attributes to all property cells for DOM element lookup
- Visual focus indicator: `ring-1 ring-inset ring-ring` on the focused cell

### Navigation behavior

- **Arrow Up/Down**: Move vertically, stop at grid boundaries
- **Arrow Left/Right**: Move horizontally with row wrapping (right on last column → first column of next row)
- **Enter** (focused): Start editing the cell
- **Enter** (editing): Commit value and move focus down one row
- **Escape** (editing): Exit edit mode, return to focused navigation mode
- **Escape** (focused): Clear focus entirely
- **Tab** (editing): Preserved existing behavior — move to next/previous cell while editing

### Existing behavior preserved

- Click-to-edit still works (clicking a cell starts editing immediately)
- Tab navigation while editing is unchanged
- Column resize, drag-and-drop reorder, sort indicators all unaffected

## Testing

- 6 new E2E tests in `e2e/database-table-keyboard.spec.ts`:
  - Arrow key navigation between cells
  - Enter to start/commit editing, Escape to return to focused mode
  - Enter while editing commits and moves focus down
  - Horizontal wrapping across rows
  - Boundary stops at grid edges
  - Escape from focused mode clears focus
- Updated existing E2E selectors from `[tabindex="0"]` to `[data-col]` to match roving tabindex pattern
- `pnpm lint && pnpm typecheck && pnpm test` pass (0 errors, 823 unit tests)
- Existing database E2E tests pass (database-crud, database-select-options, database-views, database-row-page)