### PR TITLE
feat: add unit tests for board-view and calendar-view grouping logic (#701)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -328,8 +328,10 @@ src/components/database/
   │   ├── table-keyboard.ts       # handleCellKeyDown — editing-mode key handler
   │   ├── table-defaults.ts       # Pure helpers: value keys, select options, display values, date formatting
   │   ├── board-view.tsx           # Kanban columns grouped by select property
+  │   ├── board-view-helpers.ts    # Pure grouping/DnD logic extracted from board-view
   │   ├── list-view.tsx            # Compact vertical list
   │   ├── calendar-view.tsx        # Month grid with date-positioned items
+  │   ├── calendar-view-helpers.ts # Pure date/grid logic extracted from calendar-view
   │   └── gallery-view.tsx         # Responsive card grid with cover + title
   ├── row-properties-header.tsx    # Properties displayed above editor when row opened as page
   └── new-database-dialog.tsx      # Dialog for creating a new database
@@ -478,8 +480,10 @@ src/
 │   │   │   ├── table-keyboard.ts       # handleCellKeyDown — editing-mode key handler
 │   │   │   ├── table-defaults.ts       # Pure helpers: value keys, select options, display values
 │   │   │   ├── board-view.tsx           # Kanban columns grouped by select property
+│   │   │   ├── board-view-helpers.ts    # Pure grouping/DnD logic extracted from board-view
 │   │   │   ├── list-view.tsx            # Compact vertical list
 │   │   │   ├── calendar-view.tsx        # Month grid with date-positioned items
+│   │   │   ├── calendar-view-helpers.ts # Pure date/grid logic extracted from calendar-view
 │   │   │   └── gallery-view.tsx         # Responsive card grid with cover + title
 │   │   ├── property-type-picker.tsx      # Dropdown menu for selecting property type when adding columns
 │   │   ├── rename-property-dialog.tsx   # Styled dialog replacing window.prompt for column rename

--- a/src/components/database/views/board-view-helpers.test.ts
+++ b/src/components/database/views/board-view-helpers.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import {
+  getSelectOptions,
+  getRowOptionId,
+  groupRowsIntoColumns,
+  resolveDropOptionId,
+  UNCATEGORIZED_COLUMN_ID,
+  UNCATEGORIZED_LABEL,
+} from "./board-view-helpers";
+import { DEFAULT_STATUS_OPTIONS } from "@/components/database/property-types/status";
+import type { DatabaseProperty, DatabaseRow, RowValue } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test factories
+// ---------------------------------------------------------------------------
+
+function makeProperty(
+  overrides: Partial<DatabaseProperty> & { id: string; type: DatabaseProperty["type"] },
+): DatabaseProperty {
+  return {
+    database_id: "db-1",
+    name: overrides.name ?? "Prop",
+    config: {},
+    position: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRowValue(value: Record<string, unknown>, propertyId: string): RowValue {
+  return {
+    id: `rv-${propertyId}`,
+    row_id: "row-1",
+    property_id: propertyId,
+    value,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeRow(
+  id: string,
+  values: Record<string, RowValue> = {},
+): DatabaseRow {
+  return {
+    page: {
+      id,
+      title: `Row ${id}`,
+      icon: null,
+      cover_url: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      created_by: "user-1",
+    },
+    values,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getSelectOptions
+// ---------------------------------------------------------------------------
+
+describe("getSelectOptions", () => {
+  it("returns config.options when present and non-empty", () => {
+    const options = [
+      { id: "1", name: "A", color: "blue" },
+      { id: "2", name: "B", color: "red" },
+    ];
+    const prop = makeProperty({
+      id: "p1",
+      type: "select",
+      config: { options },
+    });
+    expect(getSelectOptions(prop)).toEqual(options);
+  });
+
+  it("returns DEFAULT_STATUS_OPTIONS for status type with empty config", () => {
+    const prop = makeProperty({ id: "p1", type: "status", config: {} });
+    expect(getSelectOptions(prop)).toEqual(DEFAULT_STATUS_OPTIONS);
+  });
+
+  it("returns DEFAULT_STATUS_OPTIONS for status type with empty options array", () => {
+    const prop = makeProperty({
+      id: "p1",
+      type: "status",
+      config: { options: [] },
+    });
+    expect(getSelectOptions(prop)).toEqual(DEFAULT_STATUS_OPTIONS);
+  });
+
+  it("returns empty array for non-status type with no options", () => {
+    const prop = makeProperty({ id: "p1", type: "select", config: {} });
+    expect(getSelectOptions(prop)).toEqual([]);
+  });
+
+  it("prefers config.options over defaults for status type", () => {
+    const custom = [{ id: "x", name: "Custom", color: "green" }];
+    const prop = makeProperty({
+      id: "p1",
+      type: "status",
+      config: { options: custom },
+    });
+    expect(getSelectOptions(prop)).toEqual(custom);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRowOptionId
+// ---------------------------------------------------------------------------
+
+describe("getRowOptionId", () => {
+  it("returns the option_id when present", () => {
+    const row = makeRow("r1", {
+      prop1: makeRowValue({ option_id: "opt-a" }, "prop1"),
+    });
+    expect(getRowOptionId(row, "prop1")).toBe("opt-a");
+  });
+
+  it("returns null when the property has no value", () => {
+    const row = makeRow("r1", {});
+    expect(getRowOptionId(row, "prop1")).toBeNull();
+  });
+
+  it("returns null when option_id is not a string", () => {
+    const row = makeRow("r1", {
+      prop1: makeRowValue({ option_id: 123 }, "prop1"),
+    });
+    expect(getRowOptionId(row, "prop1")).toBeNull();
+  });
+
+  it("returns null when option_id is missing from value", () => {
+    const row = makeRow("r1", {
+      prop1: makeRowValue({ text: "hello" }, "prop1"),
+    });
+    expect(getRowOptionId(row, "prop1")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupRowsIntoColumns
+// ---------------------------------------------------------------------------
+
+describe("groupRowsIntoColumns", () => {
+  const options = [
+    { id: "opt-a", name: "To Do", color: "gray" },
+    { id: "opt-b", name: "In Progress", color: "blue" },
+    { id: "opt-c", name: "Done", color: "green" },
+  ];
+
+  const groupByProperty = makeProperty({
+    id: "status-prop",
+    type: "select",
+    config: { options },
+  });
+
+  it("groups rows into the correct columns", () => {
+    const rows = [
+      makeRow("r1", { "status-prop": makeRowValue({ option_id: "opt-a" }, "status-prop") }),
+      makeRow("r2", { "status-prop": makeRowValue({ option_id: "opt-b" }, "status-prop") }),
+      makeRow("r3", { "status-prop": makeRowValue({ option_id: "opt-a" }, "status-prop") }),
+    ];
+
+    const cols = groupRowsIntoColumns({
+      groupByProperty,
+      rows,
+      hideEmptyGroups: false,
+    });
+
+    // 3 option columns + 1 uncategorized
+    expect(cols).toHaveLength(4);
+    expect(cols[0].id).toBe("opt-a");
+    expect(cols[0].rows).toHaveLength(2);
+    expect(cols[0].rows[0].page.id).toBe("r1");
+    expect(cols[0].rows[1].page.id).toBe("r3");
+
+    expect(cols[1].id).toBe("opt-b");
+    expect(cols[1].rows).toHaveLength(1);
+
+    expect(cols[2].id).toBe("opt-c");
+    expect(cols[2].rows).toHaveLength(0);
+
+    expect(cols[3].id).toBe(UNCATEGORIZED_COLUMN_ID);
+    expect(cols[3].label).toBe(UNCATEGORIZED_LABEL);
+    expect(cols[3].rows).toHaveLength(0);
+  });
+
+  it("places rows without a value in the uncategorized column", () => {
+    const rows = [
+      makeRow("r1", {}), // no value at all
+      makeRow("r2", { "status-prop": makeRowValue({ text: "hello" }, "status-prop") }), // no option_id
+    ];
+
+    const cols = groupRowsIntoColumns({
+      groupByProperty,
+      rows,
+      hideEmptyGroups: false,
+    });
+
+    const uncategorized = cols.find((c) => c.id === UNCATEGORIZED_COLUMN_ID);
+    expect(uncategorized).toBeDefined();
+    expect(uncategorized!.rows).toHaveLength(2);
+  });
+
+  it("returns columns with uncategorized for an empty database", () => {
+    const cols = groupRowsIntoColumns({
+      groupByProperty,
+      rows: [],
+      hideEmptyGroups: false,
+    });
+
+    // All option columns (empty) + uncategorized
+    expect(cols).toHaveLength(4);
+    cols.forEach((col) => expect(col.rows).toHaveLength(0));
+  });
+
+  it("hides empty columns when hideEmptyGroups is true", () => {
+    const rows = [
+      makeRow("r1", { "status-prop": makeRowValue({ option_id: "opt-a" }, "status-prop") }),
+    ];
+
+    const cols = groupRowsIntoColumns({
+      groupByProperty,
+      rows,
+      hideEmptyGroups: true,
+    });
+
+    // Only opt-a has rows; opt-b, opt-c, and uncategorized are empty and hidden
+    expect(cols).toHaveLength(1);
+    expect(cols[0].id).toBe("opt-a");
+  });
+
+  it("shows uncategorized column when it has rows even with hideEmptyGroups", () => {
+    const rows = [
+      makeRow("r1", {}), // uncategorized
+    ];
+
+    const cols = groupRowsIntoColumns({
+      groupByProperty,
+      rows,
+      hideEmptyGroups: true,
+    });
+
+    // Only uncategorized has rows
+    expect(cols).toHaveLength(1);
+    expect(cols[0].id).toBe(UNCATEGORIZED_COLUMN_ID);
+    expect(cols[0].rows).toHaveLength(1);
+  });
+
+  it("preserves column order matching the options array", () => {
+    const rows = [
+      makeRow("r1", { "status-prop": makeRowValue({ option_id: "opt-c" }, "status-prop") }),
+      makeRow("r2", { "status-prop": makeRowValue({ option_id: "opt-a" }, "status-prop") }),
+    ];
+
+    const cols = groupRowsIntoColumns({
+      groupByProperty,
+      rows,
+      hideEmptyGroups: false,
+    });
+
+    expect(cols[0].id).toBe("opt-a");
+    expect(cols[1].id).toBe("opt-b");
+    expect(cols[2].id).toBe("opt-c");
+    expect(cols[3].id).toBe(UNCATEGORIZED_COLUMN_ID);
+  });
+
+  it("handles rows with option_ids not matching any defined option", () => {
+    const rows = [
+      makeRow("r1", { "status-prop": makeRowValue({ option_id: "opt-unknown" }, "status-prop") }),
+    ];
+
+    const cols = groupRowsIntoColumns({
+      groupByProperty,
+      rows,
+      hideEmptyGroups: false,
+    });
+
+    // The row has an option_id but it doesn't match any option, so it won't
+    // appear in any option column. It also won't be in uncategorized because
+    // it has a non-null option_id. This is the expected behavior — orphaned
+    // option_ids are silently dropped from the board.
+    const allRowIds = cols.flatMap((c) => c.rows.map((r) => r.page.id));
+    expect(allRowIds).not.toContain("r1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDropOptionId
+// ---------------------------------------------------------------------------
+
+describe("resolveDropOptionId", () => {
+  it("returns null for the uncategorized column", () => {
+    expect(resolveDropOptionId(UNCATEGORIZED_COLUMN_ID)).toBeNull();
+  });
+
+  it("returns the column ID as the option ID for regular columns", () => {
+    expect(resolveDropOptionId("opt-a")).toBe("opt-a");
+    expect(resolveDropOptionId("some-id")).toBe("some-id");
+  });
+});

--- a/src/components/database/views/board-view-helpers.ts
+++ b/src/components/database/views/board-view-helpers.ts
@@ -1,0 +1,128 @@
+// Pure functions for board-view grouping and drag-and-drop resolution.
+// No React dependencies — all computation is side-effect-free.
+
+import { DEFAULT_STATUS_OPTIONS } from "@/components/database/property-types/status";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  SelectOption,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const UNCATEGORIZED_COLUMN_ID = "__uncategorized__";
+export const UNCATEGORIZED_LABEL = "No value";
+
+// ---------------------------------------------------------------------------
+// Column data type
+// ---------------------------------------------------------------------------
+
+export interface ColumnData {
+  id: string;
+  label: string;
+  color: string;
+  rows: DatabaseRow[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve the effective select/status options for a property. */
+export function getSelectOptions(property: DatabaseProperty): SelectOption[] {
+  if (Array.isArray(property.config.options) && property.config.options.length > 0) {
+    return property.config.options as SelectOption[];
+  }
+  if (property.type === "status") {
+    return DEFAULT_STATUS_OPTIONS;
+  }
+  return [];
+}
+
+/** Extract the option_id from a row's value for a given property. */
+export function getRowOptionId(row: DatabaseRow, propertyId: string): string | null {
+  const rv = row.values[propertyId];
+  if (!rv) return null;
+  const optionId = rv.value?.option_id;
+  return typeof optionId === "string" ? optionId : null;
+}
+
+// ---------------------------------------------------------------------------
+// Column grouping
+// ---------------------------------------------------------------------------
+
+export interface GroupColumnsOptions {
+  groupByProperty: DatabaseProperty;
+  rows: DatabaseRow[];
+  hideEmptyGroups: boolean;
+}
+
+/**
+ * Group rows into board columns based on a select/status property.
+ * Returns one column per option, plus an uncategorized column for rows
+ * without a value (or when hideEmptyGroups is false).
+ */
+export function groupRowsIntoColumns({
+  groupByProperty,
+  rows,
+  hideEmptyGroups,
+}: GroupColumnsOptions): ColumnData[] {
+  const options = getSelectOptions(groupByProperty);
+
+  // Group rows by option_id
+  const rowsByOption = new Map<string, DatabaseRow[]>();
+  const uncategorized: DatabaseRow[] = [];
+
+  for (const row of rows) {
+    const optionId = getRowOptionId(row, groupByProperty.id);
+    if (!optionId) {
+      uncategorized.push(row);
+    } else {
+      const existing = rowsByOption.get(optionId);
+      if (existing) {
+        existing.push(row);
+      } else {
+        rowsByOption.set(optionId, [row]);
+      }
+    }
+  }
+
+  const cols: ColumnData[] = [];
+
+  for (const option of options) {
+    const columnRows = rowsByOption.get(option.id) ?? [];
+    if (hideEmptyGroups && columnRows.length === 0) continue;
+    cols.push({
+      id: option.id,
+      label: option.name,
+      color: option.color,
+      rows: columnRows,
+    });
+  }
+
+  // Uncategorized column last
+  if (uncategorized.length > 0 || !hideEmptyGroups) {
+    cols.push({
+      id: UNCATEGORIZED_COLUMN_ID,
+      label: UNCATEGORIZED_LABEL,
+      color: "gray",
+      rows: uncategorized,
+    });
+  }
+
+  return cols;
+}
+
+// ---------------------------------------------------------------------------
+// Drag-and-drop resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a drop target column ID to the option_id that should be set on the
+ * moved card. Returns `null` for the uncategorized column (clear the value).
+ */
+export function resolveDropOptionId(columnId: string): string | null {
+  return columnId === UNCATEGORIZED_COLUMN_ID ? null : columnId;
+}

--- a/src/components/database/views/board-view.tsx
+++ b/src/components/database/views/board-view.tsx
@@ -5,20 +5,17 @@ import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { getPropertyTypeConfig } from "@/components/database/property-types/index";
 import { evaluateFormulaForRow } from "@/components/database/property-types/formula";
-import { DEFAULT_STATUS_OPTIONS } from "@/components/database/property-types/status";
 import type {
   DatabaseProperty,
   DatabaseRow,
   DatabaseViewConfig,
-  SelectOption,
 } from "@/lib/types";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const UNCATEGORIZED_COLUMN_ID = "__uncategorized__";
-const UNCATEGORIZED_LABEL = "No value";
+import {
+  UNCATEGORIZED_COLUMN_ID,
+  groupRowsIntoColumns,
+  resolveDropOptionId,
+  type ColumnData,
+} from "./board-view-helpers";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -51,27 +48,7 @@ interface DropTarget {
   insertIndex: number;
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
-function getSelectOptions(property: DatabaseProperty): SelectOption[] {
-  if (Array.isArray(property.config.options) && property.config.options.length > 0) {
-    return property.config.options as SelectOption[];
-  }
-  // Status properties fall back to default options when none are configured
-  if (property.type === "status") {
-    return DEFAULT_STATUS_OPTIONS;
-  }
-  return [];
-}
-
-function getRowOptionId(row: DatabaseRow, propertyId: string): string | null {
-  const rv = row.values[propertyId];
-  if (!rv) return null;
-  const optionId = rv.value?.option_id;
-  return typeof optionId === "string" ? optionId : null;
-}
 
 // ---------------------------------------------------------------------------
 // BoardView
@@ -112,51 +89,11 @@ export const BoardView = memo(function BoardView({
   const columns = useMemo(() => {
     if (!groupByProperty || (groupByProperty.type !== "select" && groupByProperty.type !== "status")) return [];
 
-    const options = getSelectOptions(groupByProperty);
-    const hideEmpty = viewConfig.hide_empty_groups ?? false;
-
-    // Group rows by option_id
-    const rowsByOption = new Map<string, DatabaseRow[]>();
-    const uncategorized: DatabaseRow[] = [];
-
-    for (const row of rows) {
-      const optionId = getRowOptionId(row, groupByProperty.id);
-      if (!optionId) {
-        uncategorized.push(row);
-      } else {
-        const existing = rowsByOption.get(optionId);
-        if (existing) {
-          existing.push(row);
-        } else {
-          rowsByOption.set(optionId, [row]);
-        }
-      }
-    }
-
-    const cols: ColumnData[] = [];
-
-    for (const option of options) {
-      const columnRows = rowsByOption.get(option.id) ?? [];
-      if (hideEmpty && columnRows.length === 0) continue;
-      cols.push({
-        id: option.id,
-        label: option.name,
-        color: option.color,
-        rows: columnRows,
-      });
-    }
-
-    // Uncategorized column last
-    if (uncategorized.length > 0 || !hideEmpty) {
-      cols.push({
-        id: UNCATEGORIZED_COLUMN_ID,
-        label: UNCATEGORIZED_LABEL,
-        color: "gray",
-        rows: uncategorized,
-      });
-    }
-
-    return cols;
+    return groupRowsIntoColumns({
+      groupByProperty,
+      rows,
+      hideEmptyGroups: viewConfig.hide_empty_groups ?? false,
+    });
   }, [groupByProperty, rows, viewConfig.hide_empty_groups]);
 
   // --- Drag handlers ---
@@ -209,7 +146,7 @@ export const BoardView = memo(function BoardView({
       e.preventDefault();
       if (!dragState || !onCardMove || !groupByProperty) return;
 
-      const newOptionId = columnId === UNCATEGORIZED_COLUMN_ID ? null : columnId;
+      const newOptionId = resolveDropOptionId(columnId);
       onCardMove(dragState.rowId, groupByProperty.id, newOptionId);
 
       setDragState(null);
@@ -274,17 +211,6 @@ export const BoardView = memo(function BoardView({
     </div>
   );
 });
-
-// ---------------------------------------------------------------------------
-// Column data type
-// ---------------------------------------------------------------------------
-
-interface ColumnData {
-  id: string;
-  label: string;
-  color: string;
-  rows: DatabaseRow[];
-}
 
 // ---------------------------------------------------------------------------
 // BoardColumn

--- a/src/components/database/views/calendar-view-helpers.test.ts
+++ b/src/components/database/views/calendar-view-helpers.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from "vitest";
+import {
+  toISODate,
+  getDaysInMonth,
+  getFirstDayOfWeek,
+  getRowDate,
+  groupRowsByDate,
+  buildCalendarGrid,
+  prevMonth,
+  nextMonth,
+} from "./calendar-view-helpers";
+import type { DatabaseRow, RowValue } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test factories
+// ---------------------------------------------------------------------------
+
+function makeRowValue(value: Record<string, unknown>, propertyId: string): RowValue {
+  return {
+    id: `rv-${propertyId}`,
+    row_id: "row-1",
+    property_id: propertyId,
+    value,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeRow(
+  id: string,
+  values: Record<string, RowValue> = {},
+): DatabaseRow {
+  return {
+    page: {
+      id,
+      title: `Row ${id}`,
+      icon: null,
+      cover_url: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      created_by: "user-1",
+    },
+    values,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// toISODate
+// ---------------------------------------------------------------------------
+
+describe("toISODate", () => {
+  it("formats a date with zero-padded month and day", () => {
+    // month is 0-indexed: 0 = January
+    expect(toISODate(2026, 0, 5)).toBe("2026-01-05");
+  });
+
+  it("formats December correctly", () => {
+    expect(toISODate(2026, 11, 25)).toBe("2026-12-25");
+  });
+
+  it("formats double-digit month and day", () => {
+    expect(toISODate(2026, 9, 15)).toBe("2026-10-15");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDaysInMonth
+// ---------------------------------------------------------------------------
+
+describe("getDaysInMonth", () => {
+  it("returns 31 for January", () => {
+    expect(getDaysInMonth(2026, 0)).toBe(31);
+  });
+
+  it("returns 28 for February in a non-leap year", () => {
+    expect(getDaysInMonth(2025, 1)).toBe(28);
+  });
+
+  it("returns 29 for February in a leap year", () => {
+    expect(getDaysInMonth(2024, 1)).toBe(29);
+  });
+
+  it("returns 30 for April", () => {
+    expect(getDaysInMonth(2026, 3)).toBe(30);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFirstDayOfWeek
+// ---------------------------------------------------------------------------
+
+describe("getFirstDayOfWeek", () => {
+  it("returns the correct day of week for a known date", () => {
+    // January 1, 2026 is a Thursday (4)
+    expect(getFirstDayOfWeek(2026, 0)).toBe(4);
+  });
+
+  it("returns 0 for a month starting on Sunday", () => {
+    // March 2026 starts on Sunday
+    expect(getFirstDayOfWeek(2026, 2)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRowDate
+// ---------------------------------------------------------------------------
+
+describe("getRowDate", () => {
+  it("extracts date from { date: 'YYYY-MM-DD' } format", () => {
+    const row = makeRow("r1", {
+      "date-prop": makeRowValue({ date: "2026-04-15" }, "date-prop"),
+    });
+    expect(getRowDate(row, "date-prop")).toBe("2026-04-15");
+  });
+
+  it("extracts date from { value: 'YYYY-MM-DD' } format", () => {
+    const row = makeRow("r1", {
+      "date-prop": makeRowValue({ value: "2026-04-15" }, "date-prop"),
+    });
+    expect(getRowDate(row, "date-prop")).toBe("2026-04-15");
+  });
+
+  it("truncates datetime strings to date-only", () => {
+    const row = makeRow("r1", {
+      "date-prop": makeRowValue({ date: "2026-04-15T12:30:00Z" }, "date-prop"),
+    });
+    expect(getRowDate(row, "date-prop")).toBe("2026-04-15");
+  });
+
+  it("returns null when the property has no value", () => {
+    const row = makeRow("r1", {});
+    expect(getRowDate(row, "date-prop")).toBeNull();
+  });
+
+  it("returns null when the date value is not a string", () => {
+    const row = makeRow("r1", {
+      "date-prop": makeRowValue({ date: 12345 }, "date-prop"),
+    });
+    expect(getRowDate(row, "date-prop")).toBeNull();
+  });
+
+  it("returns null when the date string is too short", () => {
+    const row = makeRow("r1", {
+      "date-prop": makeRowValue({ date: "2026" }, "date-prop"),
+    });
+    expect(getRowDate(row, "date-prop")).toBeNull();
+  });
+
+  it("prefers 'date' key over 'value' key", () => {
+    const row = makeRow("r1", {
+      "date-prop": makeRowValue({ date: "2026-04-15", value: "2026-05-20" }, "date-prop"),
+    });
+    expect(getRowDate(row, "date-prop")).toBe("2026-04-15");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupRowsByDate
+// ---------------------------------------------------------------------------
+
+describe("groupRowsByDate", () => {
+  it("groups rows by their date value", () => {
+    const rows = [
+      makeRow("r1", { dp: makeRowValue({ date: "2026-04-10" }, "dp") }),
+      makeRow("r2", { dp: makeRowValue({ date: "2026-04-10" }, "dp") }),
+      makeRow("r3", { dp: makeRowValue({ date: "2026-04-15" }, "dp") }),
+    ];
+
+    const map = groupRowsByDate(rows, "dp");
+    expect(map.size).toBe(2);
+    expect(map.get("2026-04-10")).toHaveLength(2);
+    expect(map.get("2026-04-15")).toHaveLength(1);
+  });
+
+  it("skips rows without a date value", () => {
+    const rows = [
+      makeRow("r1", { dp: makeRowValue({ date: "2026-04-10" }, "dp") }),
+      makeRow("r2", {}), // no value
+      makeRow("r3", { dp: makeRowValue({ text: "not a date" }, "dp") }),
+    ];
+
+    const map = groupRowsByDate(rows, "dp");
+    expect(map.size).toBe(1);
+    expect(map.get("2026-04-10")).toHaveLength(1);
+  });
+
+  it("returns an empty map for an empty rows array", () => {
+    const map = groupRowsByDate([], "dp");
+    expect(map.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCalendarGrid
+// ---------------------------------------------------------------------------
+
+describe("buildCalendarGrid", () => {
+  it("produces a grid divisible by 7 (complete weeks)", () => {
+    const cells = buildCalendarGrid(2026, 3, new Map(), "2026-04-24");
+    expect(cells.length % 7).toBe(0);
+  });
+
+  it("includes all days of the target month", () => {
+    // April 2026 has 30 days
+    const cells = buildCalendarGrid(2026, 3, new Map(), "2026-04-24");
+    const currentMonthCells = cells.filter((c) => c.isCurrentMonth);
+    expect(currentMonthCells).toHaveLength(30);
+    expect(currentMonthCells[0].day).toBe(1);
+    expect(currentMonthCells[29].day).toBe(30);
+  });
+
+  it("marks the correct cell as today", () => {
+    const cells = buildCalendarGrid(2026, 3, new Map(), "2026-04-15");
+    const todayCell = cells.find((c) => c.isToday);
+    expect(todayCell).toBeDefined();
+    expect(todayCell!.date).toBe("2026-04-15");
+    expect(todayCell!.isCurrentMonth).toBe(true);
+  });
+
+  it("does not mark any cell as today when today is in a different month", () => {
+    const cells = buildCalendarGrid(2026, 3, new Map(), "2026-05-01");
+    // May 1 might appear as overflow, but let's check if it's marked
+    const todayCells = cells.filter((c) => c.isToday);
+    // May 1 could be in the overflow — if so it should be marked
+    if (todayCells.length > 0) {
+      expect(todayCells[0].date).toBe("2026-05-01");
+      expect(todayCells[0].isCurrentMonth).toBe(false);
+    }
+  });
+
+  it("assigns rows to the correct date cells", () => {
+    const rows = [makeRow("r1"), makeRow("r2")];
+    const rowsByDate = new Map<string, DatabaseRow[]>();
+    rowsByDate.set("2026-04-10", rows);
+
+    const cells = buildCalendarGrid(2026, 3, rowsByDate, "2026-04-24");
+    const cell10 = cells.find((c) => c.date === "2026-04-10");
+    expect(cell10).toBeDefined();
+    expect(cell10!.items).toHaveLength(2);
+    expect(cell10!.items[0].page.id).toBe("r1");
+  });
+
+  it("includes previous month overflow days", () => {
+    // April 2026 starts on Wednesday (day 3), so there should be 3 overflow days from March
+    const cells = buildCalendarGrid(2026, 3, new Map(), "2026-04-24");
+    const overflowBefore = [];
+    for (const cell of cells) {
+      if (cell.isCurrentMonth) break;
+      overflowBefore.push(cell);
+    }
+    expect(overflowBefore.length).toBe(3); // Sun, Mon, Tue from March
+    expect(overflowBefore[0].date).toBe("2026-03-29");
+    expect(overflowBefore[0].isCurrentMonth).toBe(false);
+  });
+
+  it("includes next month overflow days to complete the last week", () => {
+    const cells = buildCalendarGrid(2026, 3, new Map(), "2026-04-24");
+    const lastCell = cells[cells.length - 1];
+    // April 30, 2026 is Thursday. Grid needs Fri + Sat to complete the week.
+    expect(lastCell.date).toBe("2026-05-02");
+    expect(lastCell.isCurrentMonth).toBe(false);
+  });
+
+  it("handles month starting on Sunday (no previous overflow)", () => {
+    // March 2026 starts on Sunday
+    const cells = buildCalendarGrid(2026, 2, new Map(), "2026-03-15");
+    expect(cells[0].date).toBe("2026-03-01");
+    expect(cells[0].isCurrentMonth).toBe(true);
+  });
+
+  it("handles rows spanning month boundaries (overflow cells get items)", () => {
+    const rowsByDate = new Map<string, DatabaseRow[]>();
+    // Row on March 31 (which is overflow in April's grid)
+    rowsByDate.set("2026-03-31", [makeRow("r-march")]);
+    // Row on May 1 (which is overflow in April's grid)
+    rowsByDate.set("2026-05-01", [makeRow("r-may")]);
+
+    const cells = buildCalendarGrid(2026, 3, rowsByDate, "2026-04-24");
+
+    const marchCell = cells.find((c) => c.date === "2026-03-31");
+    expect(marchCell).toBeDefined();
+    expect(marchCell!.items).toHaveLength(1);
+    expect(marchCell!.items[0].page.id).toBe("r-march");
+
+    const mayCell = cells.find((c) => c.date === "2026-05-01");
+    expect(mayCell).toBeDefined();
+    expect(mayCell!.items).toHaveLength(1);
+    expect(mayCell!.items[0].page.id).toBe("r-may");
+  });
+
+  it("handles February in a leap year", () => {
+    // February 2024 has 29 days
+    const cells = buildCalendarGrid(2024, 1, new Map(), "2024-02-15");
+    const febCells = cells.filter((c) => c.isCurrentMonth);
+    expect(febCells).toHaveLength(29);
+  });
+
+  it("handles year boundary (January grid shows December overflow)", () => {
+    // January 2026 starts on Thursday (day 4)
+    const cells = buildCalendarGrid(2026, 0, new Map(), "2026-01-15");
+    const overflowBefore = [];
+    for (const cell of cells) {
+      if (cell.isCurrentMonth) break;
+      overflowBefore.push(cell);
+    }
+    expect(overflowBefore.length).toBe(4);
+    // These should be December 2025 dates
+    expect(overflowBefore[0].date).toBe("2025-12-28");
+  });
+
+  it("handles December grid showing January overflow", () => {
+    // December 2025 starts on Monday (day 1)
+    const cells = buildCalendarGrid(2025, 11, new Map(), "2025-12-15");
+    const lastCell = cells[cells.length - 1];
+    // December 31, 2025 is Wednesday. Need Thu, Fri, Sat to complete.
+    expect(lastCell.date).toBe("2026-01-03");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prevMonth / nextMonth
+// ---------------------------------------------------------------------------
+
+describe("prevMonth", () => {
+  it("returns the previous month in the same year", () => {
+    expect(prevMonth(2026, 6)).toEqual({ year: 2026, month: 5 });
+  });
+
+  it("rolls back to December of the previous year from January", () => {
+    expect(prevMonth(2026, 0)).toEqual({ year: 2025, month: 11 });
+  });
+});
+
+describe("nextMonth", () => {
+  it("returns the next month in the same year", () => {
+    expect(nextMonth(2026, 6)).toEqual({ year: 2026, month: 7 });
+  });
+
+  it("rolls forward to January of the next year from December", () => {
+    expect(nextMonth(2025, 11)).toEqual({ year: 2026, month: 0 });
+  });
+});

--- a/src/components/database/views/calendar-view-helpers.ts
+++ b/src/components/database/views/calendar-view-helpers.ts
@@ -1,0 +1,173 @@
+// Pure functions for calendar-view date computation and grid building.
+// No React dependencies — all computation is side-effect-free.
+
+import type { DatabaseRow } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Date helpers
+// ---------------------------------------------------------------------------
+
+export function toISODate(year: number, month: number, day: number): string {
+  const m = String(month + 1).padStart(2, "0");
+  const dd = String(day).padStart(2, "0");
+  return `${year}-${m}-${dd}`;
+}
+
+export function getDaysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+export function getFirstDayOfWeek(year: number, month: number): number {
+  return new Date(year, month, 1).getDay();
+}
+
+/** Extract the date string (YYYY-MM-DD) from a row's date property value. */
+export function getRowDate(row: DatabaseRow, propertyId: string): string | null {
+  const rv = row.values[propertyId];
+  if (!rv) return null;
+  // Date values store { date: "YYYY-MM-DD" } or { value: "YYYY-MM-DD" }
+  const dateVal = rv.value?.date ?? rv.value?.value;
+  if (typeof dateVal === "string" && dateVal.length >= 10) {
+    return dateVal.slice(0, 10);
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Row grouping by date
+// ---------------------------------------------------------------------------
+
+/** Group rows by their date value for a given property. */
+export function groupRowsByDate(
+  rows: DatabaseRow[],
+  datePropertyId: string,
+): Map<string, DatabaseRow[]> {
+  const map = new Map<string, DatabaseRow[]>();
+
+  for (const row of rows) {
+    const date = getRowDate(row, datePropertyId);
+    if (!date) continue;
+    const existing = map.get(date);
+    if (existing) {
+      existing.push(row);
+    } else {
+      map.set(date, [row]);
+    }
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Calendar cell data
+// ---------------------------------------------------------------------------
+
+export interface CalendarCell {
+  date: string; // ISO date YYYY-MM-DD
+  day: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  items: DatabaseRow[];
+}
+
+/**
+ * Build a calendar grid for a given month. The grid always starts on Sunday
+ * and fills previous/next month overflow days to complete full weeks.
+ *
+ * @param todayISO - The current date as "YYYY-MM-DD", injected for testability.
+ */
+export function buildCalendarGrid(
+  year: number,
+  month: number,
+  rowsByDate: Map<string, DatabaseRow[]>,
+  todayISO?: string,
+): CalendarCell[] {
+  const today = todayISO ?? _todayISO();
+  const daysInMonth = getDaysInMonth(year, month);
+  const firstDay = getFirstDayOfWeek(year, month);
+
+  const cells: CalendarCell[] = [];
+
+  // Previous month overflow
+  if (firstDay > 0) {
+    const prevMonth = month === 0 ? 11 : month - 1;
+    const prevYear = month === 0 ? year - 1 : year;
+    const prevDays = getDaysInMonth(prevYear, prevMonth);
+    for (let i = firstDay - 1; i >= 0; i--) {
+      const day = prevDays - i;
+      const date = toISODate(prevYear, prevMonth, day);
+      cells.push({
+        date,
+        day,
+        isCurrentMonth: false,
+        isToday: date === today,
+        items: rowsByDate.get(date) ?? [],
+      });
+    }
+  }
+
+  // Current month
+  for (let d = 1; d <= daysInMonth; d++) {
+    const date = toISODate(year, month, d);
+    cells.push({
+      date,
+      day: d,
+      isCurrentMonth: true,
+      isToday: date === today,
+      items: rowsByDate.get(date) ?? [],
+    });
+  }
+
+  // Next month overflow to fill the grid (always complete the last week)
+  const remainder = cells.length % 7;
+  if (remainder > 0) {
+    const nextMonth = month === 11 ? 0 : month + 1;
+    const nextYear = month === 11 ? year + 1 : year;
+    const fill = 7 - remainder;
+    for (let d = 1; d <= fill; d++) {
+      const date = toISODate(nextYear, nextMonth, d);
+      cells.push({
+        date,
+        day: d,
+        isCurrentMonth: false,
+        isToday: date === today,
+        items: rowsByDate.get(date) ?? [],
+      });
+    }
+  }
+
+  return cells;
+}
+
+// ---------------------------------------------------------------------------
+// Month navigation
+// ---------------------------------------------------------------------------
+
+export interface MonthYear {
+  year: number;
+  month: number; // 0-indexed (0 = January, 11 = December)
+}
+
+/** Compute the previous month, handling year rollover. */
+export function prevMonth(year: number, month: number): MonthYear {
+  if (month === 0) {
+    return { year: year - 1, month: 11 };
+  }
+  return { year, month: month - 1 };
+}
+
+/** Compute the next month, handling year rollover. */
+export function nextMonth(year: number, month: number): MonthYear {
+  if (month === 11) {
+    return { year: year + 1, month: 0 };
+  }
+  return { year, month: month + 1 };
+}
+
+// ---------------------------------------------------------------------------
+// Internal — default "today" for production use
+// ---------------------------------------------------------------------------
+
+function _todayISO(): string {
+  const d = new Date();
+  return toISODate(d.getFullYear(), d.getMonth(), d.getDate());
+}

--- a/src/components/database/views/calendar-view.tsx
+++ b/src/components/database/views/calendar-view.tsx
@@ -10,6 +10,11 @@ import type {
   DatabaseRow,
   DatabaseViewConfig,
 } from "@/lib/types";
+import {
+  buildCalendarGrid,
+  groupRowsByDate,
+  type CalendarCell,
+} from "./calendar-view-helpers";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -33,115 +38,6 @@ const FULL_MONTHS = [
   "November",
   "December",
 ];
-
-// ---------------------------------------------------------------------------
-// Date helpers
-// ---------------------------------------------------------------------------
-
-function toISODate(year: number, month: number, day: number): string {
-  const m = String(month + 1).padStart(2, "0");
-  const dd = String(day).padStart(2, "0");
-  return `${year}-${m}-${dd}`;
-}
-
-function getDaysInMonth(year: number, month: number): number {
-  return new Date(year, month + 1, 0).getDate();
-}
-
-function getFirstDayOfWeek(year: number, month: number): number {
-  return new Date(year, month, 1).getDay();
-}
-
-function todayISO(): string {
-  const d = new Date();
-  return toISODate(d.getFullYear(), d.getMonth(), d.getDate());
-}
-
-/** Extract the date string from a row's date property value. */
-function getRowDate(row: DatabaseRow, propertyId: string): string | null {
-  const rv = row.values[propertyId];
-  if (!rv) return null;
-  // Date values store { date: "YYYY-MM-DD" } or { value: "YYYY-MM-DD" }
-  const dateVal = rv.value?.date ?? rv.value?.value;
-  if (typeof dateVal === "string" && dateVal.length >= 10) {
-    return dateVal.slice(0, 10);
-  }
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Calendar cell data
-// ---------------------------------------------------------------------------
-
-interface CalendarCell {
-  date: string; // ISO date YYYY-MM-DD
-  day: number;
-  isCurrentMonth: boolean;
-  isToday: boolean;
-  items: DatabaseRow[];
-}
-
-function buildCalendarGrid(
-  year: number,
-  month: number,
-  rowsByDate: Map<string, DatabaseRow[]>,
-): CalendarCell[] {
-  const today = todayISO();
-  const daysInMonth = getDaysInMonth(year, month);
-  const firstDay = getFirstDayOfWeek(year, month);
-
-  const cells: CalendarCell[] = [];
-
-  // Previous month overflow
-  if (firstDay > 0) {
-    const prevMonth = month === 0 ? 11 : month - 1;
-    const prevYear = month === 0 ? year - 1 : year;
-    const prevDays = getDaysInMonth(prevYear, prevMonth);
-    for (let i = firstDay - 1; i >= 0; i--) {
-      const day = prevDays - i;
-      const date = toISODate(prevYear, prevMonth, day);
-      cells.push({
-        date,
-        day,
-        isCurrentMonth: false,
-        isToday: date === today,
-        items: rowsByDate.get(date) ?? [],
-      });
-    }
-  }
-
-  // Current month
-  for (let d = 1; d <= daysInMonth; d++) {
-    const date = toISODate(year, month, d);
-    cells.push({
-      date,
-      day: d,
-      isCurrentMonth: true,
-      isToday: date === today,
-      items: rowsByDate.get(date) ?? [],
-    });
-  }
-
-  // Next month overflow to fill the grid (always complete the last week)
-  const remainder = cells.length % 7;
-  if (remainder > 0) {
-    const nextMonth = month === 11 ? 0 : month + 1;
-    const nextYear = month === 11 ? year + 1 : year;
-    const fill = 7 - remainder;
-    for (let d = 1; d <= fill; d++) {
-      const date = toISODate(nextYear, nextMonth, d);
-      cells.push({
-        date,
-        day: d,
-        isCurrentMonth: false,
-        isToday: date === today,
-        items: rowsByDate.get(date) ?? [],
-      });
-    }
-  }
-
-  return cells;
-}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -190,20 +86,8 @@ export const CalendarView = memo(function CalendarView({
 
   // Group rows by date
   const rowsByDate = useMemo(() => {
-    const map = new Map<string, DatabaseRow[]>();
-    if (!datePropertyId) return map;
-
-    for (const row of rows) {
-      const date = getRowDate(row, datePropertyId);
-      if (!date) continue;
-      const existing = map.get(date);
-      if (existing) {
-        existing.push(row);
-      } else {
-        map.set(date, [row]);
-      }
-    }
-    return map;
+    if (!datePropertyId) return new Map<string, DatabaseRow[]>();
+    return groupRowsByDate(rows, datePropertyId);
   }, [rows, datePropertyId]);
 
   // Build the calendar grid


### PR DESCRIPTION
Closes #701

## What

Extracts pure computation logic from `board-view.tsx` and `calendar-view.tsx` into co-located helper modules, then adds 53 unit tests covering all grouping, date assignment, and navigation logic.

## How

**Board view** — extracted into `board-view-helpers.ts`:
- `getSelectOptions` — resolves select/status options with default fallback
- `getRowOptionId` — extracts option_id from a row value
- `groupRowsIntoColumns` — groups rows by select property into board columns
- `resolveDropOptionId` — maps drop target column to option_id (null for uncategorized)

**Calendar view** — extracted into `calendar-view-helpers.ts`:
- `toISODate`, `getDaysInMonth`, `getFirstDayOfWeek` — date utilities
- `getRowDate` — extracts date string from row value
- `groupRowsByDate` — groups rows into a date→rows map
- `buildCalendarGrid` — builds the full month grid with overflow days
- `prevMonth`, `nextMonth` — month navigation with year rollover

The original components now import from the helpers. `buildCalendarGrid` accepts an optional `todayISO` parameter for deterministic testing.

## Testing

- 18 board-view-helpers tests: option resolution, row grouping (with value, uncategorized, empty DB, hide empty, column ordering, orphaned IDs), DnD resolution
- 35 calendar-view-helpers tests: date formatting, days-in-month (including leap year), date extraction, row grouping, grid construction (complete weeks, overflow, year boundaries), month navigation
- `pnpm lint && pnpm typecheck && pnpm test` — all 1013 tests pass
- No interactive UI changes — E2E tests not required