### PR TITLE
fix: eliminate skeleton layout shift during page navigation (#666)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/[pageId]/loading.test.ts
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/loading.test.ts
@@ -45,4 +45,12 @@ describe("[pageId] route loading state", () => {
     // The auth check and workspace lookup should run in parallel
     expect(page).toContain("Promise.all");
   });
+
+  it("page.tsx does not use dynamic() with loading fallbacks (#666)", () => {
+    const page = readFileSync(resolve(PAGE_DIR, "page.tsx"), "utf-8");
+    // Convention: view components must be imported directly, not via dynamic().
+    // dynamic() loading fallbacks create a second skeleton that shifts after
+    // loading.tsx, causing visible layout jank during navigation.
+    expect(page).not.toMatch(/\bdynamic\b/);
+  });
 });

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import dynamic from "next/dynamic";
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
 import { captureSupabaseError } from "@/lib/sentry";
@@ -11,82 +10,10 @@ import {
   type BreadcrumbItem,
 } from "@/components/page-breadcrumb";
 import { PageBacklinks } from "@/components/page-backlinks";
+import { PageViewClient } from "@/components/page-view-client";
+import { RowPropertiesHeader } from "@/components/database/row-properties-header";
+import { DatabaseViewClient } from "@/components/database/database-view-client";
 import type { DatabaseProperty, RowValue } from "@/lib/types";
-
-const PageViewClient = dynamic(
-  () =>
-    import("@/components/page-view-client").then((mod) => mod.PageViewClient),
-  {
-    loading: () => (
-      <>
-        <div className="flex items-start gap-2">
-          <div className="min-w-0 flex-1">
-            <div className="h-9 w-1/3 animate-pulse bg-muted" />
-          </div>
-          <div className="h-8 w-8 animate-pulse bg-muted" />
-        </div>
-        <div className="mt-4 space-y-3">
-          <div className="h-4 w-full animate-pulse bg-muted" />
-          <div className="h-4 w-5/6 animate-pulse bg-muted" />
-          <div className="h-4 w-4/6 animate-pulse bg-muted" />
-        </div>
-      </>
-    ),
-  },
-);
-
-const RowPropertiesHeader = dynamic(
-  () =>
-    import("@/components/database/row-properties-header").then(
-      (mod) => mod.RowPropertiesHeader,
-    ),
-  {
-    loading: () => (
-      <div className="mb-4 space-y-2">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-4">
-            <div className="h-4 w-32 animate-pulse bg-muted" />
-            <div className="h-4 w-48 animate-pulse bg-muted" />
-          </div>
-        ))}
-      </div>
-    ),
-  },
-);
-
-const DatabaseViewClient = dynamic(
-  () =>
-    import("@/components/database/database-view-client").then(
-      (mod) => mod.DatabaseViewClient,
-    ),
-  {
-    loading: () => (
-      <>
-        <div className="flex items-start gap-2">
-          <div className="min-w-0 flex-1">
-            <div className="h-9 w-1/3 animate-pulse bg-muted" />
-          </div>
-        </div>
-        <div className="mt-6 space-y-3">
-          <div className="flex items-center gap-2 border-b border-overlay-border pb-2">
-            <div className="h-5 w-20 animate-pulse bg-muted" />
-            <div className="h-5 w-20 animate-pulse bg-muted" />
-          </div>
-          <div className="space-y-2">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="flex gap-2">
-                <div className="h-10 w-1/4 animate-pulse bg-muted" />
-                <div className="h-10 w-1/4 animate-pulse bg-muted" />
-                <div className="h-10 w-1/4 animate-pulse bg-muted" />
-                <div className="h-10 w-1/4 animate-pulse bg-muted" />
-              </div>
-            ))}
-          </div>
-        </div>
-      </>
-    ),
-  },
-);
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
Closes #666

## What

When navigating to a page, two different skeletons rendered in sequence — `loading.tsx` showed one layout, then `dynamic()` loading fallbacks in `page.tsx` showed a different layout before the actual content appeared. This caused a visible layout shift/jank during every page navigation. Database pages were especially affected since `loading.tsx` rendered a narrow regular-page skeleton while the database view is full-width with a table grid.

## How

Replaced `dynamic()` imports with direct imports for `PageViewClient`, `DatabaseViewClient`, and `RowPropertiesHeader` in the `[pageId]` page route. The `dynamic()` wrappers were used for code-splitting but didn't use `ssr: false` — they were unnecessary since the server component already has all data when it renders. Inner `dynamic()` imports within the client components (e.g., `Editor` with `ssr: false`, `PageMenu`) remain unchanged as they handle browser-only code splitting without causing page-level layout shifts.

The loading flow is now: `loading.tsx` skeleton → actual content (single transition, no intermediate skeleton).

## Testing

- Added regression test in `loading.test.ts` verifying `page.tsx` does not use `dynamic()` imports (which would reintroduce the double-skeleton problem)
- All existing unit tests pass (828/828)
- All page and database E2E tests pass (page-crud, database-crud, database-row-page, database-board, database-calendar, database-inline, database-column-reorder)
- Lint and typecheck clean