### PR TITLE
feat: expand unauthenticated E2E specs in CI (#704)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: npx playwright install --with-deps chromium
       - name: Run unauthenticated E2E tests
-        run: pnpm test:e2e -- e2e/auth.spec.ts
+        run: pnpm test:e2e -- e2e/auth.spec.ts e2e/public-routes.spec.ts
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}

--- a/e2e/public-routes.spec.ts
+++ b/e2e/public-routes.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Landing page", () => {
+  test("renders title, tagline, and navigation links", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "Memo" })).toBeVisible();
+    await expect(
+      page.getByText("A Notion-style workspace, built with zero human code."),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /view source/i }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: /sign in/i })).toBeVisible();
+  });
+
+  test("has no console errors", async ({ page }) => {
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        errors.push(msg.text());
+      }
+    });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    // Filter out known non-actionable errors (e.g. favicon 404, third-party scripts)
+    const actionableErrors = errors.filter(
+      (e) => !e.includes("favicon") && !e.includes("ERR_BLOCKED_BY_CLIENT"),
+    );
+    expect(actionableErrors).toHaveLength(0);
+  });
+});
+
+test.describe("Sign-in form validation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/sign-in");
+    // Wait for hydration so controlled inputs are ready
+    await page.locator('input[type="email"]').waitFor({ state: "visible" });
+    await page.waitForTimeout(300);
+  });
+
+  test("empty submit is blocked by browser validation", async ({ page }) => {
+    await page.getByRole("button", { name: /sign in/i }).click();
+    // The form should not navigate — still on sign-in
+    expect(page.url()).toContain("/sign-in");
+    // The email input should be invalid (required but empty)
+    const emailInput = page.locator('input[type="email"]');
+    await expect(emailInput).toHaveAttribute("required", "");
+  });
+
+  test("invalid email format is blocked by browser validation", async ({
+    page,
+  }) => {
+    await page.fill('input[type="email"]', "not-an-email");
+    await page.fill('input[type="password"]', "password123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+    // Should still be on sign-in — browser blocks submission for invalid email
+    expect(page.url()).toContain("/sign-in");
+  });
+
+  test("short password is blocked by minLength validation", async ({
+    page,
+  }) => {
+    await page.fill('input[type="email"]', "test@example.com");
+    await page.fill('input[type="password"]', "abc");
+    await page.getByRole("button", { name: /sign in/i }).click();
+    // Should still be on sign-in — browser blocks submission for short password
+    expect(page.url()).toContain("/sign-in");
+  });
+});
+
+test.describe("Sign-up form validation", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/sign-up");
+    await page.locator('input[type="email"]').waitFor({ state: "visible" });
+    await page.waitForTimeout(300);
+  });
+
+  test("empty submit is blocked by browser validation", async ({ page }) => {
+    await page.getByRole("button", { name: /sign up/i }).click();
+    expect(page.url()).toContain("/sign-up");
+    // Display name, email, and password are all required
+    const displayNameInput = page.locator("#display-name");
+    await expect(displayNameInput).toHaveAttribute("required", "");
+    const emailInput = page.locator('input[type="email"]');
+    await expect(emailInput).toHaveAttribute("required", "");
+    const passwordInput = page.locator('input[type="password"]');
+    await expect(passwordInput).toHaveAttribute("required", "");
+  });
+
+  test("invalid email format is blocked by browser validation", async ({
+    page,
+  }) => {
+    await page.fill("#display-name", "Test User");
+    await page.fill('input[type="email"]', "bad-email");
+    await page.fill('input[type="password"]', "password123");
+    await page.getByRole("button", { name: /sign up/i }).click();
+    expect(page.url()).toContain("/sign-up");
+  });
+
+  test("short password is blocked by minLength validation", async ({
+    page,
+  }) => {
+    await page.fill("#display-name", "Test User");
+    await page.fill('input[type="email"]', "test@example.com");
+    await page.fill('input[type="password"]', "ab");
+    await page.getByRole("button", { name: /sign up/i }).click();
+    expect(page.url()).toContain("/sign-up");
+  });
+});
+
+test.describe("Unknown routes", () => {
+  test("unknown top-level path redirects to /sign-in for unauthenticated users", async ({
+    page,
+  }) => {
+    // All unknown paths match the [workspaceSlug] dynamic segment in the (app)
+    // route group, which redirects unauthenticated users to sign-in.
+    // The not-found page is only visible to authenticated users.
+    await page.goto("/nonexistent-route-abc123");
+    await page.waitForURL(/sign-in/, { timeout: 10_000 });
+    expect(page.url()).toContain("/sign-in");
+  });
+});
+
+test.describe("Auth redirects for protected routes", () => {
+  const protectedRoutes = [
+    "/some-workspace",
+    "/some-workspace/some-page-id",
+    "/some-workspace/settings",
+    "/some-workspace/settings/members",
+  ];
+
+  for (const route of protectedRoutes) {
+    test(`${route} redirects to /sign-in`, async ({ page }) => {
+      await page.goto(route);
+      await page.waitForURL(/sign-in/, { timeout: 10_000 });
+      expect(page.url()).toContain("/sign-in");
+    });
+  }
+});
+
+test.describe("Health API", () => {
+  test("/api/health returns a successful response", async ({ request }) => {
+    const response = await request.get("/api/health");
+    expect(response.ok()).toBe(true);
+    const body = await response.json();
+    expect(body).toHaveProperty("status");
+    expect(body).toHaveProperty("timestamp");
+    expect(["ok", "degraded"]).toContain(body.status);
+  });
+});


### PR DESCRIPTION
Closes #704

## What

Adds `e2e/public-routes.spec.ts` with 14 unauthenticated E2E tests and updates the CI workflow to run them alongside the existing `auth.spec.ts`.

## How

New spec file uses base `@playwright/test` (no auth fixture) and covers:

- **Landing page** — title, tagline, navigation links render; no console errors
- **Sign-in form validation** — empty submit blocked, invalid email blocked, short password blocked (all via HTML5 browser validation)
- **Sign-up form validation** — empty submit blocked (all 3 fields required), invalid email blocked, short password blocked
- **Unknown routes** — unauthenticated access to unknown paths redirects to `/sign-in`
- **Auth redirects** — 4 protected route patterns (`/workspace`, `/workspace/page`, `/workspace/settings`, `/workspace/settings/members`) all redirect to `/sign-in`
- **Health API** — `/api/health` returns 200 with `status` and `timestamp` fields

CI workflow updated: `pnpm test:e2e -- e2e/auth.spec.ts e2e/public-routes.spec.ts`

## 404 page note

The acceptance criteria includes "404 page renders for unknown routes." In the current routing structure, all unknown top-level paths match the `[workspaceSlug]` dynamic segment in the `(app)` route group, which redirects unauthenticated users to `/sign-in`. The root `not-found.tsx` page is only reachable by authenticated users accessing a non-existent workspace. The test verifies the actual unauthenticated behavior (redirect to sign-in) instead.

## Testing

- `pnpm lint` — 0 errors (31 pre-existing warnings)
- `pnpm typecheck` — clean
- `pnpm test -- --run` — 960 tests pass
- `pnpm test:e2e -- e2e/auth.spec.ts e2e/public-routes.spec.ts` — 22 tests pass (8 + 14)
- No `TEST_USER_EMAIL`/`TEST_USER_PASSWORD` required for the new spec