### PR TITLE
test: add unit tests for database mutation hooks (#709)

### DIFF
--- a/src/components/database/hooks/use-database-filters.test.ts
+++ b/src/components/database/hooks/use-database-filters.test.ts
@@ -1,0 +1,490 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const updateViewMock = vi.fn();
+const toastErrorMock = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock needs flexible arity
+const sortRowsMock = vi.fn((...args: any[]) => args[0]);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock needs flexible arity
+const filterRowsMock = vi.fn((...args: any[]) => args[0]);
+
+vi.mock("@/lib/database", () => ({
+  updateView: (...args: unknown[]) => updateViewMock(...args),
+}));
+
+vi.mock("@/lib/database-filters", () => ({
+  sortRows: (rows: unknown[], sorts: unknown[], props: unknown[]) =>
+    sortRowsMock(rows, sorts, props),
+  filterRows: (rows: unknown[], filters: unknown[], props: unknown[]) =>
+    filterRowsMock(rows, filters, props),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  useDatabaseFilters,
+  type UseDatabaseFiltersParams,
+} from "./use-database-filters";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  DatabaseView,
+} from "@/lib/types";
+import type { SortRule, FilterRule } from "@/lib/database-filters";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(
+  id: string,
+  name: string,
+  type: DatabaseProperty["type"] = "text",
+): DatabaseProperty {
+  return {
+    id,
+    database_id: "db-1",
+    name,
+    type,
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeView(
+  id: string,
+  config: DatabaseView["config"] = {},
+): DatabaseView {
+  return {
+    id,
+    database_id: "db-1",
+    name: "Table view",
+    type: "table",
+    config,
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeRow(id: string): DatabaseRow {
+  return {
+    page: {
+      id,
+      title: `Row ${id}`,
+      icon: null,
+      cover_url: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      created_by: "user-1",
+    },
+    values: {},
+  };
+}
+
+function setup(overrides?: Partial<UseDatabaseFiltersParams>) {
+  const activeView = overrides?.activeView ?? makeView("view-1");
+  const rows = overrides?.rows ?? [makeRow("row-1"), makeRow("row-2")];
+  const properties = overrides?.properties ?? [makeProp("p1", "Title")];
+
+  const setViews = vi.fn((updater) => {
+    if (typeof updater === "function") {
+      return updater([activeView]);
+    }
+    return updater;
+  });
+
+  const initialProps: UseDatabaseFiltersParams = {
+    pageId: "db-1",
+    activeView,
+    rows,
+    properties,
+    setViews,
+    ...overrides,
+    // Ensure setViews from overrides or our default is used
+  };
+  // Override setViews if not provided
+  if (!overrides?.setViews) {
+    initialProps.setViews = setViews;
+  }
+
+  const hookResult = renderHook(
+    (props: UseDatabaseFiltersParams) => useDatabaseFilters(props),
+    { initialProps },
+  );
+
+  return { ...hookResult, setViews: initialProps.setViews as ReturnType<typeof vi.fn> };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDatabaseFilters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset sort/filter mocks to pass-through
+    sortRowsMock.mockImplementation((rows: unknown[]) => rows);
+    filterRowsMock.mockImplementation((rows: unknown[]) => rows);
+  });
+
+  // -------------------------------------------------------------------------
+  // activeSorts / activeFilters
+  // -------------------------------------------------------------------------
+
+  describe("activeSorts and activeFilters", () => {
+    it("extracts sorts from active view config", () => {
+      const sorts: SortRule[] = [
+        { property_id: "p1", direction: "asc" },
+      ];
+      const { result } = setup({
+        activeView: makeView("view-1", { sorts }),
+      });
+
+      expect(result.current.activeSorts).toEqual(sorts);
+    });
+
+    it("extracts filters from active view config", () => {
+      const filters: FilterRule[] = [
+        { property_id: "p1", operator: "is_not_empty", value: null },
+      ];
+      const { result } = setup({
+        activeView: makeView("view-1", {
+          filters: filters as DatabaseView["config"]["filters"],
+        }),
+      });
+
+      expect(result.current.activeFilters).toEqual(filters);
+    });
+
+    it("defaults to empty arrays when no sorts/filters in config", () => {
+      const { result } = setup({
+        activeView: makeView("view-1", {}),
+      });
+
+      expect(result.current.activeSorts).toEqual([]);
+      expect(result.current.activeFilters).toEqual([]);
+    });
+
+    it("defaults to empty arrays when activeView is undefined", () => {
+      const { result } = setup({ activeView: undefined });
+
+      expect(result.current.activeSorts).toEqual([]);
+      expect(result.current.activeFilters).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // displayedRows
+  // -------------------------------------------------------------------------
+
+  describe("displayedRows", () => {
+    it("returns rows unchanged when no sorts or filters", () => {
+      const rows = [makeRow("r1"), makeRow("r2")];
+      const { result } = setup({ rows });
+
+      expect(result.current.displayedRows).toEqual(rows);
+      expect(sortRowsMock).not.toHaveBeenCalled();
+      expect(filterRowsMock).not.toHaveBeenCalled();
+    });
+
+    it("applies filters when present", () => {
+      const rows = [makeRow("r1"), makeRow("r2")];
+      const filtered = [makeRow("r1")];
+      filterRowsMock.mockReturnValue(filtered);
+
+      const filters: FilterRule[] = [
+        { property_id: "p1", operator: "is_not_empty", value: null },
+      ];
+      const properties = [makeProp("p1", "Title")];
+      const { result } = setup({
+        rows,
+        properties,
+        activeView: makeView("view-1", {
+          filters: filters as DatabaseView["config"]["filters"],
+        }),
+      });
+
+      expect(result.current.displayedRows).toEqual(filtered);
+      expect(filterRowsMock).toHaveBeenCalledWith(rows, filters, properties);
+    });
+
+    it("applies sorts when present", () => {
+      const rows = [makeRow("r1"), makeRow("r2")];
+      const sorted = [makeRow("r2"), makeRow("r1")];
+      sortRowsMock.mockReturnValue(sorted);
+
+      const sorts: SortRule[] = [
+        { property_id: "p1", direction: "desc" },
+      ];
+      const properties = [makeProp("p1", "Title")];
+      const { result } = setup({
+        rows,
+        properties,
+        activeView: makeView("view-1", { sorts }),
+      });
+
+      expect(result.current.displayedRows).toEqual(sorted);
+      expect(sortRowsMock).toHaveBeenCalledWith(rows, sorts, properties);
+    });
+
+    it("applies filters then sorts when both present", () => {
+      const rows = [makeRow("r1"), makeRow("r2"), makeRow("r3")];
+      const filtered = [makeRow("r1"), makeRow("r3")];
+      const sorted = [makeRow("r3"), makeRow("r1")];
+      filterRowsMock.mockReturnValue(filtered);
+      sortRowsMock.mockReturnValue(sorted);
+
+      const sorts: SortRule[] = [
+        { property_id: "p1", direction: "desc" },
+      ];
+      const filters: FilterRule[] = [
+        { property_id: "p1", operator: "is_not_empty", value: null },
+      ];
+      const { result } = setup({
+        rows,
+        activeView: makeView("view-1", {
+          sorts,
+          filters: filters as DatabaseView["config"]["filters"],
+        }),
+      });
+
+      expect(result.current.displayedRows).toEqual(sorted);
+      // filterRows is called with original rows
+      expect(filterRowsMock).toHaveBeenCalled();
+      // sortRows is called with filtered result
+      expect(sortRowsMock).toHaveBeenCalledWith(
+        filtered,
+        sorts,
+        expect.any(Array),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleSortsChange
+  // -------------------------------------------------------------------------
+
+  describe("handleSortsChange", () => {
+    it("persists new sorts to view config", async () => {
+      updateViewMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setViews } = setup();
+
+      const newSorts: SortRule[] = [
+        { property_id: "p1", direction: "asc" },
+      ];
+
+      await act(async () => {
+        await result.current.handleSortsChange(newSorts);
+      });
+
+      // Optimistic update
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1")]);
+      expect(updated[0].config.sorts).toEqual(newSorts);
+
+      expect(updateViewMock).toHaveBeenCalledWith(
+        "view-1",
+        { config: { sorts: newSorts } },
+        "db-1",
+      );
+    });
+
+    it("shows toast on failure", async () => {
+      updateViewMock.mockResolvedValue({
+        data: null,
+        error: new Error("failed"),
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleSortsChange([
+          { property_id: "p1", direction: "asc" },
+        ]);
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update sort", {
+        duration: 8000,
+      });
+    });
+
+    it("does nothing when no active view", async () => {
+      const { result } = setup({ activeView: undefined });
+
+      await act(async () => {
+        await result.current.handleSortsChange([
+          { property_id: "p1", direction: "asc" },
+        ]);
+      });
+
+      expect(updateViewMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleFiltersChange
+  // -------------------------------------------------------------------------
+
+  describe("handleFiltersChange", () => {
+    it("persists new filters to view config", async () => {
+      updateViewMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setViews } = setup();
+
+      const newFilters: FilterRule[] = [
+        { property_id: "p1", operator: "is_not_empty", value: null },
+      ];
+
+      await act(async () => {
+        await result.current.handleFiltersChange(newFilters);
+      });
+
+      // Optimistic update
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1")]);
+      expect(updated[0].config.filters).toEqual(newFilters);
+
+      expect(updateViewMock).toHaveBeenCalledWith(
+        "view-1",
+        { config: { filters: newFilters } },
+        "db-1",
+      );
+    });
+
+    it("shows toast on failure", async () => {
+      updateViewMock.mockResolvedValue({
+        data: null,
+        error: new Error("failed"),
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleFiltersChange([
+          { property_id: "p1", operator: "is_not_empty", value: null },
+        ]);
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to update filter",
+        { duration: 8000 },
+      );
+    });
+
+    it("does nothing when no active view", async () => {
+      const { result } = setup({ activeView: undefined });
+
+      await act(async () => {
+        await result.current.handleFiltersChange([
+          { property_id: "p1", operator: "is_not_empty", value: null },
+        ]);
+      });
+
+      expect(updateViewMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleSortToggle
+  // -------------------------------------------------------------------------
+
+  describe("handleSortToggle", () => {
+    it("adds asc sort for unsorted property", () => {
+      updateViewMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setViews } = setup({
+        activeView: makeView("view-1", { sorts: [] }),
+      });
+
+      act(() => {
+        result.current.handleSortToggle("p1");
+      });
+
+      // Optimistic update should add asc sort
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1", { sorts: [] })]);
+      expect(updated[0].config.sorts).toEqual([
+        { property_id: "p1", direction: "asc" },
+      ]);
+    });
+
+    it("toggles asc to desc", () => {
+      updateViewMock.mockResolvedValue({ data: null, error: null });
+
+      const sorts: SortRule[] = [
+        { property_id: "p1", direction: "asc" },
+      ];
+      const { result, setViews } = setup({
+        activeView: makeView("view-1", { sorts }),
+      });
+
+      act(() => {
+        result.current.handleSortToggle("p1");
+      });
+
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1", { sorts })]);
+      expect(updated[0].config.sorts).toEqual([
+        { property_id: "p1", direction: "desc" },
+      ]);
+    });
+
+    it("removes sort when already desc", () => {
+      updateViewMock.mockResolvedValue({ data: null, error: null });
+
+      const sorts: SortRule[] = [
+        { property_id: "p1", direction: "desc" },
+      ];
+      const { result, setViews } = setup({
+        activeView: makeView("view-1", { sorts }),
+      });
+
+      act(() => {
+        result.current.handleSortToggle("p1");
+      });
+
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1", { sorts })]);
+      expect(updated[0].config.sorts).toEqual([]);
+    });
+
+    it("preserves other sorts when toggling", () => {
+      updateViewMock.mockResolvedValue({ data: null, error: null });
+
+      const sorts: SortRule[] = [
+        { property_id: "p1", direction: "asc" },
+        { property_id: "p2", direction: "desc" },
+      ];
+      const { result, setViews } = setup({
+        activeView: makeView("view-1", { sorts }),
+      });
+
+      act(() => {
+        result.current.handleSortToggle("p1");
+      });
+
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1", { sorts })]);
+      expect(updated[0].config.sorts).toEqual([
+        { property_id: "p1", direction: "desc" },
+        { property_id: "p2", direction: "desc" },
+      ]);
+    });
+  });
+});

--- a/src/components/database/hooks/use-database-properties.test.ts
+++ b/src/components/database/hooks/use-database-properties.test.ts
@@ -1,0 +1,554 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const addPropertyMock = vi.fn();
+const updatePropertyMock = vi.fn();
+const deletePropertyMock = vi.fn();
+const reorderPropertiesMock = vi.fn();
+const loadDatabaseMock = vi.fn();
+const updateViewMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock("@/lib/database", () => ({
+  addProperty: (...args: unknown[]) => addPropertyMock(...args),
+  updateProperty: (...args: unknown[]) => updatePropertyMock(...args),
+  deleteProperty: (...args: unknown[]) => deletePropertyMock(...args),
+  reorderProperties: (...args: unknown[]) => reorderPropertiesMock(...args),
+  loadDatabase: (...args: unknown[]) => loadDatabaseMock(...args),
+  updateView: (...args: unknown[]) => updateViewMock(...args),
+}));
+
+vi.mock("@/lib/column-helpers", () => ({
+  generateColumnName: (type: string, _existing: Set<string>) =>
+    `${type.charAt(0).toUpperCase() + type.slice(1)}`,
+  getDefaultColumnConfig: (type: string) =>
+    type === "status"
+      ? { options: [{ id: "s1", name: "Todo", color: "gray" }] }
+      : {},
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  useDatabaseProperties,
+  type UseDatabasePropertiesParams,
+} from "./use-database-properties";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  DatabaseView,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(
+  id: string,
+  name: string,
+  position: number,
+  type: DatabaseProperty["type"] = "text",
+): DatabaseProperty {
+  return {
+    id,
+    database_id: "db-1",
+    name,
+    type,
+    config: {},
+    position,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeView(
+  id: string,
+  config: DatabaseView["config"] = {},
+): DatabaseView {
+  return {
+    id,
+    database_id: "db-1",
+    name: "Table view",
+    type: "table",
+    config,
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeRow(
+  id: string,
+  values: DatabaseRow["values"] = {},
+): DatabaseRow {
+  return {
+    page: {
+      id,
+      title: `Row ${id}`,
+      icon: null,
+      cover_url: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      created_by: "user-1",
+    },
+    values,
+  };
+}
+
+function setup(overrides?: {
+  properties?: DatabaseProperty[];
+  views?: DatabaseView[];
+  rows?: DatabaseRow[];
+}) {
+  const properties = overrides?.properties ?? [
+    makeProp("title-prop", "Title", 0),
+    makeProp("prop-1", "Status", 1, "select"),
+  ];
+  const views = overrides?.views ?? [makeView("view-1")];
+  const rows = overrides?.rows ?? [makeRow("row-1")];
+
+  const setProperties = vi.fn((updater) => {
+    if (typeof updater === "function") return updater(properties);
+    return updater;
+  });
+  const setViews = vi.fn((updater) => {
+    if (typeof updater === "function") return updater(views);
+    return updater;
+  });
+  const setRows = vi.fn((updater) => {
+    if (typeof updater === "function") return updater(rows);
+    return updater;
+  });
+
+  const initialProps: UseDatabasePropertiesParams = {
+    pageId: "db-1",
+    properties,
+    setProperties,
+    views,
+    setViews,
+    setRows,
+  };
+
+  const hookResult = renderHook(
+    (props: UseDatabasePropertiesParams) => useDatabaseProperties(props),
+    { initialProps },
+  );
+
+  return { ...hookResult, setProperties, setViews, setRows, properties, views };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDatabaseProperties", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // handleAddColumn
+  // -------------------------------------------------------------------------
+
+  describe("handleAddColumn", () => {
+    it("adds a property with generated name and default config", async () => {
+      const newProp = makeProp("new-prop", "Text", 2);
+      addPropertyMock.mockResolvedValue({ data: newProp, error: null });
+
+      const { result, setProperties } = setup();
+
+      await act(async () => {
+        await result.current.handleAddColumn("text");
+      });
+
+      expect(addPropertyMock).toHaveBeenCalledWith(
+        "db-1",
+        "Text",
+        "text",
+        {},
+      );
+      const updater = setProperties.mock.calls[0][0];
+      const updated = updater([makeProp("title-prop", "Title", 0)]);
+      expect(updated).toHaveLength(2);
+      expect(updated[1].id).toBe("new-prop");
+    });
+
+    it("passes status default config for status type", async () => {
+      const newProp = makeProp("new-status", "Status", 2, "status");
+      addPropertyMock.mockResolvedValue({ data: newProp, error: null });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleAddColumn("status");
+      });
+
+      expect(addPropertyMock).toHaveBeenCalledWith(
+        "db-1",
+        "Status",
+        "status",
+        { options: [{ id: "s1", name: "Todo", color: "gray" }] },
+      );
+    });
+
+    it("shows toast on error", async () => {
+      addPropertyMock.mockResolvedValue({
+        data: null,
+        error: new Error("failed"),
+      });
+
+      const { result, setProperties } = setup();
+
+      await act(async () => {
+        await result.current.handleAddColumn("text");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add column", {
+        duration: 8000,
+      });
+      expect(setProperties).not.toHaveBeenCalled();
+    });
+
+    it("guards against concurrent calls", async () => {
+      // Use a deferred promise so we control when the first call resolves
+      let resolveFirst!: (v: { data: DatabaseProperty; error: null }) => void;
+      const firstCall = new Promise<{ data: DatabaseProperty; error: null }>(
+        (r) => {
+          resolveFirst = r;
+        },
+      );
+      addPropertyMock.mockImplementationOnce(() => firstCall);
+
+      const { result } = setup();
+
+      // Start first call (don't await yet)
+      const p1 = act(async () => {
+        await result.current.handleAddColumn("text");
+      });
+
+      // Second call should be guarded — the ref is still true
+      await act(async () => {
+        await result.current.handleAddColumn("number");
+      });
+
+      // Resolve the first
+      resolveFirst({ data: makeProp("p1", "Text", 2), error: null });
+      await p1;
+
+      // Only one addProperty call should have been made
+      expect(addPropertyMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleColumnHeaderClick / handlePropertyRename
+  // -------------------------------------------------------------------------
+
+  describe("handlePropertyRename", () => {
+    it("opens rename dialog and renames optimistically", async () => {
+      updatePropertyMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setProperties } = setup();
+
+      // Open rename dialog
+      act(() => {
+        result.current.handleColumnHeaderClick("prop-1");
+      });
+
+      expect(result.current.renameDialogOpen).toBe(true);
+      expect(result.current.renamingProperty).toEqual({
+        id: "prop-1",
+        name: "Status",
+      });
+
+      // Perform rename
+      await act(async () => {
+        await result.current.handlePropertyRename("Priority");
+      });
+
+      // Optimistic update
+      const updater = setProperties.mock.calls[0][0];
+      const updated = updater([
+        makeProp("title-prop", "Title", 0),
+        makeProp("prop-1", "Status", 1, "select"),
+      ]);
+      expect(updated[1].name).toBe("Priority");
+
+      expect(updatePropertyMock).toHaveBeenCalledWith(
+        "prop-1",
+        { name: "Priority" },
+        "db-1",
+      );
+    });
+
+    it("reverts on rename failure", async () => {
+      updatePropertyMock.mockResolvedValue({
+        data: null,
+        error: new Error("rename failed"),
+      });
+
+      const { result, setProperties } = setup();
+
+      act(() => {
+        result.current.handleColumnHeaderClick("prop-1");
+      });
+
+      await act(async () => {
+        await result.current.handlePropertyRename("New Name");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to rename property",
+        { duration: 8000 },
+      );
+      // Revert call: second setProperties call restores old name
+      expect(setProperties).toHaveBeenCalledTimes(2);
+      const revertUpdater = setProperties.mock.calls[1][0];
+      const reverted = revertUpdater([
+        makeProp("title-prop", "Title", 0),
+        makeProp("prop-1", "New Name", 1, "select"),
+      ]);
+      expect(reverted[1].name).toBe("Status");
+    });
+
+    it("does nothing when no property is being renamed", async () => {
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handlePropertyRename("Anything");
+      });
+
+      expect(updatePropertyMock).not.toHaveBeenCalled();
+    });
+
+    it("does nothing for unknown property id", () => {
+      const { result } = setup();
+
+      act(() => {
+        result.current.handleColumnHeaderClick("nonexistent");
+      });
+
+      expect(result.current.renameDialogOpen).toBe(false);
+      expect(result.current.renamingProperty).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleColumnReorder
+  // -------------------------------------------------------------------------
+
+  describe("handleColumnReorder", () => {
+    it("reorders properties optimistically", async () => {
+      reorderPropertiesMock.mockResolvedValue({ error: null });
+
+      const props = [
+        makeProp("p-a", "A", 0),
+        makeProp("p-b", "B", 1),
+        makeProp("p-c", "C", 2),
+      ];
+      const { result, setProperties } = setup({ properties: props });
+
+      await act(async () => {
+        await result.current.handleColumnReorder(["p-c", "p-a", "p-b"]);
+      });
+
+      const updater = setProperties.mock.calls[0][0];
+      const updated = updater(props);
+      expect(updated.map((p: DatabaseProperty) => p.id)).toEqual([
+        "p-c",
+        "p-a",
+        "p-b",
+      ]);
+      expect(updated[0].position).toBe(0);
+      expect(updated[1].position).toBe(1);
+      expect(updated[2].position).toBe(2);
+
+      expect(reorderPropertiesMock).toHaveBeenCalledWith("db-1", [
+        "p-c",
+        "p-a",
+        "p-b",
+      ]);
+    });
+
+    it("reverts on reorder failure", async () => {
+      reorderPropertiesMock.mockResolvedValue({
+        error: new Error("reorder failed"),
+      });
+
+      const props = [makeProp("p-a", "A", 0), makeProp("p-b", "B", 1)];
+      const { result, setProperties } = setup({ properties: props });
+
+      await act(async () => {
+        await result.current.handleColumnReorder(["p-b", "p-a"]);
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to reorder columns",
+        { duration: 8000 },
+      );
+      // Revert: second setProperties call restores original
+      expect(setProperties).toHaveBeenCalledTimes(2);
+      const revertValue = setProperties.mock.calls[1][0];
+      expect(revertValue).toEqual(props);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleRequestDeleteColumn / handleConfirmDeleteColumn
+  // -------------------------------------------------------------------------
+
+  describe("handleConfirmDeleteColumn", () => {
+    it("deletes property, cleans up views and row values", async () => {
+      deletePropertyMock.mockResolvedValue({ error: null });
+
+      const props = [
+        makeProp("title-prop", "Title", 0),
+        makeProp("prop-del", "To Delete", 1, "text"),
+      ];
+      const views = [
+        makeView("view-1", { visible_properties: ["title-prop", "prop-del"] }),
+      ];
+      const rows = [
+        makeRow("row-1", {
+          "prop-del": {
+            id: "rv-1",
+            row_id: "row-1",
+            property_id: "prop-del",
+            value: { text: "hello" },
+            created_at: "2025-01-01T00:00:00Z",
+            updated_at: "2025-01-01T00:00:00Z",
+          },
+        }),
+      ];
+
+      const { result, setProperties, setViews, setRows } = setup({
+        properties: props,
+        views,
+        rows,
+      });
+
+      // Request delete
+      act(() => {
+        result.current.handleRequestDeleteColumn("prop-del");
+      });
+      expect(result.current.deletingProperty).toEqual({
+        id: "prop-del",
+        name: "To Delete",
+      });
+
+      // Confirm delete
+      await act(async () => {
+        await result.current.handleConfirmDeleteColumn();
+      });
+
+      expect(deletePropertyMock).toHaveBeenCalledWith("prop-del", "db-1");
+
+      // Properties updated
+      const propUpdater = setProperties.mock.calls[0][0];
+      const updatedProps = propUpdater(props);
+      expect(updatedProps).toHaveLength(1);
+      expect(updatedProps[0].id).toBe("title-prop");
+
+      // Views cleaned up
+      const viewUpdater = setViews.mock.calls[0][0];
+      const updatedViews = viewUpdater(views);
+      expect(updatedViews[0].config.visible_properties).toEqual([
+        "title-prop",
+      ]);
+
+      // Row values cleaned up
+      const rowUpdater = setRows.mock.calls[0][0];
+      const updatedRows = rowUpdater(rows);
+      expect(updatedRows[0].values).toEqual({});
+    });
+
+    it("prevents deleting the title property (position 0)", () => {
+      const props = [makeProp("title-prop", "Title", 0)];
+      const { result } = setup({ properties: props });
+
+      act(() => {
+        result.current.handleRequestDeleteColumn("title-prop");
+      });
+
+      expect(result.current.deletingProperty).toBeNull();
+    });
+
+    it("reverts on delete failure", async () => {
+      deletePropertyMock.mockResolvedValue({
+        error: new Error("delete failed"),
+      });
+      loadDatabaseMock.mockResolvedValue({
+        data: { rows: [makeRow("row-1")] },
+        error: null,
+      });
+
+      const props = [
+        makeProp("title-prop", "Title", 0),
+        makeProp("prop-del", "Col", 1),
+      ];
+      const views = [makeView("view-1")];
+      const { result, setProperties, setViews } = setup({
+        properties: props,
+        views,
+      });
+
+      act(() => {
+        result.current.handleRequestDeleteColumn("prop-del");
+      });
+
+      await act(async () => {
+        await result.current.handleConfirmDeleteColumn();
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to delete property",
+        { duration: 8000 },
+      );
+      // Properties and views reverted
+      const revertProps = setProperties.mock.calls[1][0];
+      expect(revertProps).toEqual(props);
+      const revertViews = setViews.mock.calls[1][0];
+      expect(revertViews).toEqual(views);
+    });
+
+    it("does nothing when no property is being deleted", async () => {
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleConfirmDeleteColumn();
+      });
+
+      expect(deletePropertyMock).not.toHaveBeenCalled();
+    });
+
+    it("handleCancelDeleteColumn clears deletingProperty", () => {
+      const props = [
+        makeProp("title-prop", "Title", 0),
+        makeProp("prop-1", "Col", 1),
+      ];
+      const { result } = setup({ properties: props });
+
+      act(() => {
+        result.current.handleRequestDeleteColumn("prop-1");
+      });
+      expect(result.current.deletingProperty).not.toBeNull();
+
+      act(() => {
+        result.current.handleCancelDeleteColumn();
+      });
+      expect(result.current.deletingProperty).toBeNull();
+    });
+  });
+});

--- a/src/components/database/hooks/use-database-rows.test.ts
+++ b/src/components/database/hooks/use-database-rows.test.ts
@@ -1,0 +1,548 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const addRowMock = vi.fn();
+const updateRowValueMock = vi.fn();
+const updatePropertyMock = vi.fn();
+const loadDatabaseMock = vi.fn();
+const captureSupabaseErrorMock = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock needs flexible arity
+const isInsufficientPrivilegeErrorMock = vi.fn((..._args: any[]) => false);
+const toastErrorMock = vi.fn();
+const softDeletePageMock = vi.fn();
+
+vi.mock("@/lib/database", () => ({
+  addRow: (...args: unknown[]) => addRowMock(...args),
+  updateRowValue: (...args: unknown[]) => updateRowValueMock(...args),
+  updateProperty: (...args: unknown[]) => updatePropertyMock(...args),
+  loadDatabase: (...args: unknown[]) => loadDatabaseMock(...args),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: (error: Error, operation: string) =>
+    captureSupabaseErrorMock(error, operation),
+  isInsufficientPrivilegeError: (error: Error) =>
+    isInsufficientPrivilegeErrorMock(error),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    rpc: (...args: unknown[]) => softDeletePageMock(...args),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { useDatabaseRows } from "./use-database-rows";
+import type { DatabaseRow, DatabaseProperty } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRow(
+  id: string,
+  values: DatabaseRow["values"] = {},
+): DatabaseRow {
+  return {
+    page: {
+      id,
+      title: `Row ${id}`,
+      icon: null,
+      cover_url: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      created_by: "user-1",
+    },
+    values,
+  };
+}
+
+function setup(overrides?: Partial<Parameters<typeof useDatabaseRows>[0]>) {
+  const rows: DatabaseRow[] = overrides?.rows ?? [makeRow("row-1")];
+  const setRows = vi.fn((updater) => {
+    if (typeof updater === "function") {
+      return updater(rows);
+    }
+    return updater;
+  });
+  const setProperties = vi.fn((updater) => {
+    if (typeof updater === "function") {
+      return updater([] as DatabaseProperty[]);
+    }
+    return updater;
+  });
+
+  const params = {
+    pageId: "db-1",
+    userId: "user-1",
+    rows,
+    setRows,
+    setProperties,
+    ...overrides,
+  };
+
+  const hookResult = renderHook(() => useDatabaseRows(params));
+  return { ...hookResult, setRows, setProperties, params };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDatabaseRows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // handleAddRow
+  // -------------------------------------------------------------------------
+
+  describe("handleAddRow", () => {
+    it("adds a row optimistically on success", async () => {
+      const newPage = {
+        id: "new-row-1",
+        title: "",
+        icon: null,
+        cover_url: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        created_by: "user-1",
+      };
+      addRowMock.mockResolvedValue({ data: newPage, error: null });
+
+      const { result, setRows } = setup();
+
+      await act(async () => {
+        await result.current.handleAddRow();
+      });
+
+      expect(addRowMock).toHaveBeenCalledWith("db-1", "user-1", undefined);
+      expect(setRows).toHaveBeenCalled();
+      // Verify the updater appends the new row
+      const updater = setRows.mock.calls[0][0];
+      const updated = updater([makeRow("row-1")]);
+      expect(updated).toHaveLength(2);
+      expect(updated[1].page.id).toBe("new-row-1");
+    });
+
+    it("builds optimistic row_values from initialValues", async () => {
+      const newPage = {
+        id: "new-row-2",
+        title: "",
+        icon: null,
+        cover_url: null,
+        created_at: "2025-01-01T00:00:00Z",
+        updated_at: "2025-01-01T00:00:00Z",
+        created_by: "user-1",
+      };
+      addRowMock.mockResolvedValue({ data: newPage, error: null });
+
+      const { result, setRows } = setup();
+
+      const initialValues = {
+        "prop-1": { option_id: "opt-a" },
+      };
+
+      await act(async () => {
+        await result.current.handleAddRow(initialValues);
+      });
+
+      expect(addRowMock).toHaveBeenCalledWith("db-1", "user-1", initialValues);
+      const updater = setRows.mock.calls[0][0];
+      const updated = updater([]);
+      expect(updated[0].values["prop-1"]).toMatchObject({
+        row_id: "new-row-2",
+        property_id: "prop-1",
+        value: { option_id: "opt-a" },
+      });
+    });
+
+    it("shows toast on error and does not update rows", async () => {
+      addRowMock.mockResolvedValue({
+        data: null,
+        error: new Error("insert failed"),
+      });
+
+      const { result, setRows } = setup();
+
+      await act(async () => {
+        await result.current.handleAddRow();
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add row", {
+        duration: 8000,
+      });
+      expect(setRows).not.toHaveBeenCalled();
+    });
+
+    it("shows toast when data is null without error", async () => {
+      addRowMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setRows } = setup();
+
+      await act(async () => {
+        await result.current.handleAddRow();
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add row", {
+        duration: 8000,
+      });
+      expect(setRows).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleCardMove
+  // -------------------------------------------------------------------------
+
+  describe("handleCardMove", () => {
+    it("optimistically updates the row value and persists", async () => {
+      updateRowValueMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setRows } = setup({
+        rows: [makeRow("row-1")],
+      });
+
+      await act(async () => {
+        await result.current.handleCardMove("row-1", "prop-status", "opt-done");
+      });
+
+      // Optimistic update was called
+      expect(setRows).toHaveBeenCalled();
+      const updater = setRows.mock.calls[0][0];
+      const updated = updater([makeRow("row-1")]);
+      expect(updated[0].values["prop-status"].value).toEqual({
+        option_id: "opt-done",
+      });
+
+      expect(updateRowValueMock).toHaveBeenCalledWith(
+        "row-1",
+        "prop-status",
+        { option_id: "opt-done" },
+        "db-1",
+      );
+    });
+
+    it("handles null newOptionId", async () => {
+      updateRowValueMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setRows } = setup();
+
+      await act(async () => {
+        await result.current.handleCardMove("row-1", "prop-status", null);
+      });
+
+      const updater = setRows.mock.calls[0][0];
+      const updated = updater([makeRow("row-1")]);
+      expect(updated[0].values["prop-status"].value).toEqual({
+        option_id: null,
+      });
+    });
+
+    it("shows toast and captures error on failure", async () => {
+      const dbError = new Error("update failed");
+      updateRowValueMock.mockResolvedValue({ data: null, error: dbError });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleCardMove("row-1", "prop-1", "opt-1");
+      });
+
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+        dbError,
+        "database-view:move-card",
+      );
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to move card", {
+        duration: 8000,
+      });
+    });
+
+    it("skips captureSupabaseError for insufficient privilege errors", async () => {
+      const dbError = new Error("insufficient_privilege");
+      isInsufficientPrivilegeErrorMock.mockReturnValue(true);
+      updateRowValueMock.mockResolvedValue({ data: null, error: dbError });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleCardMove("row-1", "prop-1", "opt-1");
+      });
+
+      expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to move card", {
+        duration: 8000,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleCellUpdate
+  // -------------------------------------------------------------------------
+
+  describe("handleCellUpdate", () => {
+    it("optimistically updates the cell value and persists", async () => {
+      updateRowValueMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setRows } = setup({
+        rows: [makeRow("row-1")],
+      });
+
+      await act(async () => {
+        await result.current.handleCellUpdate("row-1", "prop-1", {
+          text: "hello",
+        });
+      });
+
+      // Optimistic update
+      const updater = setRows.mock.calls[0][0];
+      const updated = updater([makeRow("row-1")]);
+      expect(updated[0].values["prop-1"].value).toEqual({ text: "hello" });
+
+      expect(updateRowValueMock).toHaveBeenCalledWith(
+        "row-1",
+        "prop-1",
+        { text: "hello" },
+        "db-1",
+      );
+    });
+
+    it("strips _newOptions from value before persisting", async () => {
+      updateRowValueMock.mockResolvedValue({ data: null, error: null });
+      updatePropertyMock.mockResolvedValue({ data: null, error: null });
+
+      const { result } = setup();
+
+      const newOptions = [
+        { id: "opt-new", name: "New", color: "blue" },
+      ];
+
+      await act(async () => {
+        await result.current.handleCellUpdate("row-1", "prop-1", {
+          option_id: "opt-new",
+          _newOptions: newOptions,
+        });
+      });
+
+      // updateRowValue should receive cleanValue without _newOptions
+      expect(updateRowValueMock).toHaveBeenCalledWith(
+        "row-1",
+        "prop-1",
+        { option_id: "opt-new" },
+        "db-1",
+      );
+    });
+
+    it("updates property config when _newOptions is provided", async () => {
+      updateRowValueMock.mockResolvedValue({ data: null, error: null });
+      updatePropertyMock.mockResolvedValue({ data: null, error: null });
+
+      const { result, setProperties } = setup();
+
+      const newOptions = [
+        { id: "opt-new", name: "New", color: "blue" },
+      ];
+
+      await act(async () => {
+        await result.current.handleCellUpdate("row-1", "prop-1", {
+          option_id: "opt-new",
+          _newOptions: newOptions,
+        });
+      });
+
+      // Property config should be updated optimistically
+      expect(setProperties).toHaveBeenCalled();
+      // And persisted
+      expect(updatePropertyMock).toHaveBeenCalledWith(
+        "prop-1",
+        { config: { options: newOptions } },
+        "db-1",
+      );
+    });
+
+    it("rolls back on updateRowValue failure", async () => {
+      const dbError = new Error("update failed");
+      updateRowValueMock.mockResolvedValue({ data: null, error: dbError });
+
+      const existingRows = [makeRow("row-1")];
+      const setRows = vi.fn((updater) => {
+        if (typeof updater === "function") {
+          return updater(existingRows);
+        }
+        return updater;
+      });
+
+      const { result } = setup({ rows: existingRows, setRows });
+
+      await act(async () => {
+        await result.current.handleCellUpdate("row-1", "prop-1", {
+          text: "new",
+        });
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update cell", {
+        duration: 8000,
+      });
+      // Rollback: setRows called with the snapshot (not a function)
+      const lastSetRowsCall = setRows.mock.calls[setRows.mock.calls.length - 1][0];
+      // The rollback sets rows directly (not via updater function)
+      expect(Array.isArray(lastSetRowsCall)).toBe(true);
+    });
+
+    it("rolls back on updateProperty failure when _newOptions present", async () => {
+      const configError = new Error("config update failed");
+      updatePropertyMock.mockResolvedValue({
+        data: null,
+        error: configError,
+      });
+      updateRowValueMock.mockResolvedValue({ data: null, error: null });
+
+      const existingRows = [makeRow("row-1")];
+      const setRows = vi.fn((updater) => {
+        if (typeof updater === "function") {
+          return updater(existingRows);
+        }
+        return updater;
+      });
+      const existingProperties: DatabaseProperty[] = [];
+      const setProperties = vi.fn((updater) => {
+        if (typeof updater === "function") {
+          return updater(existingProperties);
+        }
+        return updater;
+      });
+
+      const { result } = setup({
+        rows: existingRows,
+        setRows,
+        setProperties,
+      });
+
+      await act(async () => {
+        await result.current.handleCellUpdate("row-1", "prop-1", {
+          option_id: "opt-1",
+          _newOptions: [{ id: "opt-1", name: "Opt", color: "red" }],
+        });
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to save new option",
+        { duration: 8000 },
+      );
+      // Both rows and properties should be rolled back
+      const lastSetRowsCall = setRows.mock.calls[setRows.mock.calls.length - 1][0];
+      expect(Array.isArray(lastSetRowsCall)).toBe(true);
+      const lastSetPropsCall =
+        setProperties.mock.calls[setProperties.mock.calls.length - 1][0];
+      expect(Array.isArray(lastSetPropsCall)).toBe(true);
+    });
+
+    it("skips captureSupabaseError for insufficient privilege errors", async () => {
+      const dbError = new Error("insufficient_privilege");
+      isInsufficientPrivilegeErrorMock.mockReturnValue(true);
+      updateRowValueMock.mockResolvedValue({ data: null, error: dbError });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleCellUpdate("row-1", "prop-1", {
+          text: "x",
+        });
+      });
+
+      expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update cell", {
+        duration: 8000,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleDeleteRow
+  // -------------------------------------------------------------------------
+
+  describe("handleDeleteRow", () => {
+    it("optimistically removes the row and calls soft_delete_page", async () => {
+      softDeletePageMock.mockResolvedValue({ data: null, error: null });
+
+      const rows = [makeRow("row-1"), makeRow("row-2")];
+      const setRows = vi.fn((updater) => {
+        if (typeof updater === "function") {
+          return updater(rows);
+        }
+        return updater;
+      });
+
+      const { result } = setup({ rows, setRows });
+
+      await act(async () => {
+        await result.current.handleDeleteRow("row-1");
+      });
+
+      // Optimistic removal
+      const updater = setRows.mock.calls[0][0];
+      const updated = updater(rows);
+      expect(updated).toHaveLength(1);
+      expect(updated[0].page.id).toBe("row-2");
+
+      expect(softDeletePageMock).toHaveBeenCalledWith("soft_delete_page", {
+        page_id: "row-1",
+      });
+    });
+
+    it("shows toast and reloads on failure", async () => {
+      const dbError = new Error("delete failed");
+      softDeletePageMock.mockResolvedValue({ data: null, error: dbError });
+      loadDatabaseMock.mockResolvedValue({
+        data: { rows: [makeRow("row-1")] },
+        error: null,
+      });
+
+      const { result, setRows } = setup();
+
+      await act(async () => {
+        await result.current.handleDeleteRow("row-1");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to delete row", {
+        duration: 8000,
+      });
+      expect(loadDatabaseMock).toHaveBeenCalledWith("db-1");
+      // setRows called with reloaded data
+      const lastCall = setRows.mock.calls[setRows.mock.calls.length - 1][0];
+      expect(lastCall).toEqual([makeRow("row-1")]);
+    });
+
+    it("skips captureSupabaseError for insufficient privilege errors on delete", async () => {
+      const dbError = new Error("insufficient_privilege");
+      isInsufficientPrivilegeErrorMock.mockReturnValue(true);
+      softDeletePageMock.mockResolvedValue({ data: null, error: dbError });
+      loadDatabaseMock.mockResolvedValue({ data: null, error: null });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleDeleteRow("row-1");
+      });
+
+      expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to delete row", {
+        duration: 8000,
+      });
+    });
+  });
+});

--- a/src/components/database/hooks/use-database-views.test.ts
+++ b/src/components/database/hooks/use-database-views.test.ts
@@ -1,0 +1,646 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const addViewMock = vi.fn();
+const updateViewMock = vi.fn();
+const deleteViewMock = vi.fn();
+const reorderViewsMock = vi.fn();
+const loadDatabaseMock = vi.fn();
+const toastErrorMock = vi.fn();
+const replaceStateMock = vi.fn();
+
+// Track the current search params value so the mock returns it
+let currentSearchParams = new URLSearchParams();
+
+vi.mock("@/lib/database", () => ({
+  addView: (...args: unknown[]) => addViewMock(...args),
+  updateView: (...args: unknown[]) => updateViewMock(...args),
+  deleteView: (...args: unknown[]) => deleteViewMock(...args),
+  reorderViews: (...args: unknown[]) => reorderViewsMock(...args),
+  loadDatabase: (...args: unknown[]) => loadDatabaseMock(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastErrorMock(...args),
+  },
+}));
+
+vi.mock("@/components/database/view-tabs", () => ({
+  VIEW_TYPE_LABELS: {
+    table: "Table",
+    board: "Board",
+    list: "List",
+    calendar: "Calendar",
+    gallery: "Gallery",
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => currentSearchParams,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  useDatabaseViews,
+  type UseDatabaseViewsParams,
+} from "./use-database-views";
+import type {
+  DatabaseProperty,
+  DatabaseView,
+  DatabaseViewConfig,
+} from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(
+  id: string,
+  name: string,
+  type: DatabaseProperty["type"] = "text",
+): DatabaseProperty {
+  return {
+    id,
+    database_id: "db-1",
+    name,
+    type,
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeView(
+  id: string,
+  overrides?: Partial<DatabaseView>,
+): DatabaseView {
+  return {
+    id,
+    database_id: "db-1",
+    name: "Table view",
+    type: "table",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function setup(overrides?: {
+  views?: DatabaseView[];
+  properties?: DatabaseProperty[];
+  searchParams?: URLSearchParams;
+}) {
+  const views = overrides?.views ?? [
+    makeView("view-1", { name: "Table view", position: 0 }),
+  ];
+  const properties = overrides?.properties ?? [
+    makeProp("title-prop", "Title"),
+  ];
+
+  currentSearchParams = overrides?.searchParams ?? new URLSearchParams();
+
+  const setViews = vi.fn((updater) => {
+    if (typeof updater === "function") return updater(views);
+    return updater;
+  });
+
+  const initialProps: UseDatabaseViewsParams = {
+    pageId: "db-1",
+    properties,
+    views,
+    setViews,
+  };
+
+  const hookResult = renderHook(
+    (props: UseDatabaseViewsParams) => useDatabaseViews(props),
+    { initialProps },
+  );
+
+  return { ...hookResult, setViews, views };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useDatabaseViews", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    currentSearchParams = new URLSearchParams();
+    // Mock window.history.replaceState
+    replaceStateMock.mockReset();
+    vi.spyOn(window.history, "replaceState").mockImplementation(replaceStateMock);
+  });
+
+  // -------------------------------------------------------------------------
+  // activeViewId
+  // -------------------------------------------------------------------------
+
+  describe("activeViewId", () => {
+    it("defaults to first view when no URL param", () => {
+      const { result } = setup();
+      expect(result.current.activeViewId).toBe("view-1");
+    });
+
+    it("uses view from URL param when valid", () => {
+      const views = [
+        makeView("view-1", { position: 0 }),
+        makeView("view-2", { position: 1 }),
+      ];
+      const { result } = setup({
+        views,
+        searchParams: new URLSearchParams("view=view-2"),
+      });
+      expect(result.current.activeViewId).toBe("view-2");
+    });
+
+    it("falls back to first view when URL param is invalid", () => {
+      const { result } = setup({
+        searchParams: new URLSearchParams("view=nonexistent"),
+      });
+      expect(result.current.activeViewId).toBe("view-1");
+    });
+
+    it("returns empty string when no views exist", () => {
+      const { result } = setup({ views: [] });
+      expect(result.current.activeViewId).toBe("");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleViewChange
+  // -------------------------------------------------------------------------
+
+  describe("handleViewChange", () => {
+    it("updates URL param via replaceState", () => {
+      const { result } = setup();
+
+      act(() => {
+        result.current.handleViewChange("view-2");
+      });
+
+      expect(replaceStateMock).toHaveBeenCalledWith(
+        null,
+        "",
+        "?view=view-2",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleAddView
+  // -------------------------------------------------------------------------
+
+  describe("handleAddView", () => {
+    it("creates a table view with default config", async () => {
+      const newView = makeView("new-view", {
+        name: "Table view",
+        type: "table",
+      });
+      addViewMock.mockResolvedValue({ data: newView, error: null });
+
+      const { result, setViews } = setup();
+
+      await act(async () => {
+        await result.current.handleAddView("table");
+      });
+
+      expect(addViewMock).toHaveBeenCalledWith(
+        "db-1",
+        "Table view",
+        "table",
+        {},
+      );
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1")]);
+      expect(updated).toHaveLength(2);
+      expect(updated[1].id).toBe("new-view");
+      // Switches to new view
+      expect(replaceStateMock).toHaveBeenCalled();
+    });
+
+    it("auto-detects group_by for board view from select property", async () => {
+      const newView = makeView("board-view", { type: "board" });
+      addViewMock.mockResolvedValue({ data: newView, error: null });
+
+      const properties = [
+        makeProp("title-prop", "Title"),
+        makeProp("status-prop", "Status", "select"),
+      ];
+      const { result } = setup({ properties });
+
+      await act(async () => {
+        await result.current.handleAddView("board");
+      });
+
+      expect(addViewMock).toHaveBeenCalledWith(
+        "db-1",
+        "Board view",
+        "board",
+        { group_by: "status-prop" },
+      );
+    });
+
+    it("auto-detects group_by for board view from status property", async () => {
+      const newView = makeView("board-view", { type: "board" });
+      addViewMock.mockResolvedValue({ data: newView, error: null });
+
+      const properties = [
+        makeProp("title-prop", "Title"),
+        makeProp("st-prop", "Progress", "status"),
+      ];
+      const { result } = setup({ properties });
+
+      await act(async () => {
+        await result.current.handleAddView("board");
+      });
+
+      expect(addViewMock).toHaveBeenCalledWith(
+        "db-1",
+        "Board view",
+        "board",
+        { group_by: "st-prop" },
+      );
+    });
+
+    it("auto-detects date_property for calendar view", async () => {
+      const newView = makeView("cal-view", { type: "calendar" });
+      addViewMock.mockResolvedValue({ data: newView, error: null });
+
+      const properties = [
+        makeProp("title-prop", "Title"),
+        makeProp("date-prop", "Due Date", "date"),
+      ];
+      const { result } = setup({ properties });
+
+      await act(async () => {
+        await result.current.handleAddView("calendar");
+      });
+
+      expect(addViewMock).toHaveBeenCalledWith(
+        "db-1",
+        "Calendar view",
+        "calendar",
+        { date_property: "date-prop" },
+      );
+    });
+
+    it("shows toast on error", async () => {
+      addViewMock.mockResolvedValue({
+        data: null,
+        error: new Error("failed"),
+      });
+
+      const { result, setViews } = setup();
+
+      await act(async () => {
+        await result.current.handleAddView("table");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to create view", {
+        duration: 8000,
+      });
+      expect(setViews).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleViewConfigChange
+  // -------------------------------------------------------------------------
+
+  describe("handleViewConfigChange", () => {
+    it("optimistically updates config and persists", async () => {
+      updateViewMock.mockResolvedValue({ data: null, error: null });
+
+      const views = [
+        makeView("view-1", { config: { row_height: "default" } }),
+      ];
+      const { result, setViews } = setup({ views });
+
+      await act(async () => {
+        await result.current.handleViewConfigChange({
+          row_height: "compact",
+        });
+      });
+
+      // Optimistic update
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater(views);
+      expect(updated[0].config).toEqual({
+        row_height: "compact",
+      });
+
+      expect(updateViewMock).toHaveBeenCalledWith(
+        "view-1",
+        { config: { row_height: "compact" } },
+        "db-1",
+      );
+    });
+
+    it("reverts on failure", async () => {
+      updateViewMock.mockResolvedValue({
+        data: null,
+        error: new Error("failed"),
+      });
+
+      const views = [
+        makeView("view-1", { config: { row_height: "default" } }),
+      ];
+      const { result, setViews } = setup({ views });
+
+      await act(async () => {
+        await result.current.handleViewConfigChange({
+          row_height: "tall",
+        });
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to update view configuration",
+        { duration: 8000 },
+      );
+      // Revert: second setViews call restores original config
+      expect(setViews).toHaveBeenCalledTimes(2);
+      const revertUpdater = setViews.mock.calls[1][0];
+      const reverted = revertUpdater([
+        makeView("view-1", { config: { row_height: "tall" } }),
+      ]);
+      expect(reverted[0].config).toEqual({ row_height: "default" });
+    });
+
+    it("does nothing when no active view", async () => {
+      const { result } = setup({ views: [] });
+
+      await act(async () => {
+        await result.current.handleViewConfigChange({ row_height: "compact" });
+      });
+
+      expect(updateViewMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleRenameView
+  // -------------------------------------------------------------------------
+
+  describe("handleRenameView", () => {
+    it("renames view and updates state on success", async () => {
+      const updatedView = makeView("view-1", { name: "New Name" });
+      updateViewMock.mockResolvedValue({ data: updatedView, error: null });
+
+      const { result, setViews } = setup();
+
+      await act(async () => {
+        await result.current.handleRenameView("view-1", "New Name");
+      });
+
+      expect(updateViewMock).toHaveBeenCalledWith(
+        "view-1",
+        { name: "New Name" },
+        "db-1",
+      );
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater([makeView("view-1")]);
+      expect(updated[0].name).toBe("New Name");
+    });
+
+    it("shows toast on failure", async () => {
+      updateViewMock.mockResolvedValue({
+        data: null,
+        error: new Error("rename failed"),
+      });
+
+      const { result, setViews } = setup();
+
+      await act(async () => {
+        await result.current.handleRenameView("view-1", "New Name");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to rename view", {
+        duration: 8000,
+      });
+      expect(setViews).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleDeleteView
+  // -------------------------------------------------------------------------
+
+  describe("handleDeleteView", () => {
+    it("deletes view and switches to first remaining", async () => {
+      deleteViewMock.mockResolvedValue({ error: null });
+
+      const views = [
+        makeView("view-1", { position: 0 }),
+        makeView("view-2", { position: 1 }),
+      ];
+      const { result, setViews } = setup({ views });
+
+      await act(async () => {
+        await result.current.handleDeleteView("view-1");
+      });
+
+      expect(deleteViewMock).toHaveBeenCalledWith("view-1", "db-1");
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater(views);
+      expect(updated).toHaveLength(1);
+      expect(updated[0].id).toBe("view-2");
+      // Switches to remaining view
+      expect(replaceStateMock).toHaveBeenCalled();
+    });
+
+    it("shows toast with error message on failure", async () => {
+      deleteViewMock.mockResolvedValue({
+        error: { message: "Cannot delete last view" },
+      });
+
+      const { result, setViews } = setup();
+
+      await act(async () => {
+        await result.current.handleDeleteView("view-1");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Cannot delete last view",
+        { duration: 8000 },
+      );
+      expect(setViews).not.toHaveBeenCalled();
+    });
+
+    it("uses fallback message when error has no message", async () => {
+      deleteViewMock.mockResolvedValue({
+        error: { message: "" },
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleDeleteView("view-1");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to delete view",
+        { duration: 8000 },
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleDuplicateView
+  // -------------------------------------------------------------------------
+
+  describe("handleDuplicateView", () => {
+    it("duplicates view with (copy) suffix and same config", async () => {
+      const sourceConfig: DatabaseViewConfig = {
+        row_height: "compact",
+        sorts: [{ property_id: "p1", direction: "asc" }],
+      };
+      const views = [
+        makeView("view-1", {
+          name: "My View",
+          type: "table",
+          config: sourceConfig,
+        }),
+      ];
+      const duplicated = makeView("view-copy", {
+        name: "My View (copy)",
+        type: "table",
+        config: { ...sourceConfig },
+      });
+      addViewMock.mockResolvedValue({ data: duplicated, error: null });
+
+      const { result, setViews } = setup({ views });
+
+      await act(async () => {
+        await result.current.handleDuplicateView("view-1");
+      });
+
+      expect(addViewMock).toHaveBeenCalledWith(
+        "db-1",
+        "My View (copy)",
+        "table",
+        { ...sourceConfig },
+      );
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater(views);
+      expect(updated).toHaveLength(2);
+      // Switches to duplicated view
+      expect(replaceStateMock).toHaveBeenCalled();
+    });
+
+    it("does nothing for nonexistent source view", async () => {
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleDuplicateView("nonexistent");
+      });
+
+      expect(addViewMock).not.toHaveBeenCalled();
+    });
+
+    it("shows toast on failure", async () => {
+      addViewMock.mockResolvedValue({
+        data: null,
+        error: new Error("failed"),
+      });
+
+      const { result, setViews } = setup();
+
+      await act(async () => {
+        await result.current.handleDuplicateView("view-1");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to duplicate view",
+        { duration: 8000 },
+      );
+      expect(setViews).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleReorderViews
+  // -------------------------------------------------------------------------
+
+  describe("handleReorderViews", () => {
+    it("reorders views optimistically", async () => {
+      reorderViewsMock.mockResolvedValue({ error: null });
+
+      const views = [
+        makeView("v-a", { position: 0 }),
+        makeView("v-b", { position: 1 }),
+        makeView("v-c", { position: 2 }),
+      ];
+      const { result, setViews } = setup({ views });
+
+      await act(async () => {
+        await result.current.handleReorderViews(["v-c", "v-a", "v-b"]);
+      });
+
+      const updater = setViews.mock.calls[0][0];
+      const updated = updater(views);
+      expect(updated.map((v: DatabaseView) => v.id)).toEqual([
+        "v-c",
+        "v-a",
+        "v-b",
+      ]);
+      expect(updated[0].position).toBe(0);
+      expect(updated[1].position).toBe(1);
+      expect(updated[2].position).toBe(2);
+
+      expect(reorderViewsMock).toHaveBeenCalledWith("db-1", [
+        "v-c",
+        "v-a",
+        "v-b",
+      ]);
+    });
+
+    it("reloads on reorder failure", async () => {
+      reorderViewsMock.mockResolvedValue({
+        error: new Error("reorder failed"),
+      });
+      loadDatabaseMock.mockResolvedValue({
+        data: {
+          views: [
+            makeView("v-a", { position: 0 }),
+            makeView("v-b", { position: 1 }),
+          ],
+        },
+        error: null,
+      });
+
+      const views = [
+        makeView("v-a", { position: 0 }),
+        makeView("v-b", { position: 1 }),
+      ];
+      const { result, setViews } = setup({ views });
+
+      await act(async () => {
+        await result.current.handleReorderViews(["v-b", "v-a"]);
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Failed to reorder views",
+        { duration: 8000 },
+      );
+      expect(loadDatabaseMock).toHaveBeenCalledWith("db-1");
+      // setViews called with reloaded data
+      const lastCall = setViews.mock.calls[setViews.mock.calls.length - 1][0];
+      expect(lastCall).toEqual([
+        makeView("v-a", { position: 0 }),
+        makeView("v-b", { position: 1 }),
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #709

## What

Adds 73 unit tests across the four database mutation hooks that previously had zero test coverage:

- **`use-database-rows`** (17 tests): `handleAddRow` (optimistic insert, value formatting), `handleCellUpdate` (optimistic update, rollback on error, `_newOptions` stripping), `handleCardMove` (board drag-and-drop), `handleDeleteRow` (optimistic remove, reload on failure)
- **`use-database-properties`** (15 tests): `handleAddColumn` (default config per type, concurrency guard), `handlePropertyRename` (optimistic + revert), `handleColumnReorder` (position swap + revert), `handleConfirmDeleteColumn` (view config cleanup, row value cleanup, title protection)
- **`use-database-views`** (23 tests): `handleAddView` (default config, auto-detect group_by/date_property), `handleViewConfigChange` (optimistic + revert), `handleRenameView`, `handleDeleteView` (last-view protection), `handleDuplicateView`, `handleReorderViews` (reload on failure), `activeViewId` (URL param resolution)
- **`use-database-filters`** (18 tests): `handleSortsChange`/`handleFiltersChange` (persist to view config), `handleSortToggle` (asc→desc→remove cycle), `displayedRows` (filter-then-sort pipeline), `activeSorts`/`activeFilters` (extraction from view config)

## How

- Uses `renderHook` from `@testing-library/react` with Vitest
- Mocks `@/lib/database` functions, `sonner` toast, `@/lib/sentry` error capture, `@/lib/supabase/client`, and `next/navigation`
- Tests verify optimistic updates by inspecting the updater functions passed to `setRows`/`setProperties`/`setViews`
- Error paths verify toast calls, `captureSupabaseError` invocations, and rollback behavior

## Testing

```
pnpm lint        # 0 errors
pnpm typecheck   # passes
pnpm test        # 82 files, 1033 tests (all pass)
```