### PR TITLE
feat: add skip-to-content link for keyboard and screen reader accessibility (#692)

### DIFF
--- a/e2e/skip-to-content.spec.ts
+++ b/e2e/skip-to-content.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "./fixtures/auth";
+
+test.describe("skip to content link", () => {
+  test("is the first focusable element and moves focus to main", async ({
+    authenticatedPage: page,
+  }) => {
+    // Press Tab — the skip link should be the first element to receive focus
+    await page.keyboard.press("Tab");
+
+    const skipLink = page.locator('a[href="#main-content"]');
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toHaveText("Skip to content");
+
+    // The link should be visible when focused (not sr-only)
+    await expect(skipLink).toBeVisible();
+
+    // Activate the skip link
+    await page.keyboard.press("Enter");
+
+    // Focus should move to the main content area
+    const main = page.locator("main#main-content");
+    await expect(main).toBeFocused();
+  });
+
+  test("is visually hidden when not focused", async ({
+    authenticatedPage: page,
+  }) => {
+    const skipLink = page.locator('a[href="#main-content"]');
+
+    // The link exists in the DOM but is visually hidden (sr-only)
+    await expect(skipLink).toBeAttached();
+    const box = await skipLink.boundingBox();
+    // sr-only makes the element 1x1px and clips it
+    expect(box?.width).toBeLessThanOrEqual(1);
+    expect(box?.height).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/components/sidebar/app-shell.tsx
+++ b/src/components/sidebar/app-shell.tsx
@@ -45,6 +45,12 @@ function AppShellInner({
 }: AppShellProps) {
   return (
     <div className="flex h-screen overflow-hidden">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-text-primary focus:shadow-md focus:ring-2 focus:ring-accent-primary focus:outline-none"
+      >
+        Skip to content
+      </a>
       <AppSidebar
         userId={userId}
         displayName={displayName}
@@ -54,7 +60,7 @@ function AppShellInner({
         <header className="flex h-10 shrink-0 items-center gap-2 border-b border-overlay-border px-4 md:hidden">
           <SidebarToggle />
         </header>
-        <main className="flex-1 overflow-y-auto">{children}</main>
+        <main id="main-content" tabIndex={-1} className="flex-1 overflow-y-auto focus:outline-none">{children}</main>
       </div>
       <FocusModeHint />
     </div>

--- a/src/components/sidebar/app-shell.tsx
+++ b/src/components/sidebar/app-shell.tsx
@@ -47,7 +47,7 @@ function AppShellInner({
     <div className="flex h-screen overflow-hidden">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-bg-primary focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-text-primary focus:shadow-md focus:ring-2 focus:ring-accent-primary focus:outline-none"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
       >
         Skip to content
       </a>


### PR DESCRIPTION
Closes #692

## What

Adds a "Skip to content" link as the first focusable element in the app shell. This is a WCAG 2.1 Level A requirement (Success Criterion 2.4.1) that allows keyboard-only and screen reader users to bypass the sidebar navigation and jump directly to the main content area.

## How

- Added an anchor link (`<a href="#main-content">Skip to content</a>`) as the first child inside `AppShellInner`, before the sidebar
- The link uses Tailwind's `sr-only` / `focus:not-sr-only` pattern: visually hidden by default, becomes visible and styled when focused
- Added `id="main-content"` and `tabIndex={-1}` to the `<main>` element so it can receive focus when the skip link is activated
- Added `focus:outline-none` to `<main>` to prevent a visible focus ring on the content area

## Testing

- E2E test (`e2e/skip-to-content.spec.ts`) verifies:
  - The skip link is the first focusable element when pressing Tab
  - The link text reads "Skip to content"
  - The link is visible when focused
  - Activating the link moves focus to the main content area
  - The link is visually hidden (sr-only) when not focused
- `pnpm lint && pnpm typecheck && pnpm test` — all pass
- `pnpm test:e2e` on skip-to-content spec — 2/2 pass