### PR TITLE
fix(database): status in group-by, In Review option, embed view switching

### DIFF
--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -351,9 +351,9 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       // Auto-detect a default config property for board and calendar views
       let config: DatabaseViewConfig = {};
       if (type === "board") {
-        const firstSelect = properties.find((p) => p.type === "select");
-        if (firstSelect) {
-          config = { group_by: firstSelect.id };
+        const firstGroupable = properties.find((p) => p.type === "select" || p.type === "status");
+        if (firstGroupable) {
+          config = { group_by: firstGroupable.id };
         }
       } else if (type === "calendar") {
         const firstDate = properties.find((p) => p.type === "date");
@@ -976,7 +976,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
                   <ViewConfigDropdown
                     label="Group by"
                     selectedId={activeView.config.group_by ?? null}
-                    options={properties.filter((p) => p.type === "select")}
+                    options={properties.filter((p) => p.type === "select" || p.type === "status")}
                     onSelect={(id) => handleViewConfigChange({ group_by: id })}
                   />
                 )}

--- a/src/components/database/property-types/status.tsx
+++ b/src/components/database/property-types/status.tsx
@@ -14,6 +14,7 @@ import { SelectDropdown } from "./select-dropdown";
 export const DEFAULT_STATUS_OPTIONS: SelectOption[] = [
   { id: "status-not-started", name: "Not Started", color: "gray" },
   { id: "status-in-progress", name: "In Progress", color: "blue" },
+  { id: "status-in-review", name: "In Review", color: "yellow" },
   { id: "status-done", name: "Done", color: "green" },
 ];
 

--- a/src/components/database/views/board-view.tsx
+++ b/src/components/database/views/board-view.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { getPropertyTypeConfig } from "@/components/database/property-types/index";
 import { evaluateFormulaForRow } from "@/components/database/property-types/formula";
+import { DEFAULT_STATUS_OPTIONS } from "@/components/database/property-types/status";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -55,8 +56,12 @@ interface DropTarget {
 // ---------------------------------------------------------------------------
 
 function getSelectOptions(property: DatabaseProperty): SelectOption[] {
-  if (Array.isArray(property.config.options)) {
+  if (Array.isArray(property.config.options) && property.config.options.length > 0) {
     return property.config.options as SelectOption[];
+  }
+  // Status properties fall back to default options when none are configured
+  if (property.type === "status") {
+    return DEFAULT_STATUS_OPTIONS;
   }
   return [];
 }
@@ -103,9 +108,9 @@ export const BoardView = memo(function BoardView({
     });
   }, [properties, viewConfig.visible_properties, groupByPropertyId]);
 
-  // Build columns from select options
+  // Build columns from select/status options
   const columns = useMemo(() => {
-    if (!groupByProperty || groupByProperty.type !== "select") return [];
+    if (!groupByProperty || (groupByProperty.type !== "select" && groupByProperty.type !== "status")) return [];
 
     const options = getSelectOptions(groupByProperty);
     const hideEmpty = viewConfig.hide_empty_groups ?? false;
@@ -235,10 +240,10 @@ export const BoardView = memo(function BoardView({
 
   // --- No group_by configured ---
 
-  if (!groupByProperty || groupByProperty.type !== "select") {
+  if (!groupByProperty || (groupByProperty.type !== "select" && groupByProperty.type !== "status")) {
     return (
       <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
-        Select a &quot;Group by&quot; property (select type) to use board view
+        Select a &quot;Group by&quot; property (select or status type) to use board view
       </div>
     );
   }

--- a/src/components/editor/database-node.tsx
+++ b/src/components/editor/database-node.tsx
@@ -13,8 +13,11 @@ import type {
 import { $applyNodeReplacement, DecoratorNode } from "lexical";
 import { Maximize2, Table2 } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { lazyCaptureException } from "@/lib/capture";
 import { VIEW_TYPE_ICON } from "@/components/database/view-tabs";
+import { BoardView } from "@/components/database/views/board-view";
+import { ListView } from "@/components/database/views/list-view";
+import { CalendarView } from "@/components/database/views/calendar-view";
+import { GalleryView } from "@/components/database/views/gallery-view";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -236,12 +239,14 @@ function InlineDatabaseComponent({
     );
   }
 
-  // Compact table rendering (max 5 rows, no filter/sort bar)
+  // Visible properties for compact table fallback
   const visibleProperties = activeView?.config.visible_properties
     ? data.properties.filter((p) =>
         activeView.config.visible_properties!.includes(p.id),
       )
     : data.properties.slice(0, 4);
+
+  const workspaceSlug = params.workspaceSlug ?? "";
 
   return (
     <div className="mt-3 border border-overlay-border">
@@ -293,68 +298,160 @@ function InlineDatabaseComponent({
         </button>
       </div>
 
-      {/* Compact view — table rows only, no filter/sort */}
+      {/* View content — renders the correct view type */}
       <div className="overflow-x-auto">
-        <table className="w-full border-collapse text-sm">
-          <thead>
-            <tr>
-              {/* Title column */}
-              <th className="bg-muted p-2 text-left text-xs font-medium uppercase tracking-widest text-muted-foreground border-b border-overlay-border">
-                Title
-              </th>
-              {visibleProperties.map((prop) => (
-                <th
-                  key={prop.id}
-                  className="bg-muted p-2 text-left text-xs font-medium uppercase tracking-widest text-muted-foreground border-b border-overlay-border"
-                >
-                  {prop.name}
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {data.rows.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={visibleProperties.length + 1}
-                  className="px-2 py-6 text-center text-xs text-muted-foreground"
-                >
-                  No rows yet
-                </td>
-              </tr>
-            ) : (
-              data.rows.map((row) => (
-                <tr
-                  key={row.page.id}
-                  className="hover:bg-overlay-subtle border-b border-overlay-border"
-                >
-                  <td className="p-2 text-sm truncate max-w-[200px]">
-                    {row.page.icon && (
-                      <span className="mr-1">{row.page.icon}</span>
-                    )}
-                    {row.page.title || "Untitled"}
-                  </td>
-                  {visibleProperties.map((prop) => {
-                    const rowValue = row.values[prop.id];
-                    const displayValue = rowValue?.value
-                      ? formatCellValue(prop.type, rowValue.value)
-                      : "";
-                    return (
-                      <td
-                        key={prop.id}
-                        className="p-2 text-sm text-muted-foreground truncate max-w-[150px]"
-                      >
-                        {displayValue}
-                      </td>
-                    );
-                  })}
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+        <InlineViewContent
+          viewType={activeView?.type ?? "table"}
+          viewConfig={activeView?.config ?? {}}
+          rows={data.rows}
+          properties={data.properties}
+          visibleProperties={visibleProperties}
+          workspaceSlug={workspaceSlug}
+        />
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// InlineViewContent — renders the correct view type for the embed
+// ---------------------------------------------------------------------------
+
+function InlineViewContent({
+  viewType,
+  viewConfig,
+  rows,
+  properties,
+  visibleProperties,
+  workspaceSlug,
+}: {
+  viewType: string;
+  viewConfig: DatabaseView["config"];
+  rows: DatabaseRow[];
+  properties: DatabaseProperty[];
+  visibleProperties: DatabaseProperty[];
+  workspaceSlug: string;
+}) {
+  switch (viewType) {
+    case "board":
+      return (
+        <div className="p-2">
+          <BoardView
+            rows={rows}
+            properties={properties}
+            viewConfig={viewConfig}
+            workspaceSlug={workspaceSlug}
+          />
+        </div>
+      );
+    case "list":
+      return (
+        <div className="p-2">
+          <ListView
+            rows={rows}
+            properties={properties}
+            viewConfig={viewConfig}
+            workspaceSlug={workspaceSlug}
+          />
+        </div>
+      );
+    case "calendar":
+      return (
+        <div className="p-2">
+          <CalendarView
+            rows={rows}
+            properties={properties}
+            viewConfig={viewConfig}
+            workspaceSlug={workspaceSlug}
+          />
+        </div>
+      );
+    case "gallery":
+      return (
+        <div className="p-2">
+          <GalleryView
+            rows={rows}
+            properties={properties}
+            viewConfig={viewConfig}
+            workspaceSlug={workspaceSlug}
+          />
+        </div>
+      );
+    case "table":
+    default:
+      return <CompactTableView rows={rows} visibleProperties={visibleProperties} />;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CompactTableView — inline table rendering (max 5 rows, no filter/sort)
+// ---------------------------------------------------------------------------
+
+function CompactTableView({
+  rows,
+  visibleProperties,
+}: {
+  rows: DatabaseRow[];
+  visibleProperties: DatabaseProperty[];
+}) {
+  return (
+    <table className="w-full border-collapse text-sm">
+      <thead>
+        <tr>
+          <th className="bg-muted p-2 text-left text-xs font-medium uppercase tracking-widest text-muted-foreground border-b border-overlay-border">
+            Title
+          </th>
+          {visibleProperties.map((prop) => (
+            <th
+              key={prop.id}
+              className="bg-muted p-2 text-left text-xs font-medium uppercase tracking-widest text-muted-foreground border-b border-overlay-border"
+            >
+              {prop.name}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.length === 0 ? (
+          <tr>
+            <td
+              colSpan={visibleProperties.length + 1}
+              className="px-2 py-6 text-center text-xs text-muted-foreground"
+            >
+              No rows yet
+            </td>
+          </tr>
+        ) : (
+          rows.map((row) => (
+            <tr
+              key={row.page.id}
+              className="hover:bg-overlay-subtle border-b border-overlay-border"
+            >
+              <td className="p-2 text-sm truncate max-w-[200px]">
+                {row.page.icon && (
+                  <span className="mr-1">{row.page.icon}</span>
+                )}
+                {row.page.title || "Untitled"}
+              </td>
+              {visibleProperties.map((prop) => {
+                const rowValue = row.values[prop.id];
+                const displayValue = rowValue?.value
+                  ? formatCellValue(prop.type, rowValue.value)
+                  : "";
+                return (
+                  <td
+                    key={prop.id}
+                    className="p-2 text-sm text-muted-foreground truncate max-w-[150px]"
+                  >
+                    {displayValue}
+                  </td>
+                );
+              })}
+            </tr>
+          ))
+        )}
+      </tbody>
+    </table>
   );
 }
 


### PR DESCRIPTION
## What

Fixes three database bugs reported together:

1. **Status missing from Board "Group by"** — The dropdown only listed `select` properties, excluding `status`. The board column logic also rejected non-`select` types.
2. **No "In Review" default status** — `DEFAULT_STATUS_OPTIONS` only had Not Started, In Progress, Done.
3. **Embedded database view switching broken** — The inline database component in the editor always rendered a `<table>` regardless of which view tab was selected.

## Changes

- **`status.tsx`** — Add "In Review" (yellow) to `DEFAULT_STATUS_OPTIONS` between In Progress and Done.
- **`database-view-client.tsx`** — Group By dropdown filter includes `status` type. Auto-detect when creating a board view also checks for `status` properties.
- **`board-view.tsx`** — Column-building logic accepts `status` in addition to `select`. Falls back to `DEFAULT_STATUS_OPTIONS` when a status property has no custom options.
- **`database-node.tsx`** — Refactored `InlineDatabaseComponent` to dispatch to the actual view components (`BoardView`, `ListView`, `CalendarView`, `GalleryView`) based on `activeView.type`, with compact table as the default fallback. Removed unused `lazyCaptureException` import.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (no new warnings)
- `pnpm test` ✅ (960 tests pass)