### PR TITLE
feat: add loading skeletons for settings and members pages (#713)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/settings/loading.test.ts
+++ b/src/app/(app)/[workspaceSlug]/settings/loading.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("settings route loading state", () => {
+  it("loading.tsx exists for the settings route segment", () => {
+    expect(existsSync(resolve(DIR, "loading.tsx"))).toBe(true);
+  });
+
+  it("loading skeleton uses the same layout container as settings page", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("mx-auto max-w-xl p-6");
+  });
+
+  it("loading skeleton includes animate-pulse elements", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("animate-pulse");
+  });
+
+  it("skeleton elements use bg-muted per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("bg-muted");
+  });
+
+  it("skeleton elements use sharp corners per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    const lines = loading.split("\n");
+    const skeletonLines = lines.filter((l) => l.includes("animate-pulse"));
+    expect(skeletonLines.length).toBeGreaterThan(0);
+    for (const line of skeletonLines) {
+      expect(line).not.toMatch(/\brounded\b/);
+    }
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/settings/loading.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/loading.tsx
@@ -1,0 +1,37 @@
+export default function SettingsLoading() {
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <div className="flex items-center gap-4">
+        {/* "Workspace settings" heading */}
+        <div className="h-8 w-56 animate-pulse bg-muted" />
+        {/* "Members" link */}
+        <div className="h-4 w-16 animate-pulse bg-muted" />
+      </div>
+      {/* Subtitle */}
+      <div className="mt-1 h-4 w-80 animate-pulse bg-muted" />
+      {/* Settings form */}
+      <div className="mt-6 flex flex-col gap-3">
+        {/* Name field */}
+        <div className="flex flex-col gap-1.5">
+          <div className="h-4 w-12 animate-pulse bg-muted" />
+          <div className="h-9 w-full animate-pulse bg-muted" />
+        </div>
+        {/* Slug field */}
+        <div className="flex flex-col gap-1.5">
+          <div className="h-4 w-10 animate-pulse bg-muted" />
+          <div className="h-9 w-full animate-pulse bg-muted" />
+          <div className="h-3 w-32 animate-pulse bg-muted" />
+        </div>
+        {/* Save button */}
+        <div className="h-9 w-28 animate-pulse bg-muted" />
+      </div>
+      {/* Danger zone separator + section */}
+      <div className="mt-8 h-px w-full bg-muted" />
+      <div className="mt-8 flex flex-col gap-3">
+        <div className="h-4 w-24 animate-pulse bg-muted" />
+        <div className="h-3 w-72 animate-pulse bg-muted" />
+        <div className="h-8 w-36 animate-pulse bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/[workspaceSlug]/settings/members/loading.test.ts
+++ b/src/app/(app)/[workspaceSlug]/settings/members/loading.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+const DIR = resolve(__dirname);
+
+describe("members route loading state", () => {
+  it("loading.tsx exists for the members route segment", () => {
+    expect(existsSync(resolve(DIR, "loading.tsx"))).toBe(true);
+  });
+
+  it("loading skeleton uses the same layout container as members page", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("mx-auto max-w-xl p-6");
+  });
+
+  it("loading skeleton includes animate-pulse elements", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("animate-pulse");
+  });
+
+  it("skeleton elements use bg-muted per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    expect(loading).toContain("bg-muted");
+  });
+
+  it("skeleton elements use sharp corners per design spec", () => {
+    const loading = readFileSync(resolve(DIR, "loading.tsx"), "utf-8");
+    const lines = loading.split("\n");
+    const skeletonLines = lines.filter((l) => l.includes("animate-pulse"));
+    expect(skeletonLines.length).toBeGreaterThan(0);
+    for (const line of skeletonLines) {
+      expect(line).not.toMatch(/\brounded\b/);
+    }
+  });
+});

--- a/src/app/(app)/[workspaceSlug]/settings/members/loading.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/loading.tsx
@@ -1,0 +1,59 @@
+export default function MembersLoading() {
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      {/* "Members" heading */}
+      <div className="h-8 w-32 animate-pulse bg-muted" />
+      {/* Subtitle */}
+      <div className="mt-1 h-4 w-64 animate-pulse bg-muted" />
+      <div className="mt-6 flex flex-col gap-8">
+        {/* Invite form skeleton */}
+        <div className="flex flex-col gap-3">
+          {/* "Invite" section label */}
+          <div className="h-3 w-12 animate-pulse bg-muted" />
+          <div className="flex items-end gap-2">
+            {/* Email field */}
+            <div className="flex flex-1 flex-col gap-1.5">
+              <div className="h-4 w-10 animate-pulse bg-muted" />
+              <div className="h-9 w-full animate-pulse bg-muted" />
+            </div>
+            {/* Role select */}
+            <div className="flex flex-col gap-1.5">
+              <div className="h-4 w-8 animate-pulse bg-muted" />
+              <div className="h-9 w-28 animate-pulse bg-muted" />
+            </div>
+            {/* Invite button */}
+            <div className="h-9 w-20 animate-pulse bg-muted" />
+          </div>
+        </div>
+        {/* Separator */}
+        <div className="h-px w-full bg-muted" />
+        {/* Member list skeleton */}
+        <div className="flex flex-col gap-3">
+          {/* "Members (N)" section label */}
+          <div className="h-3 w-24 animate-pulse bg-muted" />
+          {/* Table header */}
+          <div className="flex items-center gap-4 border-b border-border px-2 pb-2">
+            <div className="h-3 w-10 flex-1 animate-pulse bg-muted" />
+            <div className="h-3 w-10 animate-pulse bg-muted" />
+          </div>
+          {/* Member rows */}
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4 px-2 py-2">
+              <div className="flex flex-1 flex-col gap-1">
+                <div
+                  className="h-4 animate-pulse bg-muted"
+                  style={{ width: `${100 + ((i * 23) % 60)}px` }}
+                />
+                <div
+                  className="h-3 animate-pulse bg-muted"
+                  style={{ width: `${140 + ((i * 31) % 50)}px` }}
+                />
+              </div>
+              <div className="h-5 w-14 animate-pulse bg-muted" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #713

## What

Adds `loading.tsx` files for the settings and members routes so Next.js shows skeleton UI during navigation instead of a blank content area.

## How

- `src/app/(app)/[workspaceSlug]/settings/loading.tsx` — skeleton matching the settings form layout (heading, subtitle, name/slug inputs, save button, danger zone section)
- `src/app/(app)/[workspaceSlug]/settings/members/loading.tsx` — skeleton matching the members page layout (heading, subtitle, invite form, separator, member list rows)
- Both follow the existing skeleton pattern: `animate-pulse` + `bg-muted`, sharp corners, same `mx-auto max-w-xl p-6` container as the actual pages
- Unit tests for both skeletons follow the established `loading.test.ts` pattern

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 82 files, 1023 tests pass (including 10 new assertions)
- No E2E tests needed — loading skeletons are non-interactive server components with no event handlers