### PR TITLE
perf: add React.memo to database table sub-components (#714)

### DIFF
--- a/src/components/database/views/table-cell-renderer.tsx
+++ b/src/components/database/views/table-cell-renderer.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { cn } from "@/lib/utils";
 import type {
   DatabaseProperty,
@@ -51,7 +52,7 @@ export interface CellRendererProps {
   displayValue: string;
 }
 
-export function CellRenderer({ value, property, propertyType, displayValue }: CellRendererProps) {
+export const CellRenderer = memo(function CellRenderer({ value, property, propertyType, displayValue }: CellRendererProps) {
   switch (propertyType) {
     case "select":
     case "status": {
@@ -155,4 +156,4 @@ export function CellRenderer({ value, property, propertyType, displayValue }: Ce
         </span>
       );
   }
-}
+});

--- a/src/components/database/views/table-cell.tsx
+++ b/src/components/database/views/table-cell.tsx
@@ -2,6 +2,7 @@
 
 import {
   Component,
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -60,7 +61,7 @@ export interface TableCellProps {
   onFocus: (rowIndex: number, colIndex: number) => void;
 }
 
-export function TableCell({
+export const TableCell = memo(function TableCell({
   rowId,
   propertyId,
   property,
@@ -271,7 +272,7 @@ export function TableCell({
       />
     </div>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // CellEditorErrorBoundary — catches rendering errors in cell editors so a

--- a/src/components/database/views/table-row.tsx
+++ b/src/components/database/views/table-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import Link from "next/link";
 import { Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -48,7 +49,35 @@ export interface TableRowProps {
   onDeleteRow?: (rowId: string) => void;
 }
 
-export function TableRow({
+// editingCell and focusedCell change on every interaction but only affect the
+// row they target. Compare whether the state is relevant to *this* row so
+// unrelated rows skip re-rendering.
+function areTableRowPropsEqual(prev: TableRowProps, next: TableRowProps): boolean {
+  if (prev.row !== next.row) return false;
+  if (prev.rowIndex !== next.rowIndex) return false;
+  if (prev.visibleProperties !== next.visibleProperties) return false;
+  if (prev.allProperties !== next.allProperties) return false;
+  if (prev.rowHeightClass !== next.rowHeightClass) return false;
+  if (prev.workspaceSlug !== next.workspaceSlug) return false;
+  if (prev.onStartEditing !== next.onStartEditing) return false;
+  if (prev.onCellKeyDown !== next.onCellKeyDown) return false;
+  if (prev.onCellBlur !== next.onCellBlur) return false;
+  if (prev.onCellFocus !== next.onCellFocus) return false;
+  if (prev.onDeleteRow !== next.onDeleteRow) return false;
+
+  // Only re-render if editing/focus state targets this row
+  const prevEditing = prev.editingCell?.rowId === prev.row.page.id ? prev.editingCell : null;
+  const nextEditing = next.editingCell?.rowId === next.row.page.id ? next.editingCell : null;
+  if (prevEditing?.propertyId !== nextEditing?.propertyId) return false;
+
+  const prevFocused = prev.focusedCell?.rowIndex === prev.rowIndex ? prev.focusedCell : null;
+  const nextFocused = next.focusedCell?.rowIndex === next.rowIndex ? next.focusedCell : null;
+  if (prevFocused?.colIndex !== nextFocused?.colIndex) return false;
+
+  return true;
+}
+
+export const TableRow = memo(function TableRow({
   row,
   rowIndex,
   visibleProperties,
@@ -145,4 +174,4 @@ export function TableRow({
       />
     </>
   );
-}
+}, areTableRowPropsEqual);


### PR DESCRIPTION
Closes #714

## What

Wraps `TableRow`, `TableCell`, and `CellRenderer` with `React.memo` to reduce unnecessary re-renders in the database table view. When any cell value changes or the user interacts with the filter/sort toolbar, only affected rows and cells now re-render instead of the entire table.

## How

- **`TableRow`** — wrapped with `React.memo` and a custom comparator (`areTableRowPropsEqual`). The comparator checks whether `editingCell` and `focusedCell` actually target *this* row, so rows unaffected by editing/focus state skip re-rendering.
- **`TableCell`** — wrapped with `React.memo` using default shallow comparison. Props are primitives, stable objects, and `useCallback`-stabilized functions.
- **`CellRenderer`** — wrapped with `React.memo` using default shallow comparison. Props are value + property + type + display string.

All callback props passed to these components are already stabilized with `useCallback` in `useTableCellNavigation` and `useDatabaseRows` — no parent changes needed.

## Testing

- ✅ `pnpm lint` — no new warnings
- ✅ `pnpm typecheck` — passes
- ✅ `pnpm test` — 84 files, 1086 tests pass
- ✅ `pnpm test:e2e` — 58 pass, 13 fail (all pre-existing failures on `main`, verified by running the same tests on `main` without changes — same failures due to test environment Supabase connectivity)
- No behavioral changes — this is a pure performance optimization wrapping existing components with `React.memo`