### PR TITLE
fix: add role="row" to table-view header and data rows (#725)

### DIFF
--- a/src/components/database/views/table-row.tsx
+++ b/src/components/database/views/table-row.tsx
@@ -93,7 +93,7 @@ export const TableRow = memo(function TableRow({
   onDeleteRow,
 }: TableRowProps) {
   return (
-    <>
+    <div role="row" style={{ display: "contents" }}>
       {/* Title cell */}
       <div
         className={cn(
@@ -172,6 +172,6 @@ export const TableRow = memo(function TableRow({
         )}
         role="gridcell"
       />
-    </>
+    </div>
   );
 }, areTableRowPropsEqual);

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -205,56 +205,59 @@ export const TableView = memo(function TableView({
         aria-label="Database table"
         onKeyDown={handleFocusedCellKeyDown}
       >
-        {/* Title column header */}
-        <div
-          className="sticky top-0 z-10 border-b border-overlay-border bg-background p-2"
-          role="columnheader"
-        >
-          <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
-            Title
-          </span>
-        </div>
+        {/* Header row */}
+        <div role="row" style={{ display: "contents" }}>
+          {/* Title column header */}
+          <div
+            className="sticky top-0 z-10 border-b border-overlay-border bg-background p-2"
+            role="columnheader"
+          >
+            <span className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+              Title
+            </span>
+          </div>
 
-        {/* Property column headers */}
-        {visibleProperties.map((prop, colIndex) => {
-          const sortRule = sorts.find((s) => s.property_id === prop.id);
-          const isDragging = columnDrag?.propertyId === prop.id;
-          const showDropBefore = !!(
-            columnDrag &&
-            columnDropTarget?.insertIndex === colIndex &&
-            columnDrag.propertyId !== prop.id
-          );
-          const showDropAfter = !!(
-            columnDrag &&
-            columnDropTarget?.insertIndex === colIndex + 1 &&
-            columnDrag.propertyId !== prop.id
-          );
-          return (
-            <TableColumnHeader
-              key={prop.id}
-              property={prop}
-              colIndex={colIndex}
-              sortRule={sortRule}
-              isDragging={isDragging}
-              showDropBefore={showDropBefore}
-              showDropAfter={showDropAfter}
-              resizingColumn={resizingColumn}
-              onColumnReorder={onColumnReorder}
-              onColumnHeaderClick={onColumnHeaderClick}
-              onDeleteColumn={onDeleteColumn}
-              onSortToggle={onSortToggle}
-              onDragStart={handleColumnDragStart}
-              onDragEnd={handleColumnDragEnd}
-              onDragOver={handleColumnDragOver}
-              onDrop={handleColumnDrop}
-              onResizeStart={handleResizeStart}
-            />
-          );
-        })}
+          {/* Property column headers */}
+          {visibleProperties.map((prop, colIndex) => {
+            const sortRule = sorts.find((s) => s.property_id === prop.id);
+            const isDragging = columnDrag?.propertyId === prop.id;
+            const showDropBefore = !!(
+              columnDrag &&
+              columnDropTarget?.insertIndex === colIndex &&
+              columnDrag.propertyId !== prop.id
+            );
+            const showDropAfter = !!(
+              columnDrag &&
+              columnDropTarget?.insertIndex === colIndex + 1 &&
+              columnDrag.propertyId !== prop.id
+            );
+            return (
+              <TableColumnHeader
+                key={prop.id}
+                property={prop}
+                colIndex={colIndex}
+                sortRule={sortRule}
+                isDragging={isDragging}
+                showDropBefore={showDropBefore}
+                showDropAfter={showDropAfter}
+                resizingColumn={resizingColumn}
+                onColumnReorder={onColumnReorder}
+                onColumnHeaderClick={onColumnHeaderClick}
+                onDeleteColumn={onDeleteColumn}
+                onSortToggle={onSortToggle}
+                onDragStart={handleColumnDragStart}
+                onDragEnd={handleColumnDragEnd}
+                onDragOver={handleColumnDragOver}
+                onDrop={handleColumnDrop}
+                onResizeStart={handleResizeStart}
+              />
+            );
+          })}
 
-        {/* Add column header button */}
-        <div className="sticky top-0 z-10 flex items-center border-b border-overlay-border bg-background px-2">
-          {onAddColumn && <PropertyTypePicker onSelect={onAddColumn} />}
+          {/* Add column header button */}
+          <div className="sticky top-0 z-10 flex items-center border-b border-overlay-border bg-background px-2">
+            {onAddColumn && <PropertyTypePicker onSelect={onAddColumn} />}
+          </div>
         </div>
 
         {/* Data rows */}


### PR DESCRIPTION
Closes #725

## What

10 E2E tests across `database-table-keyboard.spec.ts` and `database-views.spec.ts` failed because they locate table rows via `[role="row"]`, but the table-view component rendered row cells as flat siblings inside the grid without any `role="row"` wrapper. The WAI-ARIA grid pattern requires `role="row"` elements between `role="grid"` and `role="gridcell"`.

## How

Added `<div role="row" style={{ display: "contents" }}>` wrappers around:
- The header row (Title + property column headers + add-column button) in `table-view.tsx`
- Each data row (title cell + property cells + trailing empty cell) in `table-row.tsx`

`display: contents` ensures the wrapper doesn't create a new box in the CSS grid layout — child elements continue to participate directly in the parent grid. This preserves the existing visual layout while adding the semantic row grouping needed for both accessibility and E2E selectors.

## Testing

- All 10 previously failing E2E tests now pass (6 in `database-table-keyboard.spec.ts`, 4 in `database-views.spec.ts`)
- `pnpm lint && pnpm typecheck && pnpm test` all pass (0 errors, 1242 unit tests pass)
- Full E2E suite for both affected spec files passes (16/16)