### PR TITLE
test: add E2E tests for formula, files, and relation property types (#724)

### DIFF
--- a/e2e/database-files.spec.ts
+++ b/e2e/database-files.spec.ts
@@ -1,0 +1,357 @@
+import path from "node:path";
+import { test, expect } from "./fixtures/auth";
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Admin client for setup and cleanup
+// ---------------------------------------------------------------------------
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+let databasePageId: string;
+let workspaceSlug: string;
+let filesPropertyId: string;
+let rowId: string;
+
+// ---------------------------------------------------------------------------
+// Setup: create a database with a files property and one row
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  const admin = getAdminClient();
+  const email = process.env.TEST_USER_EMAIL!;
+
+  // Find the test user
+  const { data: userList } = await admin.auth.admin.listUsers({
+    perPage: 1000,
+  });
+  let testUserId: string | undefined;
+  if (userList?.users) {
+    testUserId = userList.users.find((u) => u.email === email)?.id;
+  }
+  if (!testUserId) throw new Error(`Test user ${email} not found`);
+
+  // Get workspace
+  const { data: memberships } = await admin
+    .from("members")
+    .select("workspace_id, workspaces(id, slug)")
+    .eq("user_id", testUserId)
+    .limit(10);
+
+  if (!memberships || memberships.length === 0) {
+    throw new Error("No workspace found for test user");
+  }
+
+  const ws = memberships[0].workspaces as unknown as {
+    id: string;
+    slug: string;
+  };
+  workspaceSlug = ws.slug;
+
+  // Create a database page
+  const { data: dbPage, error: dbErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      title: "Files Test DB",
+      is_database: true,
+      position: 9981,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (dbErr || !dbPage)
+    throw new Error(`Failed to create database: ${dbErr?.message}`);
+  databasePageId = dbPage.id;
+
+  // Create a files property
+  const { data: filesProp, error: filesErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Attachments",
+      type: "files",
+      config: {},
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (filesErr || !filesProp)
+    throw new Error(
+      `Failed to create files property: ${filesErr?.message}`,
+    );
+  filesPropertyId = filesProp.id;
+
+  // Create a default table view
+  const { error: tvErr } = await admin
+    .from("database_views")
+    .insert({
+      database_id: databasePageId,
+      name: "Table view",
+      type: "table",
+      config: {},
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (tvErr) throw new Error(`Failed to create table view: ${tvErr.message}`);
+
+  // Create a row
+  const { data: rowPage, error: rowErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      parent_id: databasePageId,
+      title: "File Row",
+      is_database: false,
+      position: 0,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (rowErr || !rowPage)
+    throw new Error(`Failed to create row: ${rowErr?.message}`);
+  rowId = rowPage.id;
+
+  // Upload a test file to Supabase Storage via admin client
+  const fs = await import("node:fs");
+  const testImagePath = path.resolve(__dirname, "fixtures/test-image.png");
+  const fileBuffer = fs.readFileSync(testImagePath);
+  const filePath = `uploads/test-e2e-${Date.now()}.png`;
+
+  const { error: uploadErr } = await admin.storage
+    .from("page-images")
+    .upload(filePath, fileBuffer, {
+      contentType: "image/png",
+      cacheControl: "3600",
+      upsert: false,
+    });
+
+  if (uploadErr)
+    throw new Error(`Failed to upload test file: ${uploadErr.message}`);
+
+  const { data: urlData } = admin.storage
+    .from("page-images")
+    .getPublicUrl(filePath);
+
+  // Pre-populate the row with a file value
+  const { error: rvErr } = await admin.from("row_values").insert({
+    row_id: rowId,
+    property_id: filesPropertyId,
+    value: {
+      files: [{ name: "test-image.png", url: urlData.publicUrl }],
+    },
+  });
+
+  if (rvErr)
+    throw new Error(`Failed to set row value: ${rvErr.message}`);
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+test.afterAll(async () => {
+  const admin = getAdminClient();
+
+  // Delete row values
+  await admin.from("row_values").delete().eq("row_id", rowId);
+
+  // Delete rows
+  await admin.from("pages").delete().eq("parent_id", databasePageId);
+
+  // Delete views, properties, and the database page
+  await admin
+    .from("database_views")
+    .delete()
+    .eq("database_id", databasePageId);
+  await admin
+    .from("database_properties")
+    .delete()
+    .eq("database_id", databasePageId);
+  await admin.from("pages").delete().eq("id", databasePageId);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function navigateToDatabase(page: import("@playwright/test").Page) {
+  await page.goto(`/${workspaceSlug}/${databasePageId}`);
+  await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Files property type", () => {
+  test("file thumbnail renders on the row detail page", async ({
+    authenticatedPage: page,
+  }) => {
+    // Navigate to the row detail page where FilesRenderer is used
+    await page.goto(`/${workspaceSlug}/${rowId}`);
+
+    // Wait for the properties header to load
+    const attachmentsLabel = page.locator("text=Attachments").first();
+    await expect(attachmentsLabel).toBeVisible({ timeout: 15_000 });
+
+    // The FilesRenderer should show the file thumbnail (img for image files)
+    const thumbnail = page.locator('img[alt="test-image.png"]');
+    await expect(thumbnail).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("file editor opens and shows existing files when cell is clicked", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Click the files cell to open the editor
+    const filesCell = page.locator('[role="gridcell"][data-col]').first();
+    await expect(filesCell).toBeVisible({ timeout: 10_000 });
+    await filesCell.click();
+
+    // The files editor should appear with the "Upload file" button
+    const uploadBtn = page.locator("button", { hasText: "Upload file" });
+    await expect(uploadBtn).toBeVisible({ timeout: 5_000 });
+
+    // The existing file should be listed with its name and remove button
+    const removeBtn = page.locator(
+      'button[aria-label="Remove test-image.png"]',
+    );
+    await expect(removeBtn).toBeVisible({ timeout: 5_000 });
+
+    // Close the editor
+    await page.keyboard.press("Escape");
+  });
+
+  test("file can be removed from the cell editor", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Click the cell to open the editor
+    const filesCell = page.locator('[role="gridcell"][data-col]').first();
+    await expect(filesCell).toBeVisible({ timeout: 10_000 });
+    await filesCell.click();
+
+    // Wait for the file to appear in the editor
+    const removeBtn = page.locator(
+      'button[aria-label="Remove test-image.png"]',
+    );
+    await expect(removeBtn).toBeVisible({ timeout: 10_000 });
+
+    // Click the remove button — this triggers onChange which closes the editor
+    await removeBtn.click();
+
+    // The editor closes after onChange. Wait for it to close.
+    await expect(removeBtn).not.toBeVisible({ timeout: 5_000 });
+
+    // Re-open the editor to verify the file was removed
+    const filesCellAgain = page
+      .locator('[role="gridcell"][data-col]')
+      .first();
+    await expect(filesCellAgain).toBeVisible({ timeout: 5_000 });
+    await filesCellAgain.click();
+
+    // The upload button should be visible but no file listed
+    const uploadBtn = page.locator("button", { hasText: "Upload file" });
+    await expect(uploadBtn).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.locator('button[aria-label="Remove test-image.png"]'),
+    ).not.toBeVisible({ timeout: 3_000 });
+
+    // Close the editor
+    await page.keyboard.press("Escape");
+
+    // Restore the file for other tests by re-inserting via admin
+    const admin = getAdminClient();
+    const { data: urlData } = admin.storage
+      .from("page-images")
+      .getPublicUrl("uploads/placeholder.png");
+
+    await admin
+      .from("row_values")
+      .upsert({
+        row_id: rowId,
+        property_id: filesPropertyId,
+        value: {
+          files: [
+            { name: "test-image.png", url: urlData.publicUrl },
+          ],
+        },
+      });
+  });
+
+  test("upload a file via the cell editor using file chooser", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // First remove existing files to start clean
+    const admin = getAdminClient();
+    await admin
+      .from("row_values")
+      .update({ value: { files: [] } })
+      .eq("row_id", rowId)
+      .eq("property_id", filesPropertyId);
+
+    // Reload to get clean state
+    await page.reload();
+    await expect(page.locator('[role="grid"]')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Click the files cell to open the editor
+    const filesCell = page.locator('[role="gridcell"][data-col]').first();
+    await expect(filesCell).toBeVisible({ timeout: 10_000 });
+    await filesCell.click();
+
+    // The files editor should appear with an "Upload file" button
+    const uploadBtn = page.locator("button", { hasText: "Upload file" });
+    await expect(uploadBtn).toBeVisible({ timeout: 5_000 });
+
+    // Listen for the file chooser event before clicking the upload button
+    const fileChooserPromise = page.waitForEvent("filechooser");
+    await uploadBtn.click();
+
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(
+      path.resolve(__dirname, "fixtures/test-image.png"),
+    );
+
+    // The upload triggers onChange which closes the editor.
+    // Wait for the editor to close (upload button disappears).
+    await expect(uploadBtn).not.toBeVisible({ timeout: 15_000 });
+
+    // Re-open the editor to verify the file was uploaded
+    const filesCellAgain = page
+      .locator('[role="gridcell"][data-col]')
+      .first();
+    await expect(filesCellAgain).toBeVisible({ timeout: 5_000 });
+    await filesCellAgain.click();
+
+    // The uploaded file should appear with a remove button
+    const removeBtn = page.locator(
+      'button[aria-label="Remove test-image.png"]',
+    );
+    await expect(removeBtn).toBeVisible({ timeout: 10_000 });
+
+    // Close the editor
+    await page.keyboard.press("Escape");
+  });
+});

--- a/e2e/database-formula.spec.ts
+++ b/e2e/database-formula.spec.ts
@@ -1,0 +1,293 @@
+import { test, expect } from "./fixtures/auth";
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Admin client for setup and cleanup
+// ---------------------------------------------------------------------------
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+let databasePageId: string;
+let workspaceSlug: string;
+let numberPropertyId: string;
+let rowId: string;
+
+// ---------------------------------------------------------------------------
+// Setup: create a database with number, text, and formula properties
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  const admin = getAdminClient();
+  const email = process.env.TEST_USER_EMAIL!;
+
+  // Find the test user
+  const { data: userList } = await admin.auth.admin.listUsers({
+    perPage: 1000,
+  });
+  let testUserId: string | undefined;
+  if (userList?.users) {
+    testUserId = userList.users.find((u) => u.email === email)?.id;
+  }
+  if (!testUserId) throw new Error(`Test user ${email} not found`);
+
+  // Get workspace
+  const { data: memberships } = await admin
+    .from("members")
+    .select("workspace_id, workspaces(id, slug)")
+    .eq("user_id", testUserId)
+    .limit(10);
+
+  if (!memberships || memberships.length === 0) {
+    throw new Error("No workspace found for test user");
+  }
+
+  const ws = memberships[0].workspaces as unknown as {
+    id: string;
+    slug: string;
+  };
+  workspaceSlug = ws.slug;
+
+  // Create a database page
+  const { data: dbPage, error: dbErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      title: "Formula Test DB",
+      is_database: true,
+      position: 9980,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (dbErr || !dbPage)
+    throw new Error(`Failed to create database: ${dbErr?.message}`);
+  databasePageId = dbPage.id;
+
+  // Create a number property
+  const { data: numProp, error: numErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Price",
+      type: "number",
+      config: {},
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (numErr || !numProp)
+    throw new Error(`Failed to create number property: ${numErr?.message}`);
+  numberPropertyId = numProp.id;
+
+  // Create a text property
+  const { data: txtProp, error: txtErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Label",
+      type: "text",
+      config: {},
+      position: 1,
+    })
+    .select()
+    .single();
+
+  if (txtErr || !txtProp)
+    throw new Error(`Failed to create text property: ${txtErr?.message}`);
+
+  // Create a formula property: prop("Price") * 2
+  const { data: fmlProp, error: fmlErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Double Price",
+      type: "formula",
+      config: { expression: 'prop("Price") * 2' },
+      position: 2,
+    })
+    .select()
+    .single();
+
+  if (fmlErr || !fmlProp)
+    throw new Error(`Failed to create formula property: ${fmlErr?.message}`);
+
+  // Create a formula property with an invalid expression
+  const { data: badFmlProp, error: badFmlErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: databasePageId,
+      name: "Bad Formula",
+      type: "formula",
+      config: { expression: "prop(nonexistent) +++" },
+      position: 3,
+    })
+    .select()
+    .single();
+
+  if (badFmlErr || !badFmlProp)
+    throw new Error(
+      `Failed to create invalid formula property: ${badFmlErr?.message}`,
+    );
+
+  // Create a default table view
+  const { error: tvErr } = await admin
+    .from("database_views")
+    .insert({
+      database_id: databasePageId,
+      name: "Table view",
+      type: "table",
+      config: {},
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (tvErr) throw new Error(`Failed to create table view: ${tvErr.message}`);
+
+  // Create a row with a Price value
+  const { data: rowPage, error: rowErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      parent_id: databasePageId,
+      title: "Item A",
+      is_database: false,
+      position: 0,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (rowErr || !rowPage)
+    throw new Error(`Failed to create row: ${rowErr?.message}`);
+  rowId = rowPage.id;
+
+  // Set the Price value to 50
+  const { error: rvErr } = await admin.from("row_values").insert({
+    row_id: rowId,
+    property_id: numberPropertyId,
+    value: { number: 50 },
+  });
+
+  if (rvErr)
+    throw new Error(`Failed to set row value: ${rvErr.message}`);
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+test.afterAll(async () => {
+  const admin = getAdminClient();
+
+  // Delete row values
+  await admin.from("row_values").delete().eq("row_id", rowId);
+
+  // Delete rows
+  await admin.from("pages").delete().eq("parent_id", databasePageId);
+
+  // Delete views, properties, and the database page
+  await admin
+    .from("database_views")
+    .delete()
+    .eq("database_id", databasePageId);
+  await admin
+    .from("database_properties")
+    .delete()
+    .eq("database_id", databasePageId);
+  await admin.from("pages").delete().eq("id", databasePageId);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function navigateToDatabase(page: import("@playwright/test").Page) {
+  await page.goto(`/${workspaceSlug}/${databasePageId}`);
+  await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Formula property type", () => {
+  test("formula column displays computed value in table view", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // The grid should show the computed formula value: 50 * 2 = 100
+    const grid = page.locator('[role="grid"]');
+    await expect(grid.getByText("100")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("formula updates when referenced property value changes", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // Verify initial formula value is 100
+    const grid = page.locator('[role="grid"]');
+    await expect(grid.getByText("100")).toBeVisible({ timeout: 10_000 });
+
+    // Find the Price cell and click to edit it.
+    // The Price column is the first property column (data-col="0").
+    const priceCell = page.locator('[role="gridcell"][data-col="0"]').first();
+    await expect(priceCell).toBeVisible({ timeout: 5_000 });
+    await priceCell.click();
+
+    // An input should appear for inline editing
+    const cellInput = page.locator(
+      '[role="gridcell"] input[type="number"]',
+    );
+    await expect(cellInput).toBeVisible({ timeout: 5_000 });
+
+    // Change the price to 75
+    await cellInput.fill("75");
+
+    // Click outside to blur and save
+    await page.locator("h1, input[aria-label]").first().click();
+
+    // The formula should now show 75 * 2 = 150
+    await expect(grid.getByText("150")).toBeVisible({ timeout: 10_000 });
+
+    // Restore the original value for other tests
+    const priceCellAgain = page
+      .locator('[role="gridcell"][data-col="0"]')
+      .first();
+    await priceCellAgain.click();
+    const cellInputAgain = page.locator(
+      '[role="gridcell"] input[type="number"]',
+    );
+    await expect(cellInputAgain).toBeVisible({ timeout: 5_000 });
+    await cellInputAgain.fill("50");
+    await page.locator("h1, input[aria-label]").first().click();
+    await expect(grid.getByText("100")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("formula error state renders for invalid expressions", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToDatabase(page);
+
+    // The invalid formula column should display "Error" with destructive styling
+    const grid = page.locator('[role="grid"]');
+    const errorCell = grid.locator("span.text-destructive", {
+      hasText: "Error",
+    });
+    await expect(errorCell).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/e2e/database-relation.spec.ts
+++ b/e2e/database-relation.spec.ts
@@ -1,0 +1,390 @@
+import { test, expect } from "./fixtures/auth";
+import { createClient } from "@supabase/supabase-js";
+
+// ---------------------------------------------------------------------------
+// Admin client for setup and cleanup
+// ---------------------------------------------------------------------------
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+let workspaceSlug: string;
+
+// Source database (has the relation column)
+let sourceDbId: string;
+let sourceRowId: string;
+let relationPropertyId: string;
+
+// Target database (linked to by the relation)
+let targetDbId: string;
+let targetRowId1: string;
+
+// ---------------------------------------------------------------------------
+// Setup: create two databases, a relation property linking them, and rows
+// ---------------------------------------------------------------------------
+
+test.beforeAll(async () => {
+  const admin = getAdminClient();
+  const email = process.env.TEST_USER_EMAIL!;
+
+  // Find the test user
+  const { data: userList } = await admin.auth.admin.listUsers({
+    perPage: 1000,
+  });
+  let testUserId: string | undefined;
+  if (userList?.users) {
+    testUserId = userList.users.find((u) => u.email === email)?.id;
+  }
+  if (!testUserId) throw new Error(`Test user ${email} not found`);
+
+  // Get workspace
+  const { data: memberships } = await admin
+    .from("members")
+    .select("workspace_id, workspaces(id, slug)")
+    .eq("user_id", testUserId)
+    .limit(10);
+
+  if (!memberships || memberships.length === 0) {
+    throw new Error("No workspace found for test user");
+  }
+
+  const ws = memberships[0].workspaces as unknown as {
+    id: string;
+    slug: string;
+  };
+  workspaceSlug = ws.slug;
+
+  // ---- Target database (the one being linked TO) ----
+
+  const { data: targetDb, error: targetDbErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      title: "Target DB",
+      is_database: true,
+      position: 9982,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (targetDbErr || !targetDb)
+    throw new Error(
+      `Failed to create target database: ${targetDbErr?.message}`,
+    );
+  targetDbId = targetDb.id;
+
+  // Create a table view for the target database
+  await admin
+    .from("database_views")
+    .insert({
+      database_id: targetDbId,
+      name: "Table view",
+      type: "table",
+      config: {},
+      position: 0,
+    });
+
+  // Create rows in the target database
+  const { data: tRow1, error: tRow1Err } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      parent_id: targetDbId,
+      title: "Alpha Item",
+      is_database: false,
+      position: 0,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (tRow1Err || !tRow1)
+    throw new Error(`Failed to create target row 1: ${tRow1Err?.message}`);
+  targetRowId1 = tRow1.id;
+
+  const { data: tRow2, error: tRow2Err } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      parent_id: targetDbId,
+      title: "Beta Item",
+      is_database: false,
+      position: 1,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (tRow2Err || !tRow2)
+    throw new Error(`Failed to create target row 2: ${tRow2Err?.message}`);
+
+  // ---- Source database (has the relation column) ----
+
+  const { data: sourceDb, error: sourceDbErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      title: "Source DB",
+      is_database: true,
+      position: 9983,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (sourceDbErr || !sourceDb)
+    throw new Error(
+      `Failed to create source database: ${sourceDbErr?.message}`,
+    );
+  sourceDbId = sourceDb.id;
+
+  // Create a relation property pointing to the target database
+  const { data: relProp, error: relErr } = await admin
+    .from("database_properties")
+    .insert({
+      database_id: sourceDbId,
+      name: "Linked Items",
+      type: "relation",
+      config: { database_id: targetDbId },
+      position: 0,
+    })
+    .select()
+    .single();
+
+  if (relErr || !relProp)
+    throw new Error(
+      `Failed to create relation property: ${relErr?.message}`,
+    );
+  relationPropertyId = relProp.id;
+
+  // Create a table view for the source database
+  await admin
+    .from("database_views")
+    .insert({
+      database_id: sourceDbId,
+      name: "Table view",
+      type: "table",
+      config: {},
+      position: 0,
+    });
+
+  // Create a row in the source database
+  const { data: srcRow, error: srcRowErr } = await admin
+    .from("pages")
+    .insert({
+      workspace_id: ws.id,
+      parent_id: sourceDbId,
+      title: "Source Row",
+      is_database: false,
+      position: 0,
+      created_by: testUserId,
+    })
+    .select()
+    .single();
+
+  if (srcRowErr || !srcRow)
+    throw new Error(`Failed to create source row: ${srcRowErr?.message}`);
+  sourceRowId = srcRow.id;
+
+  // Pre-populate the relation value so the pill test is independent
+  const { error: rvErr } = await admin.from("row_values").insert({
+    row_id: sourceRowId,
+    property_id: relationPropertyId,
+    value: { page_ids: [targetRowId1] },
+  });
+
+  if (rvErr)
+    throw new Error(`Failed to set relation value: ${rvErr.message}`);
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+test.afterAll(async () => {
+  const admin = getAdminClient();
+
+  // Clean up source database
+  await admin.from("row_values").delete().eq("row_id", sourceRowId);
+  await admin.from("pages").delete().eq("parent_id", sourceDbId);
+  await admin
+    .from("database_views")
+    .delete()
+    .eq("database_id", sourceDbId);
+  await admin
+    .from("database_properties")
+    .delete()
+    .eq("database_id", sourceDbId);
+  await admin.from("pages").delete().eq("id", sourceDbId);
+
+  // Clean up target database
+  await admin.from("pages").delete().eq("parent_id", targetDbId);
+  await admin
+    .from("database_views")
+    .delete()
+    .eq("database_id", targetDbId);
+  await admin
+    .from("database_properties")
+    .delete()
+    .eq("database_id", targetDbId);
+  await admin.from("pages").delete().eq("id", targetDbId);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function navigateToSourceDatabase(
+  page: import("@playwright/test").Page,
+) {
+  await page.goto(`/${workspaceSlug}/${sourceDbId}`);
+  await expect(page.locator('[role="grid"]')).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Open the relation editor by clicking the relation cell.
+ * Returns the search input locator (visible when editor is open).
+ */
+async function openRelationEditor(page: import("@playwright/test").Page) {
+  const relationCell = page
+    .locator('[role="gridcell"][data-col]')
+    .first();
+  await expect(relationCell).toBeVisible({ timeout: 10_000 });
+  await relationCell.click();
+
+  const searchInput = page.locator('input[placeholder="Search pages…"]');
+  await expect(searchInput).toBeVisible({ timeout: 5_000 });
+  return searchInput;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Relation property type", () => {
+  test("select a related row via the relation picker and verify selection persists", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToSourceDatabase(page);
+
+    // Open the relation editor
+    await openRelationEditor(page);
+
+    // "Alpha Item" should already be selected (pre-populated).
+    // Verify the "Remove" label indicates it's selected.
+    const removeAlpha = page.locator(
+      'button[aria-label="Remove Alpha Item"]',
+    );
+    await expect(removeAlpha).toBeVisible({ timeout: 10_000 });
+
+    // Select "Beta Item" — this triggers onChange which closes the editor
+    const betaOption = page.locator(
+      'button[aria-label="Add Beta Item"]',
+    );
+    await expect(betaOption).toBeVisible({ timeout: 5_000 });
+    await betaOption.click();
+
+    // The editor closes immediately after selection. Wait for it to close.
+    const searchInput = page.locator('input[placeholder="Search pages…"]');
+    await expect(searchInput).not.toBeVisible({ timeout: 5_000 });
+
+    // Re-open the editor to verify both selections persisted
+    await openRelationEditor(page);
+
+    // Both should now have "Remove" labels
+    await expect(
+      page.locator('button[aria-label="Remove Alpha Item"]'),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.locator('button[aria-label="Remove Beta Item"]'),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Close the editor
+    await page.keyboard.press("Escape");
+  });
+
+  test("relation pill renders on the row detail page and navigates on click", async ({
+    authenticatedPage: page,
+  }) => {
+    // Navigate directly to the source row detail page
+    await page.goto(`/${workspaceSlug}/${sourceRowId}`);
+
+    // Wait for the row detail page to load — the properties header should appear
+    const linkedItemsLabel = page.locator("text=Linked Items").first();
+    await expect(linkedItemsLabel).toBeVisible({ timeout: 15_000 });
+
+    // The RelationRenderer renders pills as buttons with aria-label.
+    // Wait for the pill to appear (async page resolution).
+    const pill = page.locator(
+      'button[aria-label="Navigate to Alpha Item"]',
+    );
+    await expect(pill).toBeVisible({ timeout: 15_000 });
+
+    // Click the pill to navigate to the target row
+    await pill.click();
+
+    // Should navigate to the target row page
+    await page.waitForURL(
+      (url) => url.pathname.includes(targetRowId1),
+      { timeout: 15_000 },
+    );
+
+    // The page should show "Alpha Item"
+    await expect(
+      page.locator("text=Alpha Item").first(),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("relation picker search filters target rows", async ({
+    authenticatedPage: page,
+  }) => {
+    await navigateToSourceDatabase(page);
+
+    // Open the relation editor
+    const searchInput = await openRelationEditor(page);
+
+    // Both rows should be visible initially — use the editor's container
+    const editorContainer = page.locator(".w-56").first();
+    await expect(
+      editorContainer.locator("button", { hasText: "Alpha Item" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      editorContainer.locator("button", { hasText: "Beta Item" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Type "Beta" to filter
+    await searchInput.fill("Beta");
+
+    // Only "Beta Item" should be visible in the editor
+    await expect(
+      editorContainer.locator("button", { hasText: "Beta Item" }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      editorContainer.locator("button", { hasText: "Alpha Item" }),
+    ).not.toBeVisible({ timeout: 3_000 });
+
+    // Clear the search
+    await searchInput.fill("");
+
+    // Both should be visible again
+    await expect(
+      editorContainer.locator("button", { hasText: "Alpha Item" }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      editorContainer.locator("button", { hasText: "Beta Item" }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Close the editor
+    await page.keyboard.press("Escape");
+  });
+});


### PR DESCRIPTION
Closes #724

## What

Adds dedicated E2E test suites for the three most complex database property types that previously lacked browser-level test coverage: **formula**, **files**, and **relation**.

## How

### `e2e/database-formula.spec.ts` (3 tests)
- Sets up a database with number, text, and formula columns via admin client
- Verifies computed formula value displays correctly (`prop("Price") * 2` → 100)
- Verifies formula recalculates when the referenced property value changes (50→75 → 150)
- Verifies invalid formula expressions render the error state (`span.text-destructive`)

### `e2e/database-files.spec.ts` (4 tests)
- Pre-populates a file value via admin client + Supabase Storage upload
- Verifies file thumbnail renders on the row detail page (via `FilesRenderer`)
- Verifies the files editor shows existing files with remove buttons when the cell is clicked
- Verifies file removal persists after closing and re-opening the editor
- Verifies file upload via `page.waitForEvent("filechooser")` + `fileChooser.setFiles()`

### `e2e/database-relation.spec.ts` (3 tests)
- Creates two databases with a relation property linking them, pre-populates a relation value
- Verifies selecting a new related row persists after closing and re-opening the editor
- Verifies relation pill renders on the row detail page and navigates to the target row on click
- Verifies the relation picker search input filters target rows

## Testing

All 10 new E2E tests pass locally:
```
pnpm lint && pnpm typecheck && pnpm test && pnpm test:e2e
```

## Notes

- Tests use `aria-label` and `role` attributes for selectors rather than `data-testid` since the existing components don't have `data-testid` attributes yet (tracked in #700).
- The files and relation editors close immediately after `onChange` fires (the `RegistryEditorCell` calls `onBlur` → `stopEditing` on every value change). Tests account for this by re-opening the editor to verify persistence.
- Discovered a pre-existing hydration warning: `RelationRenderer` renders a `<button>` pill inside a `<button>` wrapper on the row detail page. Not addressed in this PR.