### PR TITLE
test: add unit tests for database property type renderers and editors (#717)

### DIFF
--- a/src/components/database/property-types/checkbox.test.tsx
+++ b/src/components/database/property-types/checkbox.test.tsx
@@ -1,0 +1,129 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { CheckboxRenderer, CheckboxEditor } from "./checkbox";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Done",
+    type: "checkbox",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CheckboxRenderer
+// ---------------------------------------------------------------------------
+
+describe("CheckboxRenderer", () => {
+  it("renders checked state from value.checked = true", () => {
+    const { container } = render(
+      <CheckboxRenderer value={{ checked: true }} property={makeProp()} />,
+    );
+    // The check icon SVG is rendered when checked
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders unchecked state from value.checked = false", () => {
+    const { container } = render(
+      <CheckboxRenderer value={{ checked: false }} property={makeProp()} />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("reads from value.value as fallback", () => {
+    const { container } = render(
+      <CheckboxRenderer value={{ value: true }} property={makeProp()} />,
+    );
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("treats missing value as unchecked", () => {
+    const { container } = render(
+      <CheckboxRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CheckboxEditor
+// ---------------------------------------------------------------------------
+
+describe("CheckboxEditor", () => {
+  it("renders a checkbox role element", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <CheckboxEditor
+        value={{ checked: false }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
+
+  it("toggles from unchecked to checked on click", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <CheckboxEditor
+        value={{ checked: false }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    await user.click(screen.getByRole("checkbox"));
+    expect(onChange).toHaveBeenCalledWith({ checked: true });
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("toggles from checked to unchecked on click", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <CheckboxEditor
+        value={{ checked: true }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    await user.click(screen.getByRole("checkbox"));
+    expect(onChange).toHaveBeenCalledWith({ checked: false });
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("reflects aria-checked attribute", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <CheckboxEditor
+        value={{ checked: true }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByRole("checkbox")).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+  });
+});

--- a/src/components/database/property-types/computed.test.tsx
+++ b/src/components/database/property-types/computed.test.tsx
@@ -1,0 +1,279 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import {
+  CreatedTimeRenderer,
+  UpdatedTimeRenderer,
+  CreatedByRenderer,
+} from "./computed";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Tooltip provider mock
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <span className={className}>{children}</span>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="tooltip-content">{children}</span>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTimeProp(type: "created_time" | "updated_time"): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: type === "created_time" ? "Created" : "Updated",
+    type,
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+function makeCreatedByProp(
+  members?: Array<{
+    id: string;
+    display_name: string;
+    avatar_url: string | null;
+  }>,
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Created By",
+    type: "created_by",
+    config: { _members: members },
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CreatedTimeRenderer
+// ---------------------------------------------------------------------------
+
+describe("CreatedTimeRenderer", () => {
+  let dateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Fix "now" to 2025-06-15T12:00:00Z for deterministic relative time
+    dateSpy = vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2025-06-15T12:00:00Z").getTime(),
+    );
+  });
+
+  afterEach(() => {
+    dateSpy.mockRestore();
+  });
+
+  it("renders 'Just now' for very recent timestamps", () => {
+    render(
+      <CreatedTimeRenderer
+        value={{ created_at: "2025-06-15T11:59:50Z" }}
+        property={makeTimeProp("created_time")}
+      />,
+    );
+    expect(screen.getByText("Just now")).toBeInTheDocument();
+  });
+
+  it("renders minutes ago for timestamps within the hour", () => {
+    render(
+      <CreatedTimeRenderer
+        value={{ created_at: "2025-06-15T11:45:00Z" }}
+        property={makeTimeProp("created_time")}
+      />,
+    );
+    expect(screen.getByText("15m ago")).toBeInTheDocument();
+  });
+
+  it("renders hours ago for timestamps within the day", () => {
+    render(
+      <CreatedTimeRenderer
+        value={{ created_at: "2025-06-15T09:00:00Z" }}
+        property={makeTimeProp("created_time")}
+      />,
+    );
+    expect(screen.getByText("3h ago")).toBeInTheDocument();
+  });
+
+  it("renders days ago for timestamps within the week", () => {
+    render(
+      <CreatedTimeRenderer
+        value={{ created_at: "2025-06-13T12:00:00Z" }}
+        property={makeTimeProp("created_time")}
+      />,
+    );
+    expect(screen.getByText("2d ago")).toBeInTheDocument();
+  });
+
+  it("renders absolute date for older timestamps", () => {
+    render(
+      <CreatedTimeRenderer
+        value={{ created_at: "2025-01-15T10:00:00Z" }}
+        property={makeTimeProp("created_time")}
+      />,
+    );
+    // Should render as a locale date string like "Jan 15, 2025"
+    expect(screen.getByText("Jan 15, 2025")).toBeInTheDocument();
+  });
+
+  it("renders nothing when created_at is absent", () => {
+    const { container } = render(
+      <CreatedTimeRenderer
+        value={{}}
+        property={makeTimeProp("created_time")}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for empty string", () => {
+    const { container } = render(
+      <CreatedTimeRenderer
+        value={{ created_at: "" }}
+        property={makeTimeProp("created_time")}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UpdatedTimeRenderer
+// ---------------------------------------------------------------------------
+
+describe("UpdatedTimeRenderer", () => {
+  let dateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dateSpy = vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2025-06-15T12:00:00Z").getTime(),
+    );
+  });
+
+  afterEach(() => {
+    dateSpy.mockRestore();
+  });
+
+  it("renders relative time for updated_at", () => {
+    render(
+      <UpdatedTimeRenderer
+        value={{ updated_at: "2025-06-15T11:30:00Z" }}
+        property={makeTimeProp("updated_time")}
+      />,
+    );
+    expect(screen.getByText("30m ago")).toBeInTheDocument();
+  });
+
+  it("renders nothing when updated_at is absent", () => {
+    const { container } = render(
+      <UpdatedTimeRenderer
+        value={{}}
+        property={makeTimeProp("updated_time")}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreatedByRenderer
+// ---------------------------------------------------------------------------
+
+describe("CreatedByRenderer", () => {
+  const MEMBERS = [
+    {
+      id: "user-1",
+      display_name: "Alice Smith",
+      avatar_url: "https://example.com/alice.jpg",
+    },
+    {
+      id: "user-2",
+      display_name: "Bob Jones",
+      avatar_url: null,
+    },
+  ];
+
+  it("renders avatar and name for a known creator", () => {
+    render(
+      <CreatedByRenderer
+        value={{ created_by: "user-1" }}
+        property={makeCreatedByProp(MEMBERS)}
+      />,
+    );
+    const img = screen.getByAltText("Alice Smith");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/alice.jpg");
+    // Name appears in both the trigger text and tooltip content
+    const nameElements = screen.getAllByText("Alice Smith");
+    expect(nameElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders initials for creator without avatar", () => {
+    render(
+      <CreatedByRenderer
+        value={{ created_by: "user-2" }}
+        property={makeCreatedByProp(MEMBERS)}
+      />,
+    );
+    expect(screen.getByText("BJ")).toBeInTheDocument();
+    // Name appears in both the trigger text and tooltip content
+    const nameElements = screen.getAllByText("Bob Jones");
+    expect(nameElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders 'Unknown' when creator is not in _members", () => {
+    render(
+      <CreatedByRenderer
+        value={{ created_by: "nonexistent" }}
+        property={makeCreatedByProp(MEMBERS)}
+      />,
+    );
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("renders 'Unknown' when _members is not set", () => {
+    render(
+      <CreatedByRenderer
+        value={{ created_by: "user-1" }}
+        property={makeCreatedByProp(undefined)}
+      />,
+    );
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("renders nothing when created_by is absent", () => {
+    const { container } = render(
+      <CreatedByRenderer
+        value={{}}
+        property={makeCreatedByProp(MEMBERS)}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for empty string created_by", () => {
+    const { container } = render(
+      <CreatedByRenderer
+        value={{ created_by: "" }}
+        property={makeCreatedByProp(MEMBERS)}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/database/property-types/date.test.tsx
+++ b/src/components/database/property-types/date.test.tsx
@@ -1,0 +1,186 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { DateRenderer, DateEditor } from "./date";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Due Date",
+    type: "date",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DateRenderer
+// ---------------------------------------------------------------------------
+
+describe("DateRenderer", () => {
+  it("renders a formatted date", () => {
+    render(
+      <DateRenderer
+        value={{ date: "2025-06-15" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("Jun 15, 2025")).toBeInTheDocument();
+  });
+
+  it("renders a date range with arrow", () => {
+    render(
+      <DateRenderer
+        value={{ date: "2025-06-15", end_date: "2025-06-20" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText(/Jun 15, 2025 → Jun 20, 2025/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when date is absent", () => {
+    const { container } = render(
+      <DateRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for invalid date string", () => {
+    const { container } = render(
+      <DateRenderer value={{ date: "not-a-date" }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders start date only when end_date is invalid", () => {
+    render(
+      <DateRenderer
+        value={{ date: "2025-03-01", end_date: "invalid" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("Mar 1, 2025")).toBeInTheDocument();
+    expect(screen.queryByText(/→/)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DateEditor
+// ---------------------------------------------------------------------------
+
+describe("DateEditor", () => {
+  it("renders a date picker with month/year header", () => {
+    render(
+      <DateEditor
+        value={{ date: "2025-06-15" }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("June 2025")).toBeInTheDocument();
+  });
+
+  it("renders day-of-week headers", () => {
+    render(
+      <DateEditor
+        value={{ date: "2025-06-15" }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Su")).toBeInTheDocument();
+    expect(screen.getByText("Mo")).toBeInTheDocument();
+    expect(screen.getByText("Sa")).toBeInTheDocument();
+  });
+
+  it("calls onChange when a day is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <DateEditor
+        value={{ date: "2025-06-15" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    // Click day 20
+    await user.click(screen.getByText("20"));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ date: "2025-06-20" }),
+    );
+  });
+
+  it("navigates to previous month", async () => {
+    const user = userEvent.setup();
+    render(
+      <DateEditor
+        value={{ date: "2025-06-15" }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByLabelText("Previous month"));
+    expect(screen.getByText("May 2025")).toBeInTheDocument();
+  });
+
+  it("navigates to next month", async () => {
+    const user = userEvent.setup();
+    render(
+      <DateEditor
+        value={{ date: "2025-06-15" }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByLabelText("Next month"));
+    expect(screen.getByText("July 2025")).toBeInTheDocument();
+  });
+
+  it("has a Today button", () => {
+    render(
+      <DateEditor
+        value={{ date: "2025-06-15" }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Today" }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens to current month when no date is set", () => {
+    const now = new Date();
+    const monthNames = [
+      "January", "February", "March", "April", "May", "June",
+      "July", "August", "September", "October", "November", "December",
+    ];
+    const expected = `${monthNames[now.getMonth()]} ${now.getFullYear()}`;
+
+    render(
+      <DateEditor
+        value={{}}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+});

--- a/src/components/database/property-types/email.test.tsx
+++ b/src/components/database/property-types/email.test.tsx
@@ -1,0 +1,136 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { EmailRenderer, EmailEditor } from "./email";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Email",
+    type: "email",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// EmailRenderer
+// ---------------------------------------------------------------------------
+
+describe("EmailRenderer", () => {
+  it("renders a mailto link", () => {
+    render(
+      <EmailRenderer
+        value={{ email: "test@example.com" }}
+        property={makeProp()}
+      />,
+    );
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "mailto:test@example.com");
+    expect(link).toHaveTextContent("test@example.com");
+  });
+
+  it("falls back to value.value when value.email is absent", () => {
+    render(
+      <EmailRenderer
+        value={{ value: "fallback@test.com" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveTextContent("fallback@test.com");
+  });
+
+  it("renders nothing for empty string", () => {
+    const { container } = render(
+      <EmailRenderer value={{ email: "" }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when value has no email keys", () => {
+    const { container } = render(
+      <EmailRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EmailEditor
+// ---------------------------------------------------------------------------
+
+describe("EmailEditor", () => {
+  it("renders an input with the current email", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <EmailEditor
+        value={{ email: "a@b.com" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByDisplayValue("a@b.com")).toBeInTheDocument();
+  });
+
+  it("calls onChange with { email } on input change", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <EmailEditor
+        value={{ email: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("name@example.com");
+    await user.type(input, "x");
+    expect(onChange).toHaveBeenCalledWith({ email: "x" });
+  });
+
+  it("calls onBlur when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <EmailEditor
+        value={{ email: "a@b.com" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByDisplayValue("a@b.com");
+    await user.type(input, "{Enter}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("calls onBlur when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <EmailEditor
+        value={{ email: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("name@example.com");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+});

--- a/src/components/database/property-types/files.test.tsx
+++ b/src/components/database/property-types/files.test.tsx
@@ -1,0 +1,228 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { FilesRenderer, FilesEditor } from "./files";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/supabase/lazy-client", () => ({
+  getClient: vi.fn().mockResolvedValue({
+    storage: {
+      from: () => ({
+        upload: vi.fn().mockResolvedValue({ error: null }),
+        getPublicUrl: () => ({ data: { publicUrl: "https://cdn.example.com/file.png" } }),
+      }),
+    },
+  }),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: vi.fn(),
+  isInsufficientPrivilegeError: vi.fn().mockReturnValue(false),
+  isSchemaNotFoundError: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("@/lib/capture", () => ({
+  lazyCaptureException: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Attachments",
+    type: "files",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FilesRenderer
+// ---------------------------------------------------------------------------
+
+describe("FilesRenderer", () => {
+  it("renders image thumbnails for image files", () => {
+    render(
+      <FilesRenderer
+        value={{
+          files: [
+            { name: "photo.png", url: "https://cdn.example.com/photo.png" },
+          ],
+        }}
+        property={makeProp()}
+      />,
+    );
+    const img = screen.getByAltText("photo.png");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://cdn.example.com/photo.png");
+  });
+
+  it("renders file icon for non-image files", () => {
+    const { container } = render(
+      <FilesRenderer
+        value={{
+          files: [
+            { name: "document.pdf", url: "https://cdn.example.com/doc.pdf" },
+          ],
+        }}
+        property={makeProp()}
+      />,
+    );
+    // FileText icon renders as an SVG
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders nothing when files array is empty", () => {
+    const { container } = render(
+      <FilesRenderer value={{ files: [] }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when files is absent", () => {
+    const { container } = render(
+      <FilesRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows overflow count when more than 3 files", () => {
+    render(
+      <FilesRenderer
+        value={{
+          files: [
+            { name: "a.png", url: "https://cdn.example.com/a.png" },
+            { name: "b.png", url: "https://cdn.example.com/b.png" },
+            { name: "c.png", url: "https://cdn.example.com/c.png" },
+            { name: "d.png", url: "https://cdn.example.com/d.png" },
+            { name: "e.pdf", url: "https://cdn.example.com/e.pdf" },
+          ],
+        }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+
+  it("shows max 3 visible thumbnails", () => {
+    render(
+      <FilesRenderer
+        value={{
+          files: [
+            { name: "a.png", url: "https://cdn.example.com/a.png" },
+            { name: "b.png", url: "https://cdn.example.com/b.png" },
+            { name: "c.png", url: "https://cdn.example.com/c.png" },
+            { name: "d.png", url: "https://cdn.example.com/d.png" },
+          ],
+        }}
+        property={makeProp()}
+      />,
+    );
+    const images = screen.getAllByRole("img");
+    expect(images).toHaveLength(3);
+  });
+
+  it("filters out invalid file entries", () => {
+    const { container } = render(
+      <FilesRenderer
+        value={{
+          files: [
+            { name: 123, url: "bad" }, // invalid: name is not string
+            null,
+            "not-an-object",
+          ],
+        }}
+        property={makeProp()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FilesEditor
+// ---------------------------------------------------------------------------
+
+describe("FilesEditor", () => {
+  it("renders the upload button", () => {
+    render(
+      <FilesEditor
+        value={{ files: [] }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /upload file/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders drag-and-drop hint text", () => {
+    render(
+      <FilesEditor
+        value={{ files: [] }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("or drag and drop")).toBeInTheDocument();
+  });
+
+  it("renders existing files with remove buttons", () => {
+    render(
+      <FilesEditor
+        value={{
+          files: [
+            { name: "report.pdf", url: "https://cdn.example.com/report.pdf" },
+          ],
+        }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Remove report.pdf"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with updated files when a file is removed", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <FilesEditor
+        value={{
+          files: [
+            { name: "a.pdf", url: "https://cdn.example.com/a.pdf" },
+            { name: "b.pdf", url: "https://cdn.example.com/b.pdf" },
+          ],
+        }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByLabelText("Remove a.pdf"));
+    expect(onChange).toHaveBeenCalledWith({
+      files: [{ name: "b.pdf", url: "https://cdn.example.com/b.pdf" }],
+    });
+  });
+});

--- a/src/components/database/property-types/formula.test.tsx
+++ b/src/components/database/property-types/formula.test.tsx
@@ -1,0 +1,88 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { FormulaRenderer } from "./formula";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(
+  config: Record<string, unknown> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Total",
+    type: "formula",
+    config,
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FormulaRenderer
+// ---------------------------------------------------------------------------
+
+describe("FormulaRenderer", () => {
+  it("renders the computed display value", () => {
+    render(
+      <FormulaRenderer
+        value={{ _display: "42", _error: null }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("renders 'Error' when _error is set", () => {
+    render(
+      <FormulaRenderer
+        value={{ _display: null, _error: "Division by zero" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("Error")).toBeInTheDocument();
+  });
+
+  it("renders nothing when _display is empty and no error", () => {
+    const { container } = render(
+      <FormulaRenderer
+        value={{ _display: "", _error: null }}
+        property={makeProp()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when value has no _display or _error", () => {
+    const { container } = render(
+      <FormulaRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("prioritizes error over display", () => {
+    render(
+      <FormulaRenderer
+        value={{ _display: "42", _error: "some error" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.queryByText("42")).toBeNull();
+  });
+
+  it("renders string display values", () => {
+    render(
+      <FormulaRenderer
+        value={{ _display: "Hello World", _error: null }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("Hello World")).toBeInTheDocument();
+  });
+});

--- a/src/components/database/property-types/multi-select.test.tsx
+++ b/src/components/database/property-types/multi-select.test.tsx
@@ -1,0 +1,198 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty, SelectOption } from "@/lib/types";
+import { MultiSelectRenderer, MultiSelectEditor } from "./multi-select";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const OPTIONS: SelectOption[] = [
+  { id: "tag-1", name: "Frontend", color: "blue" },
+  { id: "tag-2", name: "Backend", color: "green" },
+  { id: "tag-3", name: "Design", color: "purple" },
+];
+
+function makeProp(
+  options: SelectOption[] = OPTIONS,
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Tags",
+    type: "multi_select",
+    config: { options },
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MultiSelectRenderer
+// ---------------------------------------------------------------------------
+
+describe("MultiSelectRenderer", () => {
+  it("renders multiple option badges", () => {
+    render(
+      <MultiSelectRenderer
+        value={{ option_ids: ["tag-1", "tag-2"] }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("Frontend")).toBeInTheDocument();
+    expect(screen.getByText("Backend")).toBeInTheDocument();
+  });
+
+  it("renders nothing when option_ids is empty", () => {
+    const { container } = render(
+      <MultiSelectRenderer
+        value={{ option_ids: [] }}
+        property={makeProp()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when option_ids is absent", () => {
+    const { container } = render(
+      <MultiSelectRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("skips option_ids that do not match any option", () => {
+    render(
+      <MultiSelectRenderer
+        value={{ option_ids: ["tag-1", "nonexistent"] }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("Frontend")).toBeInTheDocument();
+    // "nonexistent" should not render anything
+    expect(screen.queryByText("nonexistent")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MultiSelectEditor
+// ---------------------------------------------------------------------------
+
+describe("MultiSelectEditor", () => {
+  it("renders the dropdown with all options", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <MultiSelectEditor
+        value={{ option_ids: [] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByText("Frontend")).toBeInTheDocument();
+    expect(screen.getByText("Backend")).toBeInTheDocument();
+    expect(screen.getByText("Design")).toBeInTheDocument();
+  });
+
+  it("calls onChange with added option_id when an option is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <MultiSelectEditor
+        value={{ option_ids: ["tag-1"] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    await user.click(screen.getByText("Backend"));
+    expect(onChange).toHaveBeenCalledWith({
+      option_ids: ["tag-1", "tag-2"],
+    });
+  });
+
+  it("calls onChange with removed option_id when a selected option is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <MultiSelectEditor
+        value={{ option_ids: ["tag-1", "tag-2"] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    await user.click(screen.getByText("Frontend"));
+    expect(onChange).toHaveBeenCalledWith({
+      option_ids: ["tag-2"],
+    });
+  });
+
+  it("filters options by search query", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <MultiSelectEditor
+        value={{ option_ids: [] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search or create…");
+    await user.type(input, "front");
+    expect(screen.getByText("Frontend")).toBeInTheDocument();
+    expect(screen.queryByText("Backend")).toBeNull();
+  });
+
+  it("creates a new option and adds it to selection", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <MultiSelectEditor
+        value={{ option_ids: ["tag-1"] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search or create…");
+    await user.type(input, "DevOps");
+    await user.click(screen.getByText("Create"));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        option_ids: expect.arrayContaining(["tag-1"]),
+        _newOptions: expect.arrayContaining([
+          expect.objectContaining({ name: "DevOps" }),
+        ]),
+      }),
+    );
+    // The new option_ids should have 2 entries (tag-1 + new)
+    const call = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+    expect(call.option_ids).toHaveLength(2);
+  });
+
+  it("calls onBlur (onClose) when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <MultiSelectEditor
+        value={{ option_ids: [] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search or create…");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+});

--- a/src/components/database/property-types/number.test.tsx
+++ b/src/components/database/property-types/number.test.tsx
@@ -1,0 +1,196 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { NumberRenderer, NumberEditor } from "./number";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(
+  config: Record<string, unknown> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Amount",
+    type: "number",
+    config,
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// NumberRenderer
+// ---------------------------------------------------------------------------
+
+describe("NumberRenderer", () => {
+  it("renders a plain number with locale formatting", () => {
+    render(
+      <NumberRenderer value={{ number: 1234 }} property={makeProp()} />,
+    );
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+  });
+
+  it("renders currency format", () => {
+    render(
+      <NumberRenderer
+        value={{ number: 42.5 }}
+        property={makeProp({ format: "currency" })}
+      />,
+    );
+    expect(screen.getByText("$42.50")).toBeInTheDocument();
+  });
+
+  it("renders percent format", () => {
+    render(
+      <NumberRenderer
+        value={{ number: 0.85 }}
+        property={makeProp({ format: "percent" })}
+      />,
+    );
+    expect(screen.getByText("85%")).toBeInTheDocument();
+  });
+
+  it("falls back to value.value when value.number is absent", () => {
+    render(
+      <NumberRenderer value={{ value: 7 }} property={makeProp()} />,
+    );
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("renders nothing for null value", () => {
+    const { container } = render(
+      <NumberRenderer value={{ number: null }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for empty string value", () => {
+    const { container } = render(
+      <NumberRenderer value={{ number: "" }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for NaN-producing value", () => {
+    const { container } = render(
+      <NumberRenderer value={{ number: "abc" }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders string numbers correctly", () => {
+    render(
+      <NumberRenderer value={{ number: "99" }} property={makeProp()} />,
+    );
+    expect(screen.getByText("99")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NumberEditor
+// ---------------------------------------------------------------------------
+
+describe("NumberEditor", () => {
+  it("renders an input with the current numeric value", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <NumberEditor
+        value={{ number: 42 }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveValue(42);
+  });
+
+  it("calls onChange with { number } on input change", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <NumberEditor
+        value={{ number: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    await user.type(input, "5");
+    expect(onChange).toHaveBeenCalledWith({ number: 5 });
+  });
+
+  it("calls onChange with null when input is cleared", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <NumberEditor
+        value={{ number: 5 }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    await user.clear(input);
+    expect(onChange).toHaveBeenCalledWith({ number: null });
+  });
+
+  it("calls onBlur when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <NumberEditor
+        value={{ number: 10 }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    await user.type(input, "{Enter}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("calls onBlur when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <NumberEditor
+        value={{ number: 10 }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("falls back to value.value when value.number is absent", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <NumberEditor
+        value={{ value: 99 }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByRole("spinbutton")).toHaveValue(99);
+  });
+});

--- a/src/components/database/property-types/person.test.tsx
+++ b/src/components/database/property-types/person.test.tsx
@@ -1,0 +1,231 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { PersonRenderer, PersonEditor } from "./person";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockSingle = vi.fn();
+
+vi.mock("@/lib/supabase/lazy-client", () => ({
+  getClient: vi.fn().mockResolvedValue({
+    from: () => ({
+      select: (...args: unknown[]) => {
+        mockSelect(...args);
+        return {
+          eq: (...eqArgs: unknown[]) => {
+            mockEq(...eqArgs);
+            return {
+              single: () => mockSingle(),
+              // For members query (no .single())
+              ...(() => {
+                const result = mockEq(...eqArgs);
+                return result;
+              })(),
+            };
+          },
+        };
+      },
+    }),
+  }),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: vi.fn(),
+  isInsufficientPrivilegeError: vi.fn().mockReturnValue(false),
+}));
+
+// Tooltip provider mock — tooltips need a provider in tests
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <span className={className}>{children}</span>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MEMBERS = [
+  {
+    id: "user-1",
+    display_name: "Alice Smith",
+    email: "alice@example.com",
+    avatar_url: "https://example.com/alice.jpg",
+  },
+  {
+    id: "user-2",
+    display_name: "Bob Jones",
+    email: "bob@example.com",
+    avatar_url: null,
+  },
+];
+
+function makeProp(
+  members = MEMBERS,
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Assignee",
+    type: "person",
+    config: { _members: members },
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// PersonRenderer
+// ---------------------------------------------------------------------------
+
+describe("PersonRenderer", () => {
+  it("renders avatar for user with avatar_url", () => {
+    render(
+      <PersonRenderer
+        value={{ user_ids: ["user-1"] }}
+        property={makeProp()}
+      />,
+    );
+    const img = screen.getByAltText("Alice Smith");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/alice.jpg");
+  });
+
+  it("renders initials for user without avatar_url", () => {
+    render(
+      <PersonRenderer
+        value={{ user_ids: ["user-2"] }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("BJ")).toBeInTheDocument();
+  });
+
+  it("renders multiple avatars", () => {
+    render(
+      <PersonRenderer
+        value={{ user_ids: ["user-1", "user-2"] }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByAltText("Alice Smith")).toBeInTheDocument();
+    expect(screen.getByText("BJ")).toBeInTheDocument();
+  });
+
+  it("renders nothing when user_ids is empty", () => {
+    const { container } = render(
+      <PersonRenderer
+        value={{ user_ids: [] }}
+        property={makeProp()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when user_ids is absent", () => {
+    const { container } = render(
+      <PersonRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("skips user_ids not found in _members", () => {
+    render(
+      <PersonRenderer
+        value={{ user_ids: ["user-1", "nonexistent"] }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByAltText("Alice Smith")).toBeInTheDocument();
+    // Only one avatar should render
+    expect(screen.queryByText("?")).toBeNull();
+  });
+
+  it("renders tooltip with display name", () => {
+    render(
+      <PersonRenderer
+        value={{ user_ids: ["user-1"] }}
+        property={makeProp()}
+      />,
+    );
+    // Our mocked TooltipContent renders as a span
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PersonEditor
+// ---------------------------------------------------------------------------
+
+describe("PersonEditor", () => {
+  // PersonEditor fetches members from Supabase on mount.
+  // We mock the Supabase client chain for the two queries:
+  // 1. pages.select("workspace_id").eq("id", database_id).single()
+  // 2. members.select(...).eq("workspace_id", ...)
+
+  it("renders a search input", async () => {
+    // Mock the DB lookup to return a workspace_id
+    mockSingle.mockResolvedValue({
+      data: { workspace_id: "ws-1" },
+      error: null,
+    });
+    // Mock the members query
+    mockEq.mockReturnValue({
+      single: () => mockSingle(),
+      then: undefined,
+    });
+
+    render(
+      <PersonEditor
+        value={{ user_ids: [] }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByPlaceholderText("Search members…"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons initially", () => {
+    // Don't resolve the mock — keep it pending
+    mockSingle.mockReturnValue(new Promise(() => {}));
+    mockEq.mockReturnValue({
+      single: () => mockSingle(),
+    });
+
+    const { container } = render(
+      <PersonEditor
+        value={{ user_ids: [] }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+
+    // Loading skeletons use animate-pulse class
+    const skeletons = container.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/database/property-types/phone.test.tsx
+++ b/src/components/database/property-types/phone.test.tsx
@@ -1,0 +1,154 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { PhoneRenderer, PhoneEditor } from "./phone";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Phone",
+    type: "phone",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PhoneRenderer
+// ---------------------------------------------------------------------------
+
+describe("PhoneRenderer", () => {
+  it("formats a 10-digit US number", () => {
+    render(
+      <PhoneRenderer
+        value={{ phone: "5551234567" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("(555) 123-4567")).toBeInTheDocument();
+  });
+
+  it("formats an 11-digit US number with country code", () => {
+    render(
+      <PhoneRenderer
+        value={{ phone: "15551234567" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("+1 (555) 123-4567")).toBeInTheDocument();
+  });
+
+  it("renders international numbers as-is", () => {
+    render(
+      <PhoneRenderer
+        value={{ phone: "+44 20 7946 0958" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("+44 20 7946 0958")).toBeInTheDocument();
+  });
+
+  it("falls back to value.value when value.phone is absent", () => {
+    render(
+      <PhoneRenderer
+        value={{ value: "1234567890" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("(123) 456-7890")).toBeInTheDocument();
+  });
+
+  it("renders nothing for empty string", () => {
+    const { container } = render(
+      <PhoneRenderer value={{ phone: "" }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when value has no phone keys", () => {
+    const { container } = render(
+      <PhoneRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PhoneEditor
+// ---------------------------------------------------------------------------
+
+describe("PhoneEditor", () => {
+  it("renders an input with the current phone value", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <PhoneEditor
+        value={{ phone: "5551234567" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByDisplayValue("5551234567")).toBeInTheDocument();
+  });
+
+  it("calls onChange with { phone } on input change", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <PhoneEditor
+        value={{ phone: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("+1 (555) 000-0000");
+    await user.type(input, "5");
+    expect(onChange).toHaveBeenCalledWith({ phone: "5" });
+  });
+
+  it("calls onBlur when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <PhoneEditor
+        value={{ phone: "555" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByDisplayValue("555");
+    await user.type(input, "{Enter}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("calls onBlur when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <PhoneEditor
+        value={{ phone: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("+1 (555) 000-0000");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+});

--- a/src/components/database/property-types/relation.test.tsx
+++ b/src/components/database/property-types/relation.test.tsx
@@ -1,0 +1,294 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { RelationRenderer, RelationEditor } from "./relation";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ workspaceSlug: "test-ws" }),
+}));
+
+// Supabase mock — chain: from().select().in() or from().select().eq().is().order()
+const mockSupabaseData = vi.fn();
+
+vi.mock("@/lib/supabase/lazy-client", () => ({
+  getClient: vi.fn().mockResolvedValue({
+    from: () => ({
+      select: () => ({
+        in: () => mockSupabaseData(),
+        eq: () => ({
+          is: () => ({
+            order: () => mockSupabaseData(),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: vi.fn(),
+  isInsufficientPrivilegeError: vi.fn().mockReturnValue(false),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(
+  config: Record<string, unknown> = { database_id: "target-db-1" },
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Related",
+    type: "relation",
+    config,
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// RelationRenderer
+// ---------------------------------------------------------------------------
+
+describe("RelationRenderer", () => {
+  it("renders loading skeletons while resolving page IDs", () => {
+    // Keep the promise pending
+    mockSupabaseData.mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(
+      <RelationRenderer
+        value={{ page_ids: ["page-1"] }}
+        property={makeProp()}
+      />,
+    );
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+
+  it("renders resolved page titles as pills", async () => {
+    mockSupabaseData.mockResolvedValue({
+      data: [
+        { id: "page-1", title: "Task Alpha", icon: "📋" },
+      ],
+      error: null,
+    });
+
+    render(
+      <RelationRenderer
+        value={{ page_ids: ["page-1"] }}
+        property={makeProp()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Task Alpha")).toBeInTheDocument();
+    });
+    expect(screen.getByText("📋")).toBeInTheDocument();
+  });
+
+  it("renders 'Deleted page' for pages not found", async () => {
+    mockSupabaseData.mockResolvedValue({
+      data: [],
+      error: null,
+    });
+
+    render(
+      <RelationRenderer
+        value={{ page_ids: ["missing-page"] }}
+        property={makeProp()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Deleted page")).toBeInTheDocument();
+    });
+  });
+
+  it("renders nothing when page_ids is empty", () => {
+    const { container } = render(
+      <RelationRenderer value={{ page_ids: [] }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when page_ids is absent", () => {
+    const { container } = render(
+      <RelationRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("navigates to page on pill click", async () => {
+    const user = userEvent.setup();
+    mockSupabaseData.mockResolvedValue({
+      data: [{ id: "page-1", title: "Task Alpha", icon: null }],
+      error: null,
+    });
+
+    render(
+      <RelationRenderer
+        value={{ page_ids: ["page-1"] }}
+        property={makeProp()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Task Alpha")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Navigate to Task Alpha"));
+    expect(mockPush).toHaveBeenCalledWith("/test-ws/page-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RelationEditor
+// ---------------------------------------------------------------------------
+
+describe("RelationEditor", () => {
+  it("renders a search input", () => {
+    mockSupabaseData.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <RelationEditor
+        value={{ page_ids: [] }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(screen.getByPlaceholderText("Search pages…")).toBeInTheDocument();
+  });
+
+  it("shows message when no target database is configured", () => {
+    render(
+      <RelationEditor
+        value={{ page_ids: [] }}
+        property={makeProp({})}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/no target database configured/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders target rows after loading", async () => {
+    mockSupabaseData.mockResolvedValue({
+      data: [
+        { id: "row-1", title: "Row One", icon: "🔵" },
+        { id: "row-2", title: "Row Two", icon: null },
+      ],
+      error: null,
+    });
+
+    render(
+      <RelationEditor
+        value={{ page_ids: [] }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Row One")).toBeInTheDocument();
+      expect(screen.getByText("Row Two")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onChange with toggled page_ids when a row is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    mockSupabaseData.mockResolvedValue({
+      data: [
+        { id: "row-1", title: "Row One", icon: null },
+      ],
+      error: null,
+    });
+
+    render(
+      <RelationEditor
+        value={{ page_ids: [] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Row One")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Add Row One"));
+    expect(onChange).toHaveBeenCalledWith({ page_ids: ["row-1"] });
+  });
+
+  it("removes a page_id when a selected row is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    mockSupabaseData.mockResolvedValue({
+      data: [
+        { id: "row-1", title: "Row One", icon: null },
+      ],
+      error: null,
+    });
+
+    render(
+      <RelationEditor
+        value={{ page_ids: ["row-1"] }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Row One")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Remove Row One"));
+    expect(onChange).toHaveBeenCalledWith({ page_ids: [] });
+  });
+
+  it("calls onBlur when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onBlur = vi.fn();
+
+    mockSupabaseData.mockResolvedValue({
+      data: [],
+      error: null,
+    });
+
+    render(
+      <RelationEditor
+        value={{ page_ids: [] }}
+        property={makeProp()}
+        onChange={vi.fn()}
+        onBlur={onBlur}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Search pages…");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+});

--- a/src/components/database/property-types/select.test.tsx
+++ b/src/components/database/property-types/select.test.tsx
@@ -1,0 +1,198 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty, SelectOption } from "@/lib/types";
+import { SelectRenderer, SelectEditor } from "./select";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const OPTIONS: SelectOption[] = [
+  { id: "opt-1", name: "High", color: "red" },
+  { id: "opt-2", name: "Medium", color: "yellow" },
+  { id: "opt-3", name: "Low", color: "green" },
+];
+
+function makeProp(
+  options: SelectOption[] = OPTIONS,
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Priority",
+    type: "select",
+    config: { options },
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SelectRenderer
+// ---------------------------------------------------------------------------
+
+describe("SelectRenderer", () => {
+  it("renders the selected option badge", () => {
+    render(
+      <SelectRenderer
+        value={{ option_id: "opt-1" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
+  it("renders nothing when no option is selected", () => {
+    const { container } = render(
+      <SelectRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when option_id is null", () => {
+    const { container } = render(
+      <SelectRenderer value={{ option_id: null }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when option_id does not match any option", () => {
+    const { container } = render(
+      <SelectRenderer
+        value={{ option_id: "nonexistent" }}
+        property={makeProp()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when config has no options", () => {
+    const { container } = render(
+      <SelectRenderer
+        value={{ option_id: "opt-1" }}
+        property={makeProp([])}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SelectEditor
+// ---------------------------------------------------------------------------
+
+describe("SelectEditor", () => {
+  it("renders the dropdown with all options", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <SelectEditor
+        value={{}}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.getByText("Low")).toBeInTheDocument();
+  });
+
+  it("calls onChange with option_id when an option is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <SelectEditor
+        value={{}}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    await user.click(screen.getByText("Medium"));
+    expect(onChange).toHaveBeenCalledWith({ option_id: "opt-2" });
+  });
+
+  it("filters options by search query", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <SelectEditor
+        value={{}}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search or create…");
+    await user.type(input, "hi");
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.queryByText("Medium")).toBeNull();
+    expect(screen.queryByText("Low")).toBeNull();
+  });
+
+  it("shows create button for new option names", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <SelectEditor
+        value={{}}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search or create…");
+    await user.type(input, "Critical");
+    expect(screen.getByText("Create")).toBeInTheDocument();
+  });
+
+  it("creates a new option when the create button is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <SelectEditor
+        value={{}}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search or create…");
+    await user.type(input, "Critical");
+    await user.click(screen.getByText("Create"));
+    // onChange should be called with the new option_id and _newOptions
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        option_id: expect.any(String),
+        _newOptions: expect.arrayContaining([
+          expect.objectContaining({ name: "Critical" }),
+        ]),
+      }),
+    );
+  });
+
+  it("calls onBlur (onClose) when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <SelectEditor
+        value={{}}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("Search or create…");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+});

--- a/src/components/database/property-types/text.test.tsx
+++ b/src/components/database/property-types/text.test.tsx
@@ -1,0 +1,147 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { TextRenderer, TextEditor } from "./text";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(overrides: Partial<DatabaseProperty> = {}): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Name",
+    type: "text",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TextRenderer
+// ---------------------------------------------------------------------------
+
+describe("TextRenderer", () => {
+  it("renders text from value.text", () => {
+    render(<TextRenderer value={{ text: "Hello" }} property={makeProp()} />);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("falls back to value.value when value.text is absent", () => {
+    render(<TextRenderer value={{ value: "Fallback" }} property={makeProp()} />);
+    expect(screen.getByText("Fallback")).toBeInTheDocument();
+  });
+
+  it("renders nothing for empty string", () => {
+    const { container } = render(
+      <TextRenderer value={{ text: "" }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when value has no text keys", () => {
+    const { container } = render(
+      <TextRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing for non-string value.text", () => {
+    const { container } = render(
+      <TextRenderer value={{ text: 42 }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TextEditor
+// ---------------------------------------------------------------------------
+
+describe("TextEditor", () => {
+  it("renders an input with the current text value", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <TextEditor
+        value={{ text: "Hello" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("Hello");
+  });
+
+  it("calls onChange with { text } on input change", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <TextEditor
+        value={{ text: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("textbox");
+    await user.type(input, "A");
+    expect(onChange).toHaveBeenCalledWith({ text: "A" });
+  });
+
+  it("calls onBlur when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <TextEditor
+        value={{ text: "Hi" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("textbox");
+    await user.type(input, "{Enter}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("calls onBlur when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <TextEditor
+        value={{ text: "Hi" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByRole("textbox");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("falls back to value.value when value.text is absent", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <TextEditor
+        value={{ value: "Fallback" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("Fallback");
+  });
+});

--- a/src/components/database/property-types/url.test.tsx
+++ b/src/components/database/property-types/url.test.tsx
@@ -1,0 +1,162 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import { UrlRenderer, UrlEditor } from "./url";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Website",
+    type: "url",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// UrlRenderer
+// ---------------------------------------------------------------------------
+
+describe("UrlRenderer", () => {
+  it("renders a link with parsed hostname", () => {
+    render(
+      <UrlRenderer
+        value={{ url: "https://example.com/path" }}
+        property={makeProp()}
+      />,
+    );
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://example.com/path");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveTextContent("example.com/path");
+  });
+
+  it("strips trailing slash from root URLs", () => {
+    render(
+      <UrlRenderer
+        value={{ url: "https://example.com/" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveTextContent("example.com");
+  });
+
+  it("falls back to raw text for invalid URLs", () => {
+    render(
+      <UrlRenderer
+        value={{ url: "not-a-url" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveTextContent("not-a-url");
+  });
+
+  it("falls back to value.value when value.url is absent", () => {
+    render(
+      <UrlRenderer
+        value={{ value: "https://fallback.com" }}
+        property={makeProp()}
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "https://fallback.com",
+    );
+  });
+
+  it("renders nothing for empty string", () => {
+    const { container } = render(
+      <UrlRenderer value={{ url: "" }} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when value has no url keys", () => {
+    const { container } = render(
+      <UrlRenderer value={{}} property={makeProp()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UrlEditor
+// ---------------------------------------------------------------------------
+
+describe("UrlEditor", () => {
+  it("renders an input with the current URL", () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <UrlEditor
+        value={{ url: "https://example.com" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    // URL input doesn't have a specific role in jsdom, find by display value
+    const input = screen.getByDisplayValue("https://example.com");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("calls onChange with { url } on input change", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <UrlEditor
+        value={{ url: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("https://…");
+    await user.type(input, "h");
+    expect(onChange).toHaveBeenCalledWith({ url: "h" });
+  });
+
+  it("calls onBlur when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <UrlEditor
+        value={{ url: "https://x.com" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByDisplayValue("https://x.com");
+    await user.type(input, "{Enter}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it("calls onBlur when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <UrlEditor
+        value={{ url: "" }}
+        property={makeProp()}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    const input = screen.getByPlaceholderText("https://…");
+    await user.type(input, "{Escape}");
+    expect(onBlur).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #717

## What

Adds 146 unit tests across 14 co-located test files for all database property type renderers and editors. Previously only `formula` and `person-skeleton` had design-spec tests — the remaining 12 property types had zero test coverage for their rendering and editing logic.

## Test files added

| Property type | File | Tests |
|---|---|---|
| text | `text.test.tsx` | 10 |
| number | `number.test.tsx` | 14 |
| checkbox | `checkbox.test.tsx` | 8 |
| url | `url.test.tsx` | 10 |
| email | `email.test.tsx` | 8 |
| phone | `phone.test.tsx` | 10 |
| select | `select.test.tsx` | 11 |
| multi-select | `multi-select.test.tsx` | 10 |
| date | `date.test.tsx` | 12 |
| person | `person.test.tsx` | 9 |
| files | `files.test.tsx` | 11 |
| relation | `relation.test.tsx` | 12 |
| formula | `formula.test.tsx` | 6 |
| computed | `computed.test.tsx` | 15 |

## How

- **Renderer tests** verify: correct value display, fallback from `value.X` to `value.value`, empty/null/missing value handling, formatted output (number locale, phone formatting, date formatting, relative timestamps).
- **Editor tests** verify: input rendering with current value, `onChange` callback shape, `onBlur` on Enter/Escape, option filtering and creation (select/multi-select), toggle behavior (checkbox), date picker navigation, file removal, relation page toggling.
- Supabase calls in person, files, and relation editors are mocked via `vi.mock("@/lib/supabase/lazy-client")`.
- Tooltip components are mocked to avoid provider requirements in unit tests.
- `Date.now` is spied on for deterministic relative-time assertions in computed tests.

## Testing

- `pnpm lint` — 0 errors (warnings are pre-existing)
- `pnpm typecheck` — passes
- `pnpm test` — 1242 tests pass (100 files)
- No UI changes — no E2E or Storybook updates needed