### PR TITLE
refactor: decompose database-view-client.tsx into focused hooks and sub-components (#670)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -285,7 +285,14 @@ Database page (is_database = true)
 
 ```
 src/components/database/
-  ├── database-view-client.tsx     # Main client component: loads data, manages view state
+  ├── database-view-client.tsx     # Main client component: loads data, composes hooks + JSX
+  ├── database-view-helpers.tsx    # ViewConfigDropdown, ComingSoonPlaceholder, DatabaseSkeleton
+  ├── delete-property-dialog.tsx   # Confirmation dialog for deleting a property
+  ├── hooks/
+  │   ├── use-database-views.ts    # View CRUD: add, rename, delete, duplicate, reorder, config
+  │   ├── use-database-rows.ts     # Row mutations: add, delete, cell update, card move
+  │   ├── use-database-properties.ts # Property CRUD: add, rename, delete, reorder + dialog state
+  │   └── use-database-filters.ts  # Sort/filter state and derived displayedRows
   ├── view-tabs.tsx                # Horizontal tab bar for switching views
   ├── filter-bar.tsx               # Active filter pills + add filter UI
   ├── sort-menu.tsx                # Sort configuration dropdown
@@ -433,7 +440,14 @@ src/
 │   │   ├── word-count-plugin.tsx    # Word count + reading time display below editor
 │   │   └── code-language-selector-plugin.tsx # Floating language picker for code blocks
 │   ├── database/                # Database views system
-│   │   ├── database-view-client.tsx     # Main client component: loads data, manages view state
+│   │   ├── database-view-client.tsx     # Main client component: loads data, composes hooks + JSX
+│   │   ├── database-view-helpers.tsx    # ViewConfigDropdown, ComingSoonPlaceholder, DatabaseSkeleton
+│   │   ├── delete-property-dialog.tsx   # Confirmation dialog for deleting a property
+│   │   ├── hooks/                       # Domain hooks extracted from database-view-client
+│   │   │   ├── use-database-views.ts    # View CRUD callbacks
+│   │   │   ├── use-database-rows.ts     # Row mutation callbacks
+│   │   │   ├── use-database-properties.ts # Property CRUD + dialog state
+│   │   │   └── use-database-filters.ts  # Sort/filter state + displayedRows
 │   │   ├── view-tabs.tsx                # Horizontal tab bar for switching views
 │   │   ├── filter-bar.tsx               # Active filter pills + add filter UI
 │   │   ├── sort-menu.tsx                # Sort configuration dropdown

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -1,70 +1,30 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
-import { toast } from "sonner";
 import type { SerializedEditorState } from "lexical";
 import { PageTitle } from "@/components/page-title";
 import { PageIcon } from "@/components/page-icon";
 import { PageCover } from "@/components/page-cover";
-import { ViewTabs, VIEW_TYPE_LABELS } from "@/components/database/view-tabs";
+import { ViewTabs } from "@/components/database/view-tabs";
 import { SortMenu } from "@/components/database/sort-menu";
 import { FilterBar } from "@/components/database/filter-bar";
 import { RenamePropertyDialog } from "@/components/database/rename-property-dialog";
+import { DeletePropertyDialog } from "@/components/database/delete-property-dialog";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { ChevronDown, Check } from "lucide-react";
-import {
-  sortRows,
-  filterRows,
-  type SortRule,
-  type FilterRule,
-} from "@/lib/database-filters";
-import {
-  addProperty,
-  addRow,
-  addView,
-  deleteProperty,
-  deleteView,
-  loadDatabase,
-  loadWorkspaceMembers,
-  reorderProperties,
-  reorderViews,
-  updateProperty,
-  updateRowValue,
-  updateView,
-} from "@/lib/database";
-import { createClient } from "@/lib/supabase/client";
-import {
-  captureSupabaseError,
-  isInsufficientPrivilegeError,
-} from "@/lib/sentry";
-import {
-  generateColumnName,
-  getDefaultColumnConfig,
-} from "@/lib/column-helpers";
+  ViewConfigDropdown,
+  ComingSoonPlaceholder,
+  DatabaseSkeleton,
+} from "@/components/database/database-view-helpers";
+import { loadDatabase, loadWorkspaceMembers } from "@/lib/database";
+import { useDatabaseViews } from "@/components/database/hooks/use-database-views";
+import { useDatabaseRows } from "@/components/database/hooks/use-database-rows";
+import { useDatabaseProperties } from "@/components/database/hooks/use-database-properties";
+import { useDatabaseFilters } from "@/components/database/hooks/use-database-filters";
 import type {
   DatabaseProperty,
   DatabaseRow,
   DatabaseView,
-  DatabaseViewConfig,
-  DatabaseViewType,
-  PropertyType,
 } from "@/lib/types";
 
 // Dynamically import view components to code-split database view types.
@@ -134,103 +94,6 @@ export interface DatabaseViewClientProps {
 }
 
 // ---------------------------------------------------------------------------
-// ViewConfigDropdown — toolbar dropdown for selecting a property (group_by, date_property)
-// ---------------------------------------------------------------------------
-
-interface ViewConfigDropdownProps {
-  label: string;
-  selectedId: string | null;
-  options: DatabaseProperty[];
-  onSelect: (propertyId: string) => void;
-}
-
-function ViewConfigDropdown({
-  label,
-  selectedId,
-  options,
-  onSelect,
-}: ViewConfigDropdownProps) {
-  const selectedName = options.find((p) => p.id === selectedId)?.name;
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        className="inline-flex h-7 items-center gap-1 rounded-sm px-2 text-xs text-muted-foreground outline-none transition-colors hover:bg-overlay-border hover:text-foreground"
-        data-testid={`view-config-${label.toLowerCase().replace(/\s+/g, "-")}`}
-      >
-        {label}: {selectedName ?? "None"}
-        <ChevronDown className="size-3" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {options.length === 0 ? (
-          <div className="px-2 py-1.5 text-xs text-muted-foreground">
-            No matching properties
-          </div>
-        ) : (
-          options.map((prop) => (
-            <DropdownMenuItem
-              key={prop.id}
-              onClick={() => onSelect(prop.id)}
-              className="gap-2 text-xs"
-            >
-              {prop.id === selectedId && <Check className="size-3" />}
-              {prop.id !== selectedId && <span className="size-3" />}
-              {prop.name}
-            </DropdownMenuItem>
-          ))
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Coming Soon placeholder for non-table view types
-// ---------------------------------------------------------------------------
-
-function ComingSoonPlaceholder({ viewType }: { viewType: DatabaseViewType }) {
-  return (
-    <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
-      {viewType.charAt(0).toUpperCase() + viewType.slice(1)} view coming soon
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Loading skeleton
-// ---------------------------------------------------------------------------
-
-function DatabaseSkeleton() {
-  return (
-    <div className="space-y-3">
-      {/* View tabs skeleton */}
-      <div className="flex items-center gap-2 border-b border-overlay-border pb-2">
-        <div className="h-5 w-20 animate-pulse bg-muted" />
-        <div className="h-5 w-20 animate-pulse bg-muted" />
-        <div className="h-5 w-20 animate-pulse bg-muted" />
-      </div>
-      {/* Table skeleton */}
-      <div className="space-y-2">
-        <div className="flex gap-2">
-          <div className="h-8 w-1/4 animate-pulse bg-muted" />
-          <div className="h-8 w-1/4 animate-pulse bg-muted" />
-          <div className="h-8 w-1/4 animate-pulse bg-muted" />
-          <div className="h-8 w-1/4 animate-pulse bg-muted" />
-        </div>
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="flex gap-2">
-            <div className="h-10 w-1/4 animate-pulse bg-muted" />
-            <div className="h-10 w-1/4 animate-pulse bg-muted" />
-            <div className="h-10 w-1/4 animate-pulse bg-muted" />
-            <div className="h-10 w-1/4 animate-pulse bg-muted" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // DatabaseViewClient
 // ---------------------------------------------------------------------------
 
@@ -246,7 +109,6 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     userId,
     initialData,
   } = props;
-  const searchParams = useSearchParams();
 
   // Database data state — seed from server-prefetched data when available
   const hasInitialData = initialData != null;
@@ -258,37 +120,6 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
   );
   const [rows, setRows] = useState<DatabaseRow[]>(initialData?.rows ?? []);
   const [loading, setLoading] = useState(!hasInitialData);
-
-  // Rename property dialog state
-  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
-  const [renamingProperty, setRenamingProperty] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
-
-  // Delete property confirmation state
-  const [deletingProperty, setDeletingProperty] = useState<{
-    id: string;
-    name: string;
-  } | null>(null);
-
-  // Guard against concurrent addProperty calls (e.g. rapid double-click)
-  const isAddingColumn = useRef(false);
-
-  // Active view: from URL ?view= param, or first view by position
-  const viewIdFromUrl = searchParams.get("view");
-
-  const activeViewId = useMemo(() => {
-    if (viewIdFromUrl && views.some((v) => v.id === viewIdFromUrl)) {
-      return viewIdFromUrl;
-    }
-    return views[0]?.id ?? "";
-  }, [viewIdFromUrl, views]);
-
-  const activeView = useMemo(
-    () => views.find((v) => v.id === activeViewId),
-    [views, activeViewId],
-  );
 
   // Load database data and workspace members on mount (skipped when
   // server-prefetched initialData is provided — eliminates the second
@@ -333,573 +164,56 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     };
   }, [pageId, workspaceId, hasInitialData]);
 
-  // Handle view tab change — update URL ?view= param without server round-trip
-  const handleViewChange = useCallback(
-    (viewId: string) => {
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("view", viewId);
-      window.history.replaceState(null, "", `?${params.toString()}`);
-    },
-    [searchParams],
-  );
+  // --- Hooks ---
 
-  // Create a new view with sensible defaults per type
-  const handleAddView = useCallback(
-    async (type: DatabaseViewType) => {
-      const name = `${VIEW_TYPE_LABELS[type]} view`;
+  const {
+    activeViewId,
+    activeView,
+    handleViewChange,
+    handleAddView,
+    handleViewConfigChange,
+    handleRenameView,
+    handleDeleteView,
+    handleDuplicateView,
+    handleReorderViews,
+  } = useDatabaseViews({ pageId, properties, views, setViews });
 
-      // Auto-detect a default config property for board and calendar views
-      let config: DatabaseViewConfig = {};
-      if (type === "board") {
-        const firstGroupable = properties.find((p) => p.type === "select" || p.type === "status");
-        if (firstGroupable) {
-          config = { group_by: firstGroupable.id };
-        }
-      } else if (type === "calendar") {
-        const firstDate = properties.find((p) => p.type === "date");
-        if (firstDate) {
-          config = { date_property: firstDate.id };
-        }
-      }
+  const {
+    handleAddRow,
+    handleCardMove,
+    handleCellUpdate,
+    handleDeleteRow,
+  } = useDatabaseRows({ pageId, userId, rows, setRows, setProperties });
 
-      const { data: newView, error } = await addView(pageId, name, type, config);
-      if (error || !newView) {
-        toast.error("Failed to create view", { duration: 8000 });
-        return;
-      }
-      setViews((prev) => [...prev, newView]);
-      // Switch to the new view
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("view", newView.id);
-      window.history.replaceState(null, "", `?${params.toString()}`);
-    },
-    [pageId, properties, searchParams],
-  );
+  const {
+    renameDialogOpen,
+    setRenameDialogOpen,
+    renamingProperty,
+    deletingProperty,
+    handleAddColumn,
+    handleColumnHeaderClick,
+    handlePropertyRename,
+    handleColumnReorder,
+    handleRequestDeleteColumn,
+    handleConfirmDeleteColumn,
+    handleCancelDeleteColumn,
+  } = useDatabaseProperties({
+    pageId,
+    properties,
+    setProperties,
+    views,
+    setViews,
+    setRows,
+  });
 
-  // Update the active view's config (used by board/calendar config dropdowns)
-  const handleViewConfigChange = useCallback(
-    async (configPatch: Partial<DatabaseViewConfig>) => {
-      if (!activeView) return;
-      const newConfig = { ...activeView.config, ...configPatch };
-
-      // Optimistic update
-      setViews((prev) =>
-        prev.map((v) =>
-          v.id === activeView.id ? { ...v, config: newConfig } : v,
-        ),
-      );
-
-      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
-      if (error) {
-        toast.error("Failed to update view configuration", { duration: 8000 });
-        // Revert
-        setViews((prev) =>
-          prev.map((v) =>
-            v.id === activeView.id ? { ...v, config: activeView.config } : v,
-          ),
-        );
-      }
-    },
-    [activeView, pageId],
-  );
-
-  // Rename a view
-  const handleRenameView = useCallback(
-    async (viewId: string, newName: string) => {
-      const { data: updated, error } = await updateView(viewId, {
-        name: newName,
-      }, pageId);
-      if (error || !updated) {
-        toast.error("Failed to rename view", { duration: 8000 });
-        return;
-      }
-      setViews((prev) =>
-        prev.map((v) => (v.id === viewId ? { ...v, name: newName } : v)),
-      );
-    },
-    [pageId],
-  );
-
-  // Delete a view (with last-view protection handled by deleteView)
-  const handleDeleteView = useCallback(
-    async (viewId: string) => {
-      const { error } = await deleteView(viewId, pageId);
-      if (error) {
-        toast.error(error.message || "Failed to delete view", {
-          duration: 8000,
-        });
-        return;
-      }
-      setViews((prev) => prev.filter((v) => v.id !== viewId));
-      // If the deleted view was active, switch to the first remaining view.
-      // Done outside setViews to avoid calling history.replaceState during render.
-      if (viewId === activeViewId) {
-        const remaining = views.filter((v) => v.id !== viewId);
-        if (remaining.length > 0) {
-          const params = new URLSearchParams(searchParams.toString());
-          params.set("view", remaining[0].id);
-          window.history.replaceState(null, "", `?${params.toString()}`);
-        }
-      }
-    },
-    [activeViewId, pageId, searchParams, views],
-  );
-
-  // Duplicate a view — copy config and create with " (copy)" suffix
-  const handleDuplicateView = useCallback(
-    async (viewId: string) => {
-      const source = views.find((v) => v.id === viewId);
-      if (!source) return;
-
-      const name = `${source.name} (copy)`;
-      const { data: newView, error } = await addView(
-        pageId,
-        name,
-        source.type,
-        { ...source.config },
-      );
-      if (error || !newView) {
-        toast.error("Failed to duplicate view", { duration: 8000 });
-        return;
-      }
-      setViews((prev) => [...prev, newView]);
-      // Switch to the duplicated view
-      const params = new URLSearchParams(searchParams.toString());
-      params.set("view", newView.id);
-      window.history.replaceState(null, "", `?${params.toString()}`);
-    },
-    [pageId, views, searchParams],
-  );
-
-  // Reorder views by updating position values
-  const handleReorderViews = useCallback(
-    async (orderedIds: string[]) => {
-      // Optimistic update — reorder locally first
-      setViews((prev) => {
-        const viewMap = new Map(prev.map((v) => [v.id, v]));
-        return orderedIds
-          .map((id, i) => {
-            const v = viewMap.get(id);
-            return v ? { ...v, position: i } : null;
-          })
-          .filter((v): v is DatabaseView => v !== null);
-      });
-
-      const { error } = await reorderViews(pageId, orderedIds);
-      if (error) {
-        toast.error("Failed to reorder views", { duration: 8000 });
-        // Reload to restore correct order
-        const { data } = await loadDatabase(pageId);
-        if (data) setViews(data.views);
-      }
-    },
-    [pageId],
-  );
-
-  // -----------------------------------------------------------------------
-  // Sort & filter — derived from active view config, persisted on change
-  // -----------------------------------------------------------------------
-
-  const activeSorts: SortRule[] = useMemo(
-    () => (activeView?.config.sorts as SortRule[] | undefined) ?? [],
-    [activeView],
-  );
-
-  const activeFilters: FilterRule[] = useMemo(
-    () => (activeView?.config.filters as FilterRule[] | undefined) ?? [],
-    [activeView],
-  );
-
-  // Apply sort and filter to produce the displayed rows
-  const displayedRows = useMemo(() => {
-    let result = rows;
-    if (activeFilters.length > 0) {
-      result = filterRows(result, activeFilters, properties);
-    }
-    if (activeSorts.length > 0) {
-      result = sortRows(result, activeSorts, properties);
-    }
-    return result;
-  }, [rows, activeSorts, activeFilters, properties]);
-
-  const handleSortsChange = useCallback(
-    async (newSorts: SortRule[]) => {
-      if (!activeView) return;
-      const newConfig = { ...activeView.config, sorts: newSorts };
-      // Optimistic update
-      setViews((prev) =>
-        prev.map((v) =>
-          v.id === activeView.id ? { ...v, config: newConfig } : v,
-        ),
-      );
-      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
-      if (error) {
-        toast.error("Failed to update sort", { duration: 8000 });
-      }
-    },
-    [activeView, pageId],
-  );
-
-  const handleFiltersChange = useCallback(
-    async (newFilters: FilterRule[]) => {
-      if (!activeView) return;
-      const newConfig = { ...activeView.config, filters: newFilters };
-      // Optimistic update
-      setViews((prev) =>
-        prev.map((v) =>
-          v.id === activeView.id ? { ...v, config: newConfig } : v,
-        ),
-      );
-      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
-      if (error) {
-        toast.error("Failed to update filter", { duration: 8000 });
-      }
-    },
-    [activeView, pageId],
-  );
-
-  // Column header sort toggle: cycles unsorted → asc → desc → unsorted
-  const handleSortToggle = useCallback(
-    (propertyId: string) => {
-      const existing = activeSorts.find((s) => s.property_id === propertyId);
-      let newSorts: SortRule[];
-      if (!existing) {
-        newSorts = [...activeSorts, { property_id: propertyId, direction: "asc" }];
-      } else if (existing.direction === "asc") {
-        newSorts = activeSorts.map((s) =>
-          s.property_id === propertyId ? { ...s, direction: "desc" as const } : s,
-        );
-      } else {
-        newSorts = activeSorts.filter((s) => s.property_id !== propertyId);
-      }
-      void handleSortsChange(newSorts);
-    },
-    [activeSorts, handleSortsChange],
-  );
-
-  // -----------------------------------------------------------------------
-  // Row / column / cell CRUD
-  // -----------------------------------------------------------------------
-
-  const handleAddRow = useCallback(
-    async (initialValues?: Record<string, Record<string, unknown>>) => {
-      const { data: rowPage, error } = await addRow(
-        pageId,
-        userId,
-        initialValues,
-      );
-      if (error || !rowPage) {
-        toast.error("Failed to add row", { duration: 8000 });
-        return;
-      }
-      // Build optimistic row_values from initialValues
-      const optimisticValues: DatabaseRow["values"] = {};
-      if (initialValues) {
-        for (const [propertyId, value] of Object.entries(initialValues)) {
-          optimisticValues[propertyId] = {
-            id: "",
-            row_id: rowPage.id,
-            property_id: propertyId,
-            value,
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-          };
-        }
-      }
-      setRows((prev) => [
-        ...prev,
-        { page: rowPage as DatabaseRow["page"], values: optimisticValues },
-      ]);
-    },
-    [pageId, userId],
-  );
-
-  const handleCardMove = useCallback(
-    async (
-      rowId: string,
-      propertyId: string,
-      newOptionId: string | null,
-    ) => {
-      const newValue: Record<string, unknown> = {
-        option_id: newOptionId,
-      };
-      // Optimistic update
-      setRows((prev) =>
-        prev.map((r) => {
-          if (r.page.id !== rowId) return r;
-          return {
-            ...r,
-            values: {
-              ...r.values,
-              [propertyId]: {
-                ...(r.values[propertyId] ?? {
-                  id: "",
-                  row_id: rowId,
-                  property_id: propertyId,
-                  created_at: new Date().toISOString(),
-                  updated_at: new Date().toISOString(),
-                }),
-                value: newValue,
-                updated_at: new Date().toISOString(),
-              },
-            },
-          };
-        }),
-      );
-
-      const { error } = await updateRowValue(rowId, propertyId, newValue, pageId);
-      if (error) {
-        if (!isInsufficientPrivilegeError(error)) {
-          captureSupabaseError(error, "database-view:move-card");
-        }
-        toast.error("Failed to move card", { duration: 8000 });
-      }
-    },
-    [pageId],
-  );
-
-  const handleCellUpdate = useCallback(
-    async (rowId: string, propertyId: string, value: Record<string, unknown>) => {
-      // Extract _newOptions before persisting — select/multi-select editors
-      // pass newly created options here so we can save them to the property config.
-      const newOptions = value._newOptions as
-        | Array<{ id: string; name: string; color: string }>
-        | undefined;
-      const { _newOptions: _, ...cleanValue } = value;
-
-      // Optimistic updates — batch property config and row value together
-      // so React renders both in the same cycle (the renderer needs the
-      // updated options to display the newly created option badge).
-      if (newOptions) {
-        setProperties((prev) =>
-          prev.map((p) =>
-            p.id === propertyId
-              ? { ...p, config: { ...p.config, options: newOptions } }
-              : p,
-          ),
-        );
-      }
-
-      setRows((prev) =>
-        prev.map((r) => {
-          if (r.page.id !== rowId) return r;
-          return {
-            ...r,
-            values: {
-              ...r.values,
-              [propertyId]: {
-                ...(r.values[propertyId] ?? {
-                  id: "",
-                  row_id: rowId,
-                  property_id: propertyId,
-                  created_at: new Date().toISOString(),
-                  updated_at: new Date().toISOString(),
-                }),
-                value: cleanValue,
-                updated_at: new Date().toISOString(),
-              },
-            },
-          };
-        }),
-      );
-
-      // Persist to DB: update property config first, then row value
-      if (newOptions) {
-        const { error: configError } = await updateProperty(propertyId, {
-          config: { options: newOptions },
-        }, pageId);
-        if (configError) {
-          if (!isInsufficientPrivilegeError(configError)) {
-            captureSupabaseError(configError, "database-view:update-property-options");
-          }
-          toast.error("Failed to save new option", { duration: 8000 });
-        }
-      }
-
-      const { error } = await updateRowValue(rowId, propertyId, cleanValue, pageId);
-      if (error) {
-        if (!isInsufficientPrivilegeError(error)) {
-          captureSupabaseError(error, "database-view:update-cell");
-        }
-        toast.error("Failed to update cell", { duration: 8000 });
-      }
-    },
-    [pageId],
-  );
-
-  const handleAddColumn = useCallback(
-    async (type: PropertyType) => {
-      if (isAddingColumn.current) return;
-      isAddingColumn.current = true;
-      try {
-        const existingNames = new Set(properties.map((p) => p.name));
-        const name = generateColumnName(type, existingNames);
-        const config = getDefaultColumnConfig(type);
-        const { data: newProp, error } = await addProperty(pageId, name, type, config);
-        if (error || !newProp) {
-          toast.error("Failed to add column", { duration: 8000 });
-          return;
-        }
-        setProperties((prev) => [...prev, newProp]);
-      } finally {
-        isAddingColumn.current = false;
-      }
-    },
-    [pageId, properties],
-  );
-
-  const handleColumnHeaderClick = useCallback(
-    (propertyId: string) => {
-      const prop = properties.find((p) => p.id === propertyId);
-      if (!prop) return;
-      setRenamingProperty({ id: prop.id, name: prop.name });
-      setRenameDialogOpen(true);
-    },
-    [properties],
-  );
-
-  const handlePropertyRename = useCallback(
-    async (newName: string) => {
-      if (!renamingProperty) return;
-      const { id: propertyId, name: oldName } = renamingProperty;
-
-      // Optimistic update
-      setProperties((prev) =>
-        prev.map((p) => (p.id === propertyId ? { ...p, name: newName } : p)),
-      );
-
-      const { error } = await updateProperty(propertyId, { name: newName }, pageId);
-      if (error) {
-        toast.error("Failed to rename property", { duration: 8000 });
-        // Revert
-        setProperties((prev) =>
-          prev.map((p) => (p.id === propertyId ? { ...p, name: oldName } : p)),
-        );
-      }
-    },
-    [renamingProperty, pageId],
-  );
-
-  const handleColumnReorder = useCallback(
-    async (orderedPropertyIds: string[]) => {
-      // Optimistic update: reorder properties in state
-      const prevProperties = properties;
-      setProperties((prev) => {
-        const byId = new Map(prev.map((p) => [p.id, p]));
-        return orderedPropertyIds
-          .map((id, i) => {
-            const p = byId.get(id);
-            return p ? { ...p, position: i } : null;
-          })
-          .filter((p): p is NonNullable<typeof p> => p !== null);
-      });
-
-      const { error } = await reorderProperties(pageId, orderedPropertyIds);
-      if (error) {
-        toast.error("Failed to reorder columns", { duration: 8000 });
-        setProperties(prevProperties);
-      }
-    },
-    [pageId, properties],
-  );
-
-  // Open the delete-property confirmation dialog (called from column header menu)
-  const handleRequestDeleteColumn = useCallback(
-    (propertyId: string) => {
-      const prop = properties.find((p) => p.id === propertyId);
-      if (!prop || prop.position === 0) return; // Title property cannot be deleted
-      setDeletingProperty({ id: prop.id, name: prop.name });
-    },
-    [properties],
-  );
-
-  // Confirmed deletion — remove property, clean up view configs, and persist
-  const handleConfirmDeleteColumn = useCallback(async () => {
-    if (!deletingProperty) return;
-    const { id: propertyId } = deletingProperty;
-    setDeletingProperty(null);
-
-    // Optimistic removal from properties
-    const prevProperties = properties;
-    setProperties((prev) => prev.filter((p) => p.id !== propertyId));
-
-    // Optimistic removal from visible_properties in all views
-    const prevViews = views;
-    setViews((prev) =>
-      prev.map((v) => {
-        const vp = v.config.visible_properties;
-        if (!vp || !vp.includes(propertyId)) return v;
-        return {
-          ...v,
-          config: {
-            ...v.config,
-            visible_properties: vp.filter((id: string) => id !== propertyId),
-          },
-        };
-      }),
-    );
-
-    // Optimistic removal from row values
-    setRows((prev) =>
-      prev.map((r) => {
-        if (!(propertyId in r.values)) return r;
-        const { [propertyId]: _, ...rest } = r.values;
-        return { ...r, values: rest };
-      }),
-    );
-
-    const { error } = await deleteProperty(propertyId, pageId);
-    if (error) {
-      toast.error("Failed to delete property", { duration: 8000 });
-      // Revert
-      setProperties(prevProperties);
-      setViews(prevViews);
-      const { data } = await loadDatabase(pageId);
-      if (data) {
-        setRows(data.rows);
-      }
-      return;
-    }
-
-    // Persist visible_properties cleanup for each affected view
-    for (const v of views) {
-      const vp = v.config.visible_properties;
-      if (vp && vp.includes(propertyId)) {
-        void updateView(v.id, {
-          config: {
-            ...v.config,
-            visible_properties: vp.filter((id: string) => id !== propertyId),
-          },
-        }, pageId);
-      }
-    }
-  }, [deletingProperty, properties, views, pageId]);
-
-  const handleCancelDeleteColumn = useCallback(() => {
-    setDeletingProperty(null);
-  }, []);
-
-  const handleDeleteRow = useCallback(
-    async (rowId: string) => {
-      // Optimistic removal
-      setRows((prev) => prev.filter((r) => r.page.id !== rowId));
-
-      const supabase = createClient();
-      const { error } = await supabase.rpc("soft_delete_page", {
-        page_id: rowId,
-      });
-      if (error) {
-        if (!isInsufficientPrivilegeError(error)) {
-          captureSupabaseError(error, "database-view:delete-row");
-        }
-        toast.error("Failed to delete row", { duration: 8000 });
-        // Reload to restore
-        const { data } = await loadDatabase(pageId);
-        if (data) setRows(data.rows);
-      }
-    },
-    [pageId],
-  );
+  const {
+    activeSorts,
+    activeFilters,
+    displayedRows,
+    handleSortsChange,
+    handleFiltersChange,
+    handleSortToggle,
+  } = useDatabaseFilters({ pageId, activeView, rows, properties, setViews });
 
   // Check if there's Lexical content to render above the database
   const hasContent =
@@ -1058,32 +372,12 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       />
 
       {/* Delete property confirmation dialog */}
-      <AlertDialog
+      <DeletePropertyDialog
         open={deletingProperty !== null}
-        onOpenChange={(open) => {
-          if (!open) handleCancelDeleteColumn();
-        }}
-      >
-        <AlertDialogContent size="sm">
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              Delete &ldquo;{deletingProperty?.name}&rdquo;?
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete the property and all its row values.
-              This cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={handleCancelDeleteColumn}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={handleConfirmDeleteColumn}>
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        propertyName={deletingProperty?.name ?? null}
+        onCancel={handleCancelDeleteColumn}
+        onConfirm={handleConfirmDeleteColumn}
+      />
     </>
   );
 }

--- a/src/components/database/database-view-helpers.stories.tsx
+++ b/src/components/database/database-view-helpers.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import {
+  ViewConfigDropdown,
+  ComingSoonPlaceholder,
+  DatabaseSkeleton,
+} from "./database-view-helpers";
+import type { DatabaseProperty } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockProperties: DatabaseProperty[] = [
+  {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Status",
+    type: "select",
+    config: {},
+    position: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "prop-2",
+    database_id: "db-1",
+    name: "Priority",
+    type: "select",
+    config: {},
+    position: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "prop-3",
+    database_id: "db-1",
+    name: "Due Date",
+    type: "date",
+    config: {},
+    position: 2,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+// ===========================================================================
+// ViewConfigDropdown
+// ===========================================================================
+
+const dropdownMeta: Meta<typeof ViewConfigDropdown> = {
+  title: "Database/ViewConfigDropdown",
+  component: ViewConfigDropdown,
+  parameters: { layout: "centered" },
+  args: {
+    label: "Group by",
+    selectedId: null,
+    options: mockProperties,
+    onSelect: fn(),
+  },
+};
+
+export { dropdownMeta as default };
+
+type DropdownStory = StoryObj<typeof ViewConfigDropdown>;
+
+/** No property selected — shows "None". */
+export const Default: DropdownStory = {};
+
+/** A property is pre-selected. */
+export const WithSelection: DropdownStory = {
+  args: {
+    selectedId: "prop-1",
+  },
+};
+
+/** No options available — shows empty state. */
+export const EmptyOptions: DropdownStory = {
+  args: {
+    options: [],
+  },
+};
+
+/** Date property label variant. */
+export const DatePropertyLabel: DropdownStory = {
+  args: {
+    label: "Date property",
+    options: mockProperties.filter((p) => p.type === "date"),
+    selectedId: "prop-3",
+  },
+};
+
+// ===========================================================================
+// ComingSoonPlaceholder — separate story file section
+// ===========================================================================
+
+export const ComingSoonBoard: StoryObj = {
+  render: () => <ComingSoonPlaceholder viewType="board" />,
+  parameters: { layout: "padded" },
+};
+
+export const ComingSoonCalendar: StoryObj = {
+  render: () => <ComingSoonPlaceholder viewType="calendar" />,
+  parameters: { layout: "padded" },
+};
+
+export const ComingSoonGallery: StoryObj = {
+  render: () => <ComingSoonPlaceholder viewType="gallery" />,
+  parameters: { layout: "padded" },
+};
+
+// ===========================================================================
+// DatabaseSkeleton
+// ===========================================================================
+
+export const Skeleton: StoryObj = {
+  render: () => <DatabaseSkeleton />,
+  parameters: { layout: "padded" },
+};

--- a/src/components/database/database-view-helpers.tsx
+++ b/src/components/database/database-view-helpers.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown, Check } from "lucide-react";
+import type { DatabaseProperty, DatabaseViewType } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// ViewConfigDropdown — toolbar dropdown for selecting a property (group_by, date_property)
+// ---------------------------------------------------------------------------
+
+export interface ViewConfigDropdownProps {
+  label: string;
+  selectedId: string | null;
+  options: DatabaseProperty[];
+  onSelect: (propertyId: string) => void;
+}
+
+export function ViewConfigDropdown({
+  label,
+  selectedId,
+  options,
+  onSelect,
+}: ViewConfigDropdownProps) {
+  const selectedName = options.find((p) => p.id === selectedId)?.name;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="inline-flex h-7 items-center gap-1 rounded-sm px-2 text-xs text-muted-foreground outline-none transition-colors hover:bg-overlay-border hover:text-foreground"
+        data-testid={`view-config-${label.toLowerCase().replace(/\s+/g, "-")}`}
+      >
+        {label}: {selectedName ?? "None"}
+        <ChevronDown className="size-3" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {options.length === 0 ? (
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">
+            No matching properties
+          </div>
+        ) : (
+          options.map((prop) => (
+            <DropdownMenuItem
+              key={prop.id}
+              onClick={() => onSelect(prop.id)}
+              className="gap-2 text-xs"
+            >
+              {prop.id === selectedId && <Check className="size-3" />}
+              {prop.id !== selectedId && <span className="size-3" />}
+              {prop.name}
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Coming Soon placeholder for non-table view types
+// ---------------------------------------------------------------------------
+
+export function ComingSoonPlaceholder({ viewType }: { viewType: DatabaseViewType }) {
+  return (
+    <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
+      {viewType.charAt(0).toUpperCase() + viewType.slice(1)} view coming soon
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+export function DatabaseSkeleton() {
+  return (
+    <div className="space-y-3">
+      {/* View tabs skeleton */}
+      <div className="flex items-center gap-2 border-b border-overlay-border pb-2">
+        <div className="h-5 w-20 animate-pulse bg-muted" />
+        <div className="h-5 w-20 animate-pulse bg-muted" />
+        <div className="h-5 w-20 animate-pulse bg-muted" />
+      </div>
+      {/* Table skeleton */}
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          <div className="h-8 w-1/4 animate-pulse bg-muted" />
+          <div className="h-8 w-1/4 animate-pulse bg-muted" />
+          <div className="h-8 w-1/4 animate-pulse bg-muted" />
+          <div className="h-8 w-1/4 animate-pulse bg-muted" />
+        </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex gap-2">
+            <div className="h-10 w-1/4 animate-pulse bg-muted" />
+            <div className="h-10 w-1/4 animate-pulse bg-muted" />
+            <div className="h-10 w-1/4 animate-pulse bg-muted" />
+            <div className="h-10 w-1/4 animate-pulse bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/database/delete-property-dialog.stories.tsx
+++ b/src/components/database/delete-property-dialog.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import { DeletePropertyDialog } from "./delete-property-dialog";
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof DeletePropertyDialog> = {
+  title: "Database/DeletePropertyDialog",
+  component: DeletePropertyDialog,
+  parameters: { layout: "centered" },
+  args: {
+    open: true,
+    propertyName: "Status",
+    onCancel: fn(),
+    onConfirm: fn(),
+  },
+};
+
+export { meta as default };
+
+type Story = StoryObj<typeof DeletePropertyDialog>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Default open state with a property name. */
+export const Default: Story = {};
+
+/** With a long property name. */
+export const LongName: Story = {
+  args: {
+    propertyName: "Very Long Property Name That Might Overflow The Dialog",
+  },
+};
+
+/** Closed state — dialog is not visible. */
+export const Closed: Story = {
+  args: {
+    open: false,
+    propertyName: null,
+  },
+};

--- a/src/components/database/delete-property-dialog.tsx
+++ b/src/components/database/delete-property-dialog.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface DeletePropertyDialogProps {
+  propertyName: string | null;
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DeletePropertyDialog({
+  propertyName,
+  open,
+  onCancel,
+  onConfirm,
+}: DeletePropertyDialogProps) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onCancel();
+      }}
+    >
+      <AlertDialogContent size="sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Delete &ldquo;{propertyName}&rdquo;?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete the property and all its row values.
+            This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm}>
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/database/hooks/use-database-filters.ts
+++ b/src/components/database/hooks/use-database-filters.ts
@@ -1,0 +1,133 @@
+import { useCallback, useMemo } from "react";
+import { toast } from "sonner";
+import {
+  sortRows,
+  filterRows,
+  type SortRule,
+  type FilterRule,
+} from "@/lib/database-filters";
+import { updateView } from "@/lib/database";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  DatabaseView,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Hook params & return type
+// ---------------------------------------------------------------------------
+
+export interface UseDatabaseFiltersParams {
+  pageId: string;
+  activeView: DatabaseView | undefined;
+  rows: DatabaseRow[];
+  properties: DatabaseProperty[];
+  setViews: React.Dispatch<React.SetStateAction<DatabaseView[]>>;
+}
+
+export interface UseDatabaseFiltersReturn {
+  activeSorts: SortRule[];
+  activeFilters: FilterRule[];
+  displayedRows: DatabaseRow[];
+  handleSortsChange: (newSorts: SortRule[]) => Promise<void>;
+  handleFiltersChange: (newFilters: FilterRule[]) => Promise<void>;
+  handleSortToggle: (propertyId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useDatabaseFilters({
+  pageId,
+  activeView,
+  rows,
+  properties,
+  setViews,
+}: UseDatabaseFiltersParams): UseDatabaseFiltersReturn {
+  const activeSorts: SortRule[] = useMemo(
+    () => (activeView?.config.sorts as SortRule[] | undefined) ?? [],
+    [activeView],
+  );
+
+  const activeFilters: FilterRule[] = useMemo(
+    () => (activeView?.config.filters as FilterRule[] | undefined) ?? [],
+    [activeView],
+  );
+
+  // Apply sort and filter to produce the displayed rows
+  const displayedRows = useMemo(() => {
+    let result = rows;
+    if (activeFilters.length > 0) {
+      result = filterRows(result, activeFilters, properties);
+    }
+    if (activeSorts.length > 0) {
+      result = sortRows(result, activeSorts, properties);
+    }
+    return result;
+  }, [rows, activeSorts, activeFilters, properties]);
+
+  const handleSortsChange = useCallback(
+    async (newSorts: SortRule[]) => {
+      if (!activeView) return;
+      const newConfig = { ...activeView.config, sorts: newSorts };
+      // Optimistic update
+      setViews((prev) =>
+        prev.map((v) =>
+          v.id === activeView.id ? { ...v, config: newConfig } : v,
+        ),
+      );
+      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
+      if (error) {
+        toast.error("Failed to update sort", { duration: 8000 });
+      }
+    },
+    [activeView, pageId, setViews],
+  );
+
+  const handleFiltersChange = useCallback(
+    async (newFilters: FilterRule[]) => {
+      if (!activeView) return;
+      const newConfig = { ...activeView.config, filters: newFilters };
+      // Optimistic update
+      setViews((prev) =>
+        prev.map((v) =>
+          v.id === activeView.id ? { ...v, config: newConfig } : v,
+        ),
+      );
+      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
+      if (error) {
+        toast.error("Failed to update filter", { duration: 8000 });
+      }
+    },
+    [activeView, pageId, setViews],
+  );
+
+  // Column header sort toggle: cycles unsorted → asc → desc → unsorted
+  const handleSortToggle = useCallback(
+    (propertyId: string) => {
+      const existing = activeSorts.find((s) => s.property_id === propertyId);
+      let newSorts: SortRule[];
+      if (!existing) {
+        newSorts = [...activeSorts, { property_id: propertyId, direction: "asc" }];
+      } else if (existing.direction === "asc") {
+        newSorts = activeSorts.map((s) =>
+          s.property_id === propertyId ? { ...s, direction: "desc" as const } : s,
+        );
+      } else {
+        newSorts = activeSorts.filter((s) => s.property_id !== propertyId);
+      }
+      void handleSortsChange(newSorts);
+    },
+    [activeSorts, handleSortsChange],
+  );
+
+  return {
+    activeSorts,
+    activeFilters,
+    displayedRows,
+    handleSortsChange,
+    handleFiltersChange,
+    handleSortToggle,
+  };
+}

--- a/src/components/database/hooks/use-database-properties.ts
+++ b/src/components/database/hooks/use-database-properties.ts
@@ -1,0 +1,245 @@
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  addProperty,
+  deleteProperty,
+  loadDatabase,
+  reorderProperties,
+  updateProperty,
+  updateView,
+} from "@/lib/database";
+import {
+  generateColumnName,
+  getDefaultColumnConfig,
+} from "@/lib/column-helpers";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  DatabaseView,
+  PropertyType,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Hook params & return type
+// ---------------------------------------------------------------------------
+
+export interface UseDatabasePropertiesParams {
+  pageId: string;
+  properties: DatabaseProperty[];
+  setProperties: React.Dispatch<React.SetStateAction<DatabaseProperty[]>>;
+  views: DatabaseView[];
+  setViews: React.Dispatch<React.SetStateAction<DatabaseView[]>>;
+  setRows: React.Dispatch<React.SetStateAction<DatabaseRow[]>>;
+}
+
+export interface UseDatabasePropertiesReturn {
+  // Rename dialog state
+  renameDialogOpen: boolean;
+  setRenameDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  renamingProperty: { id: string; name: string } | null;
+  // Delete dialog state
+  deletingProperty: { id: string; name: string } | null;
+  // Callbacks
+  handleAddColumn: (type: PropertyType) => Promise<void>;
+  handleColumnHeaderClick: (propertyId: string) => void;
+  handlePropertyRename: (newName: string) => Promise<void>;
+  handleColumnReorder: (orderedPropertyIds: string[]) => Promise<void>;
+  handleRequestDeleteColumn: (propertyId: string) => void;
+  handleConfirmDeleteColumn: () => Promise<void>;
+  handleCancelDeleteColumn: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useDatabaseProperties({
+  pageId,
+  properties,
+  setProperties,
+  views,
+  setViews,
+  setRows,
+}: UseDatabasePropertiesParams): UseDatabasePropertiesReturn {
+  // Rename property dialog state
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [renamingProperty, setRenamingProperty] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  // Delete property confirmation state
+  const [deletingProperty, setDeletingProperty] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
+
+  // Guard against concurrent addProperty calls (e.g. rapid double-click)
+  const isAddingColumn = useRef(false);
+
+  const handleAddColumn = useCallback(
+    async (type: PropertyType) => {
+      if (isAddingColumn.current) return;
+      isAddingColumn.current = true;
+      try {
+        const existingNames = new Set(properties.map((p) => p.name));
+        const name = generateColumnName(type, existingNames);
+        const config = getDefaultColumnConfig(type);
+        const { data: newProp, error } = await addProperty(pageId, name, type, config);
+        if (error || !newProp) {
+          toast.error("Failed to add column", { duration: 8000 });
+          return;
+        }
+        setProperties((prev) => [...prev, newProp]);
+      } finally {
+        isAddingColumn.current = false;
+      }
+    },
+    [pageId, properties, setProperties],
+  );
+
+  const handleColumnHeaderClick = useCallback(
+    (propertyId: string) => {
+      const prop = properties.find((p) => p.id === propertyId);
+      if (!prop) return;
+      setRenamingProperty({ id: prop.id, name: prop.name });
+      setRenameDialogOpen(true);
+    },
+    [properties],
+  );
+
+  const handlePropertyRename = useCallback(
+    async (newName: string) => {
+      if (!renamingProperty) return;
+      const { id: propertyId, name: oldName } = renamingProperty;
+
+      // Optimistic update
+      setProperties((prev) =>
+        prev.map((p) => (p.id === propertyId ? { ...p, name: newName } : p)),
+      );
+
+      const { error } = await updateProperty(propertyId, { name: newName }, pageId);
+      if (error) {
+        toast.error("Failed to rename property", { duration: 8000 });
+        // Revert
+        setProperties((prev) =>
+          prev.map((p) => (p.id === propertyId ? { ...p, name: oldName } : p)),
+        );
+      }
+    },
+    [renamingProperty, pageId, setProperties],
+  );
+
+  const handleColumnReorder = useCallback(
+    async (orderedPropertyIds: string[]) => {
+      // Optimistic update: reorder properties in state
+      const prevProperties = properties;
+      setProperties((prev) => {
+        const byId = new Map(prev.map((p) => [p.id, p]));
+        return orderedPropertyIds
+          .map((id, i) => {
+            const p = byId.get(id);
+            return p ? { ...p, position: i } : null;
+          })
+          .filter((p): p is NonNullable<typeof p> => p !== null);
+      });
+
+      const { error } = await reorderProperties(pageId, orderedPropertyIds);
+      if (error) {
+        toast.error("Failed to reorder columns", { duration: 8000 });
+        setProperties(prevProperties);
+      }
+    },
+    [pageId, properties, setProperties],
+  );
+
+  // Open the delete-property confirmation dialog (called from column header menu)
+  const handleRequestDeleteColumn = useCallback(
+    (propertyId: string) => {
+      const prop = properties.find((p) => p.id === propertyId);
+      if (!prop || prop.position === 0) return; // Title property cannot be deleted
+      setDeletingProperty({ id: prop.id, name: prop.name });
+    },
+    [properties],
+  );
+
+  // Confirmed deletion — remove property, clean up view configs, and persist
+  const handleConfirmDeleteColumn = useCallback(async () => {
+    if (!deletingProperty) return;
+    const { id: propertyId } = deletingProperty;
+    setDeletingProperty(null);
+
+    // Optimistic removal from properties
+    const prevProperties = properties;
+    setProperties((prev) => prev.filter((p) => p.id !== propertyId));
+
+    // Optimistic removal from visible_properties in all views
+    const prevViews = views;
+    setViews((prev) =>
+      prev.map((v) => {
+        const vp = v.config.visible_properties;
+        if (!vp || !vp.includes(propertyId)) return v;
+        return {
+          ...v,
+          config: {
+            ...v.config,
+            visible_properties: vp.filter((id: string) => id !== propertyId),
+          },
+        };
+      }),
+    );
+
+    // Optimistic removal from row values
+    setRows((prev) =>
+      prev.map((r) => {
+        if (!(propertyId in r.values)) return r;
+        const { [propertyId]: _, ...rest } = r.values;
+        return { ...r, values: rest };
+      }),
+    );
+
+    const { error } = await deleteProperty(propertyId, pageId);
+    if (error) {
+      toast.error("Failed to delete property", { duration: 8000 });
+      // Revert
+      setProperties(prevProperties);
+      setViews(prevViews);
+      const { data } = await loadDatabase(pageId);
+      if (data) {
+        setRows(data.rows);
+      }
+      return;
+    }
+
+    // Persist visible_properties cleanup for each affected view
+    for (const v of views) {
+      const vp = v.config.visible_properties;
+      if (vp && vp.includes(propertyId)) {
+        void updateView(v.id, {
+          config: {
+            ...v.config,
+            visible_properties: vp.filter((id: string) => id !== propertyId),
+          },
+        }, pageId);
+      }
+    }
+  }, [deletingProperty, properties, views, pageId, setProperties, setViews, setRows]);
+
+  const handleCancelDeleteColumn = useCallback(() => {
+    setDeletingProperty(null);
+  }, []);
+
+  return {
+    renameDialogOpen,
+    setRenameDialogOpen,
+    renamingProperty,
+    deletingProperty,
+    handleAddColumn,
+    handleColumnHeaderClick,
+    handlePropertyRename,
+    handleColumnReorder,
+    handleRequestDeleteColumn,
+    handleConfirmDeleteColumn,
+    handleCancelDeleteColumn,
+  };
+}

--- a/src/components/database/hooks/use-database-rows.ts
+++ b/src/components/database/hooks/use-database-rows.ts
@@ -1,0 +1,219 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+import {
+  addRow,
+  loadDatabase,
+  updateProperty,
+  updateRowValue,
+} from "@/lib/database";
+import { createClient } from "@/lib/supabase/client";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+} from "@/lib/sentry";
+import type { DatabaseProperty, DatabaseRow } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Hook params & return type
+// ---------------------------------------------------------------------------
+
+export interface UseDatabaseRowsParams {
+  pageId: string;
+  userId: string;
+  rows: DatabaseRow[];
+  setRows: React.Dispatch<React.SetStateAction<DatabaseRow[]>>;
+  setProperties: React.Dispatch<React.SetStateAction<DatabaseProperty[]>>;
+}
+
+export interface UseDatabaseRowsReturn {
+  handleAddRow: (initialValues?: Record<string, Record<string, unknown>>) => Promise<void>;
+  handleCardMove: (rowId: string, propertyId: string, newOptionId: string | null) => Promise<void>;
+  handleCellUpdate: (rowId: string, propertyId: string, value: Record<string, unknown>) => Promise<void>;
+  handleDeleteRow: (rowId: string) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useDatabaseRows({
+  pageId,
+  userId,
+  setRows,
+  setProperties,
+}: UseDatabaseRowsParams): UseDatabaseRowsReturn {
+  const handleAddRow = useCallback(
+    async (initialValues?: Record<string, Record<string, unknown>>) => {
+      const { data: rowPage, error } = await addRow(
+        pageId,
+        userId,
+        initialValues,
+      );
+      if (error || !rowPage) {
+        toast.error("Failed to add row", { duration: 8000 });
+        return;
+      }
+      // Build optimistic row_values from initialValues
+      const optimisticValues: DatabaseRow["values"] = {};
+      if (initialValues) {
+        for (const [propertyId, value] of Object.entries(initialValues)) {
+          optimisticValues[propertyId] = {
+            id: "",
+            row_id: rowPage.id,
+            property_id: propertyId,
+            value,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          };
+        }
+      }
+      setRows((prev) => [
+        ...prev,
+        { page: rowPage as DatabaseRow["page"], values: optimisticValues },
+      ]);
+    },
+    [pageId, userId, setRows],
+  );
+
+  const handleCardMove = useCallback(
+    async (
+      rowId: string,
+      propertyId: string,
+      newOptionId: string | null,
+    ) => {
+      const newValue: Record<string, unknown> = {
+        option_id: newOptionId,
+      };
+      // Optimistic update
+      setRows((prev) =>
+        prev.map((r) => {
+          if (r.page.id !== rowId) return r;
+          return {
+            ...r,
+            values: {
+              ...r.values,
+              [propertyId]: {
+                ...(r.values[propertyId] ?? {
+                  id: "",
+                  row_id: rowId,
+                  property_id: propertyId,
+                  created_at: new Date().toISOString(),
+                  updated_at: new Date().toISOString(),
+                }),
+                value: newValue,
+                updated_at: new Date().toISOString(),
+              },
+            },
+          };
+        }),
+      );
+
+      const { error } = await updateRowValue(rowId, propertyId, newValue, pageId);
+      if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-view:move-card");
+        }
+        toast.error("Failed to move card", { duration: 8000 });
+      }
+    },
+    [pageId, setRows],
+  );
+
+  const handleCellUpdate = useCallback(
+    async (rowId: string, propertyId: string, value: Record<string, unknown>) => {
+      // Extract _newOptions before persisting — select/multi-select editors
+      // pass newly created options here so we can save them to the property config.
+      const newOptions = value._newOptions as
+        | Array<{ id: string; name: string; color: string }>
+        | undefined;
+      const { _newOptions: _, ...cleanValue } = value;
+
+      // Optimistic updates — batch property config and row value together
+      // so React renders both in the same cycle (the renderer needs the
+      // updated options to display the newly created option badge).
+      if (newOptions) {
+        setProperties((prev) =>
+          prev.map((p) =>
+            p.id === propertyId
+              ? { ...p, config: { ...p.config, options: newOptions } }
+              : p,
+          ),
+        );
+      }
+
+      setRows((prev) =>
+        prev.map((r) => {
+          if (r.page.id !== rowId) return r;
+          return {
+            ...r,
+            values: {
+              ...r.values,
+              [propertyId]: {
+                ...(r.values[propertyId] ?? {
+                  id: "",
+                  row_id: rowId,
+                  property_id: propertyId,
+                  created_at: new Date().toISOString(),
+                  updated_at: new Date().toISOString(),
+                }),
+                value: cleanValue,
+                updated_at: new Date().toISOString(),
+              },
+            },
+          };
+        }),
+      );
+
+      // Persist to DB: update property config first, then row value
+      if (newOptions) {
+        const { error: configError } = await updateProperty(propertyId, {
+          config: { options: newOptions },
+        }, pageId);
+        if (configError) {
+          if (!isInsufficientPrivilegeError(configError)) {
+            captureSupabaseError(configError, "database-view:update-property-options");
+          }
+          toast.error("Failed to save new option", { duration: 8000 });
+        }
+      }
+
+      const { error } = await updateRowValue(rowId, propertyId, cleanValue, pageId);
+      if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-view:update-cell");
+        }
+        toast.error("Failed to update cell", { duration: 8000 });
+      }
+    },
+    [pageId, setRows, setProperties],
+  );
+
+  const handleDeleteRow = useCallback(
+    async (rowId: string) => {
+      // Optimistic removal
+      setRows((prev) => prev.filter((r) => r.page.id !== rowId));
+
+      const supabase = createClient();
+      const { error } = await supabase.rpc("soft_delete_page", {
+        page_id: rowId,
+      });
+      if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-view:delete-row");
+        }
+        toast.error("Failed to delete row", { duration: 8000 });
+        // Reload to restore
+        const { data } = await loadDatabase(pageId);
+        if (data) setRows(data.rows);
+      }
+    },
+    [pageId, setRows],
+  );
+
+  return {
+    handleAddRow,
+    handleCardMove,
+    handleCellUpdate,
+    handleDeleteRow,
+  };
+}

--- a/src/components/database/hooks/use-database-views.ts
+++ b/src/components/database/hooks/use-database-views.ts
@@ -84,9 +84,9 @@ export function useDatabaseViews({
       // Auto-detect a default config property for board and calendar views
       let config: DatabaseViewConfig = {};
       if (type === "board") {
-        const firstSelect = properties.find((p) => p.type === "select");
-        if (firstSelect) {
-          config = { group_by: firstSelect.id };
+        const firstGroupable = properties.find((p) => p.type === "select" || p.type === "status");
+        if (firstGroupable) {
+          config = { group_by: firstGroupable.id };
         }
       } else if (type === "calendar") {
         const firstDate = properties.find((p) => p.type === "date");

--- a/src/components/database/hooks/use-database-views.ts
+++ b/src/components/database/hooks/use-database-views.ts
@@ -1,0 +1,243 @@
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import { VIEW_TYPE_LABELS } from "@/components/database/view-tabs";
+import {
+  addView,
+  deleteView,
+  loadDatabase,
+  reorderViews,
+  updateView,
+} from "@/lib/database";
+import type {
+  DatabaseProperty,
+  DatabaseView,
+  DatabaseViewConfig,
+  DatabaseViewType,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Hook params & return type
+// ---------------------------------------------------------------------------
+
+export interface UseDatabaseViewsParams {
+  pageId: string;
+  properties: DatabaseProperty[];
+  views: DatabaseView[];
+  setViews: React.Dispatch<React.SetStateAction<DatabaseView[]>>;
+}
+
+export interface UseDatabaseViewsReturn {
+  activeViewId: string;
+  activeView: DatabaseView | undefined;
+  handleViewChange: (viewId: string) => void;
+  handleAddView: (type: DatabaseViewType) => Promise<void>;
+  handleViewConfigChange: (configPatch: Partial<DatabaseViewConfig>) => Promise<void>;
+  handleRenameView: (viewId: string, newName: string) => Promise<void>;
+  handleDeleteView: (viewId: string) => Promise<void>;
+  handleDuplicateView: (viewId: string) => Promise<void>;
+  handleReorderViews: (orderedIds: string[]) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useDatabaseViews({
+  pageId,
+  properties,
+  views,
+  setViews,
+}: UseDatabaseViewsParams): UseDatabaseViewsReturn {
+  const searchParams = useSearchParams();
+
+  // Active view: from URL ?view= param, or first view by position
+  const viewIdFromUrl = searchParams.get("view");
+
+  const activeViewId = useMemo(() => {
+    if (viewIdFromUrl && views.some((v) => v.id === viewIdFromUrl)) {
+      return viewIdFromUrl;
+    }
+    return views[0]?.id ?? "";
+  }, [viewIdFromUrl, views]);
+
+  const activeView = useMemo(
+    () => views.find((v) => v.id === activeViewId),
+    [views, activeViewId],
+  );
+
+  // Handle view tab change — update URL ?view= param without server round-trip
+  const handleViewChange = useCallback(
+    (viewId: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("view", viewId);
+      window.history.replaceState(null, "", `?${params.toString()}`);
+    },
+    [searchParams],
+  );
+
+  // Create a new view with sensible defaults per type
+  const handleAddView = useCallback(
+    async (type: DatabaseViewType) => {
+      const name = `${VIEW_TYPE_LABELS[type]} view`;
+
+      // Auto-detect a default config property for board and calendar views
+      let config: DatabaseViewConfig = {};
+      if (type === "board") {
+        const firstSelect = properties.find((p) => p.type === "select");
+        if (firstSelect) {
+          config = { group_by: firstSelect.id };
+        }
+      } else if (type === "calendar") {
+        const firstDate = properties.find((p) => p.type === "date");
+        if (firstDate) {
+          config = { date_property: firstDate.id };
+        }
+      }
+
+      const { data: newView, error } = await addView(pageId, name, type, config);
+      if (error || !newView) {
+        toast.error("Failed to create view", { duration: 8000 });
+        return;
+      }
+      setViews((prev) => [...prev, newView]);
+      // Switch to the new view
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("view", newView.id);
+      window.history.replaceState(null, "", `?${params.toString()}`);
+    },
+    [pageId, properties, searchParams, setViews],
+  );
+
+  // Update the active view's config (used by board/calendar config dropdowns)
+  const handleViewConfigChange = useCallback(
+    async (configPatch: Partial<DatabaseViewConfig>) => {
+      if (!activeView) return;
+      const newConfig = { ...activeView.config, ...configPatch };
+
+      // Optimistic update
+      setViews((prev) =>
+        prev.map((v) =>
+          v.id === activeView.id ? { ...v, config: newConfig } : v,
+        ),
+      );
+
+      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
+      if (error) {
+        toast.error("Failed to update view configuration", { duration: 8000 });
+        // Revert
+        setViews((prev) =>
+          prev.map((v) =>
+            v.id === activeView.id ? { ...v, config: activeView.config } : v,
+          ),
+        );
+      }
+    },
+    [activeView, pageId, setViews],
+  );
+
+  // Rename a view
+  const handleRenameView = useCallback(
+    async (viewId: string, newName: string) => {
+      const { data: updated, error } = await updateView(viewId, {
+        name: newName,
+      }, pageId);
+      if (error || !updated) {
+        toast.error("Failed to rename view", { duration: 8000 });
+        return;
+      }
+      setViews((prev) =>
+        prev.map((v) => (v.id === viewId ? { ...v, name: newName } : v)),
+      );
+    },
+    [pageId, setViews],
+  );
+
+  // Delete a view (with last-view protection handled by deleteView)
+  const handleDeleteView = useCallback(
+    async (viewId: string) => {
+      const { error } = await deleteView(viewId, pageId);
+      if (error) {
+        toast.error(error.message || "Failed to delete view", {
+          duration: 8000,
+        });
+        return;
+      }
+      setViews((prev) => prev.filter((v) => v.id !== viewId));
+      // If the deleted view was active, switch to the first remaining view.
+      // Done outside setViews to avoid calling history.replaceState during render.
+      if (viewId === activeViewId) {
+        const remaining = views.filter((v) => v.id !== viewId);
+        if (remaining.length > 0) {
+          const params = new URLSearchParams(searchParams.toString());
+          params.set("view", remaining[0].id);
+          window.history.replaceState(null, "", `?${params.toString()}`);
+        }
+      }
+    },
+    [activeViewId, pageId, searchParams, setViews, views],
+  );
+
+  // Duplicate a view — copy config and create with " (copy)" suffix
+  const handleDuplicateView = useCallback(
+    async (viewId: string) => {
+      const source = views.find((v) => v.id === viewId);
+      if (!source) return;
+
+      const name = `${source.name} (copy)`;
+      const { data: newView, error } = await addView(
+        pageId,
+        name,
+        source.type,
+        { ...source.config },
+      );
+      if (error || !newView) {
+        toast.error("Failed to duplicate view", { duration: 8000 });
+        return;
+      }
+      setViews((prev) => [...prev, newView]);
+      // Switch to the duplicated view
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("view", newView.id);
+      window.history.replaceState(null, "", `?${params.toString()}`);
+    },
+    [pageId, views, searchParams, setViews],
+  );
+
+  // Reorder views by updating position values
+  const handleReorderViews = useCallback(
+    async (orderedIds: string[]) => {
+      // Optimistic update — reorder locally first
+      setViews((prev) => {
+        const viewMap = new Map(prev.map((v) => [v.id, v]));
+        return orderedIds
+          .map((id, i) => {
+            const v = viewMap.get(id);
+            return v ? { ...v, position: i } : null;
+          })
+          .filter((v): v is DatabaseView => v !== null);
+      });
+
+      const { error } = await reorderViews(pageId, orderedIds);
+      if (error) {
+        toast.error("Failed to reorder views", { duration: 8000 });
+        // Reload to restore correct order
+        const { data } = await loadDatabase(pageId);
+        if (data) setViews(data.views);
+      }
+    },
+    [pageId, setViews],
+  );
+
+  return {
+    activeViewId,
+    activeView,
+    handleViewChange,
+    handleAddView,
+    handleViewConfigChange,
+    handleRenameView,
+    handleDeleteView,
+    handleDuplicateView,
+    handleReorderViews,
+  };
+}

--- a/src/components/database/property-type-picker.test.ts
+++ b/src/components/database/property-type-picker.test.ts
@@ -10,13 +10,6 @@ import { resolve } from "path";
  * accepts a PropertyType parameter and passes it through to addProperty.
  */
 
-function readViewClient(): string {
-  return readFileSync(
-    resolve(__dirname, "./database-view-client.tsx"),
-    "utf-8",
-  );
-}
-
 function readPropertiesHook(): string {
   return readFileSync(
     resolve(__dirname, "./hooks/use-database-properties.ts"),

--- a/src/components/database/property-type-picker.test.ts
+++ b/src/components/database/property-type-picker.test.ts
@@ -17,6 +17,13 @@ function readViewClient(): string {
   );
 }
 
+function readPropertiesHook(): string {
+  return readFileSync(
+    resolve(__dirname, "./hooks/use-database-properties.ts"),
+    "utf-8",
+  );
+}
+
 function readTableView(): string {
   return readFileSync(
     resolve(__dirname, "./views/table-view.tsx"),
@@ -32,22 +39,23 @@ function readPropertyTypePicker(): string {
 }
 
 describe("property type selector regression (#538)", () => {
-  const viewClient = readViewClient();
+  // handleAddColumn was extracted to the useDatabaseProperties hook
+  const propertiesHook = readPropertiesHook();
 
   it("handleAddColumn accepts a type parameter", () => {
     // The callback must accept a PropertyType, not be a zero-arg function.
-    expect(viewClient).toMatch(/handleAddColumn[^]*?async\s*\(\s*type\s*:\s*PropertyType\s*\)/);
+    expect(propertiesHook).toMatch(/handleAddColumn[^]*?async\s*\(\s*type\s*:\s*PropertyType\s*\)/);
   });
 
   it("addProperty is called with the type parameter, not a hardcoded string", () => {
     // Must NOT contain addProperty(pageId, name, "text") — the type should be dynamic.
     const hardcodedCall = /addProperty\(\s*pageId\s*,\s*name\s*,\s*"text"\s*\)/;
-    expect(viewClient).not.toMatch(hardcodedCall);
+    expect(propertiesHook).not.toMatch(hardcodedCall);
   });
 
   it("addProperty is called with the dynamic type variable", () => {
     // Must contain addProperty(pageId, name, type, ...) — using the parameter.
-    expect(viewClient).toMatch(/addProperty\(\s*pageId\s*,\s*name\s*,\s*type\b/);
+    expect(propertiesHook).toMatch(/addProperty\(\s*pageId\s*,\s*name\s*,\s*type\b/);
   });
 
   it("table view uses PropertyTypePicker for add-column", () => {
@@ -69,27 +77,28 @@ describe("property type selector regression (#538)", () => {
  * These tests verify the view client uses the extracted helper.
  */
 describe("default column name matches property type (#563)", () => {
-  const viewClient = readViewClient();
+  // Column naming logic was extracted to the useDatabaseProperties hook
+  const propertiesHook = readPropertiesHook();
 
   it("imports generateColumnName from column-helpers", () => {
-    expect(viewClient).toContain("generateColumnName");
-    expect(viewClient).toMatch(
+    expect(propertiesHook).toContain("generateColumnName");
+    expect(propertiesHook).toMatch(
       /import\s*\{[^}]*generateColumnName[^}]*\}\s*from\s*["']@\/lib\/column-helpers["']/,
     );
   });
 
   it("does not use the generic 'Property N' naming pattern", () => {
     // The old pattern: `Property ${properties.length + 1}`
-    expect(viewClient).not.toMatch(/`Property \$\{properties\.length/);
+    expect(propertiesHook).not.toMatch(/`Property \$\{properties\.length/);
   });
 
   it("calls generateColumnName to derive the column name", () => {
-    expect(viewClient).toMatch(/generateColumnName\s*\(/);
+    expect(propertiesHook).toMatch(/generateColumnName\s*\(/);
   });
 
   it("calls getDefaultColumnConfig to derive the column config", () => {
-    expect(viewClient).toContain("getDefaultColumnConfig");
-    expect(viewClient).toMatch(/getDefaultColumnConfig\s*\(/);
+    expect(propertiesHook).toContain("getDefaultColumnConfig");
+    expect(propertiesHook).toMatch(/getDefaultColumnConfig\s*\(/);
   });
 });
 


### PR DESCRIPTION
Closes #670

## What

Decomposes `database-view-client.tsx` (1073 lines, 30+ callbacks) into focused hooks and sub-components. The main file is now 367 lines — pure composition of hooks and JSX.

## How

Extracted four domain hooks into `src/components/database/hooks/`:

| Hook | Responsibility | Callbacks |
|---|---|---|
| `useDatabaseViews` | View CRUD + active view derivation | add, rename, delete, duplicate, reorder, config change |
| `useDatabaseRows` | Row mutations | add, delete, cell update, card move |
| `useDatabaseProperties` | Property CRUD + rename/delete dialog state | add, rename, delete, reorder, column header click |
| `useDatabaseFilters` | Sort/filter state + derived `displayedRows` | sorts change, filters change, sort toggle |

Extracted sub-components:
- `DeletePropertyDialog` — standalone confirmation dialog (was inline JSX)
- `database-view-helpers.tsx` — `ViewConfigDropdown`, `ComingSoonPlaceholder`, `DatabaseSkeleton`

Each hook accepts minimal props and returns callbacks + state. The `loadDatabase` effect and initial state setup remain in the main component.

## Testing

- `pnpm lint` — no new errors (0 errors, pre-existing warnings only)
- `pnpm typecheck` — passes
- `pnpm test` — 960/960 tests pass (78 files)
- Updated `property-type-picker.test.ts` to read from the extracted hook file instead of the main component
- E2E tests not run locally (dev server requires Supabase credentials) — CI will validate
- No behavior changes — all callbacks preserve identical logic