### PR TITLE
fix(metrics): use date-filtered CI pass rate query

### DIFF
--- a/.ona/automations/daily-metrics.yaml
+++ b/.ona/automations/daily-metrics.yaml
@@ -107,9 +107,11 @@ action:
 
                 **CI pass rate:**
                 ```
-                gh run list --limit 20 --json conclusion
+                TOTAL=$(gh run list --created "YYYY-MM-DD" --limit 500 --json conclusion --jq 'length')
+                SUCCESS=$(gh run list --created "YYYY-MM-DD" --limit 500 --json conclusion --jq '[.[] | select(.conclusion == "success")] | length')
                 ```
-                Calculate: `round((success_count / total_count) * 100)`.
+                Replace YYYY-MM-DD with today's date.
+                Calculate: `round((SUCCESS / TOTAL) * 100)`. If TOTAL is 0, set to 100.
 
                 **GitHub Issues:**
                 ```


### PR DESCRIPTION
The daily metrics automation's CI pass rate calculation had three problems:

1. **Tiny sample size** — `--limit 20` missed most runs on busy days (300+ runs/day)
2. **No date filtering** — grabbed the 20 most recent runs at 9 AM UTC, missing earlier failures
3. **Inflated results** — reported 100% on days that were actually 94-98%

Replaces `gh run list --limit 20 --json conclusion` with a date-filtered query using `--created "YYYY-MM-DD" --limit 500` that captures all runs for the target day.

| Date | Old (reported) | Actual |
|------|---------------|--------|
| Apr 15 | 100% | 94.8% |
| Apr 21 | 90% | 97.8% |
| Apr 24 | 100% | 94.9% |