### PR TITLE
feat: add Sentry error capture to database properties and views hooks (#731)

### DIFF
--- a/src/components/database/hooks/use-database-properties.test.ts
+++ b/src/components/database/hooks/use-database-properties.test.ts
@@ -12,6 +12,8 @@ const reorderPropertiesMock = vi.fn();
 const loadDatabaseMock = vi.fn();
 const updateViewMock = vi.fn();
 const toastErrorMock = vi.fn();
+const captureSupabaseErrorMock = vi.fn();
+const isInsufficientPrivilegeErrorMock = vi.fn((_error: unknown) => false);
 
 vi.mock("@/lib/database", () => ({
   addProperty: (...args: unknown[]) => addPropertyMock(...args),
@@ -35,6 +37,11 @@ vi.mock("sonner", () => ({
   toast: {
     error: (...args: unknown[]) => toastErrorMock(...args),
   },
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: (error: unknown, operation: unknown) => captureSupabaseErrorMock(error, operation),
+  isInsufficientPrivilegeError: (error: unknown) => isInsufficientPrivilegeErrorMock(error),
 }));
 
 // ---------------------------------------------------------------------------
@@ -203,10 +210,11 @@ describe("useDatabaseProperties", () => {
       );
     });
 
-    it("shows toast on error", async () => {
+    it("shows toast and captures Sentry error on failure", async () => {
+      const error = new Error("failed");
       addPropertyMock.mockResolvedValue({
         data: null,
-        error: new Error("failed"),
+        error,
       });
 
       const { result, setProperties } = setup();
@@ -218,7 +226,28 @@ describe("useDatabaseProperties", () => {
       expect(toastErrorMock).toHaveBeenCalledWith("Failed to add column", {
         duration: 8000,
       });
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-properties:add");
       expect(setProperties).not.toHaveBeenCalled();
+    });
+
+    it("skips Sentry capture for insufficient privilege errors", async () => {
+      const error = new Error("violates row-level security policy");
+      isInsufficientPrivilegeErrorMock.mockReturnValueOnce(true);
+      addPropertyMock.mockResolvedValue({
+        data: null,
+        error,
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleAddColumn("text");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add column", {
+        duration: 8000,
+      });
+      expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
     });
 
     it("guards against concurrent calls", async () => {
@@ -293,10 +322,11 @@ describe("useDatabaseProperties", () => {
       );
     });
 
-    it("reverts on rename failure", async () => {
+    it("reverts on rename failure and captures Sentry error", async () => {
+      const error = new Error("rename failed");
       updatePropertyMock.mockResolvedValue({
         data: null,
-        error: new Error("rename failed"),
+        error,
       });
 
       const { result, setProperties } = setup();
@@ -313,6 +343,7 @@ describe("useDatabaseProperties", () => {
         "Failed to rename property",
         { duration: 8000 },
       );
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-properties:rename");
       // Revert call: second setProperties call restores old name
       expect(setProperties).toHaveBeenCalledTimes(2);
       const revertUpdater = setProperties.mock.calls[1][0];
@@ -321,6 +352,27 @@ describe("useDatabaseProperties", () => {
         makeProp("prop-1", "New Name", 1, "select"),
       ]);
       expect(reverted[1].name).toBe("Status");
+    });
+
+    it("skips Sentry capture for insufficient privilege on rename", async () => {
+      isInsufficientPrivilegeErrorMock.mockReturnValueOnce(true);
+      updatePropertyMock.mockResolvedValue({
+        data: null,
+        error: new Error("42501"),
+      });
+
+      const { result } = setup();
+
+      act(() => {
+        result.current.handleColumnHeaderClick("prop-1");
+      });
+
+      await act(async () => {
+        await result.current.handlePropertyRename("New Name");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalled();
+      expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
     });
 
     it("does nothing when no property is being renamed", async () => {
@@ -382,9 +434,10 @@ describe("useDatabaseProperties", () => {
       ]);
     });
 
-    it("reverts on reorder failure", async () => {
+    it("reverts on reorder failure and captures Sentry error", async () => {
+      const error = new Error("reorder failed");
       reorderPropertiesMock.mockResolvedValue({
-        error: new Error("reorder failed"),
+        error,
       });
 
       const props = [makeProp("p-a", "A", 0), makeProp("p-b", "B", 1)];
@@ -398,6 +451,7 @@ describe("useDatabaseProperties", () => {
         "Failed to reorder columns",
         { duration: 8000 },
       );
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-properties:reorder");
       // Revert: second setProperties call restores original
       expect(setProperties).toHaveBeenCalledTimes(2);
       const revertValue = setProperties.mock.calls[1][0];
@@ -485,9 +539,10 @@ describe("useDatabaseProperties", () => {
       expect(result.current.deletingProperty).toBeNull();
     });
 
-    it("reverts on delete failure", async () => {
+    it("reverts on delete failure and captures Sentry error", async () => {
+      const error = new Error("delete failed");
       deletePropertyMock.mockResolvedValue({
-        error: new Error("delete failed"),
+        error,
       });
       loadDatabaseMock.mockResolvedValue({
         data: { rows: [makeRow("row-1")] },
@@ -516,6 +571,7 @@ describe("useDatabaseProperties", () => {
         "Failed to delete property",
         { duration: 8000 },
       );
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-properties:delete");
       // Properties and views reverted
       const revertProps = setProperties.mock.calls[1][0];
       expect(revertProps).toEqual(props);

--- a/src/components/database/hooks/use-database-properties.ts
+++ b/src/components/database/hooks/use-database-properties.ts
@@ -12,6 +12,10 @@ import {
   generateColumnName,
   getDefaultColumnConfig,
 } from "@/lib/column-helpers";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+} from "@/lib/sentry";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -87,6 +91,9 @@ export function useDatabaseProperties({
         const config = getDefaultColumnConfig(type);
         const { data: newProp, error } = await addProperty(pageId, name, type, config);
         if (error || !newProp) {
+          if (error && !isInsufficientPrivilegeError(error)) {
+            captureSupabaseError(error, "database-properties:add");
+          }
           toast.error("Failed to add column", { duration: 8000 });
           return;
         }
@@ -120,6 +127,9 @@ export function useDatabaseProperties({
 
       const { error } = await updateProperty(propertyId, { name: newName }, pageId);
       if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-properties:rename");
+        }
         toast.error("Failed to rename property", { duration: 8000 });
         // Revert
         setProperties((prev) =>
@@ -146,6 +156,9 @@ export function useDatabaseProperties({
 
       const { error } = await reorderProperties(pageId, orderedPropertyIds);
       if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-properties:reorder");
+        }
         toast.error("Failed to reorder columns", { duration: 8000 });
         setProperties(prevProperties);
       }
@@ -200,6 +213,9 @@ export function useDatabaseProperties({
 
     const { error } = await deleteProperty(propertyId, pageId);
     if (error) {
+      if (!isInsufficientPrivilegeError(error)) {
+        captureSupabaseError(error, "database-properties:delete");
+      }
       toast.error("Failed to delete property", { duration: 8000 });
       // Revert
       setProperties(prevProperties);

--- a/src/components/database/hooks/use-database-views.test.ts
+++ b/src/components/database/hooks/use-database-views.test.ts
@@ -12,6 +12,8 @@ const reorderViewsMock = vi.fn();
 const loadDatabaseMock = vi.fn();
 const toastErrorMock = vi.fn();
 const replaceStateMock = vi.fn();
+const captureSupabaseErrorMock = vi.fn();
+const isInsufficientPrivilegeErrorMock = vi.fn((_error: unknown) => false);
 
 // Track the current search params value so the mock returns it
 let currentSearchParams = new URLSearchParams();
@@ -28,6 +30,11 @@ vi.mock("sonner", () => ({
   toast: {
     error: (...args: unknown[]) => toastErrorMock(...args),
   },
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: (error: unknown, operation: unknown) => captureSupabaseErrorMock(error, operation),
+  isInsufficientPrivilegeError: (error: unknown) => isInsufficientPrivilegeErrorMock(error),
 }));
 
 vi.mock("@/components/database/view-tabs", () => ({
@@ -296,10 +303,11 @@ describe("useDatabaseViews", () => {
       );
     });
 
-    it("shows toast on error", async () => {
+    it("shows toast and captures Sentry error on failure", async () => {
+      const error = new Error("failed");
       addViewMock.mockResolvedValue({
         data: null,
-        error: new Error("failed"),
+        error,
       });
 
       const { result, setViews } = setup();
@@ -311,7 +319,26 @@ describe("useDatabaseViews", () => {
       expect(toastErrorMock).toHaveBeenCalledWith("Failed to create view", {
         duration: 8000,
       });
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:create");
       expect(setViews).not.toHaveBeenCalled();
+    });
+
+    it("skips Sentry capture for insufficient privilege on create", async () => {
+      const error = new Error("violates row-level security policy");
+      isInsufficientPrivilegeErrorMock.mockReturnValueOnce(true);
+      addViewMock.mockResolvedValue({
+        data: null,
+        error,
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleAddView("table");
+      });
+
+      expect(toastErrorMock).toHaveBeenCalled();
+      expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
     });
   });
 
@@ -348,10 +375,11 @@ describe("useDatabaseViews", () => {
       );
     });
 
-    it("reverts on failure", async () => {
+    it("reverts on failure and captures Sentry error", async () => {
+      const error = new Error("failed");
       updateViewMock.mockResolvedValue({
         data: null,
-        error: new Error("failed"),
+        error,
       });
 
       const views = [
@@ -369,6 +397,7 @@ describe("useDatabaseViews", () => {
         "Failed to update view configuration",
         { duration: 8000 },
       );
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:update-config");
       // Revert: second setViews call restores original config
       expect(setViews).toHaveBeenCalledTimes(2);
       const revertUpdater = setViews.mock.calls[1][0];
@@ -414,10 +443,11 @@ describe("useDatabaseViews", () => {
       expect(updated[0].name).toBe("New Name");
     });
 
-    it("shows toast on failure", async () => {
+    it("shows toast and captures Sentry error on failure", async () => {
+      const error = new Error("rename failed");
       updateViewMock.mockResolvedValue({
         data: null,
-        error: new Error("rename failed"),
+        error,
       });
 
       const { result, setViews } = setup();
@@ -429,6 +459,7 @@ describe("useDatabaseViews", () => {
       expect(toastErrorMock).toHaveBeenCalledWith("Failed to rename view", {
         duration: 8000,
       });
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:rename");
       expect(setViews).not.toHaveBeenCalled();
     });
   });
@@ -460,9 +491,10 @@ describe("useDatabaseViews", () => {
       expect(replaceStateMock).toHaveBeenCalled();
     });
 
-    it("shows toast with error message on failure", async () => {
+    it("shows toast with error message and captures Sentry error on failure", async () => {
+      const error = { message: "Cannot delete last view" };
       deleteViewMock.mockResolvedValue({
-        error: { message: "Cannot delete last view" },
+        error,
       });
 
       const { result, setViews } = setup();
@@ -475,6 +507,7 @@ describe("useDatabaseViews", () => {
         "Cannot delete last view",
         { duration: 8000 },
       );
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:delete");
       expect(setViews).not.toHaveBeenCalled();
     });
 
@@ -549,10 +582,11 @@ describe("useDatabaseViews", () => {
       expect(addViewMock).not.toHaveBeenCalled();
     });
 
-    it("shows toast on failure", async () => {
+    it("shows toast and captures Sentry error on failure", async () => {
+      const error = new Error("failed");
       addViewMock.mockResolvedValue({
         data: null,
-        error: new Error("failed"),
+        error,
       });
 
       const { result, setViews } = setup();
@@ -565,6 +599,7 @@ describe("useDatabaseViews", () => {
         "Failed to duplicate view",
         { duration: 8000 },
       );
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:duplicate");
       expect(setViews).not.toHaveBeenCalled();
     });
   });
@@ -606,9 +641,10 @@ describe("useDatabaseViews", () => {
       ]);
     });
 
-    it("reloads on reorder failure", async () => {
+    it("reloads on reorder failure and captures Sentry error", async () => {
+      const error = new Error("reorder failed");
       reorderViewsMock.mockResolvedValue({
-        error: new Error("reorder failed"),
+        error,
       });
       loadDatabaseMock.mockResolvedValue({
         data: {
@@ -634,6 +670,7 @@ describe("useDatabaseViews", () => {
         "Failed to reorder views",
         { duration: 8000 },
       );
+      expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:reorder");
       expect(loadDatabaseMock).toHaveBeenCalledWith("db-1");
       // setViews called with reloaded data
       const lastCall = setViews.mock.calls[setViews.mock.calls.length - 1][0];

--- a/src/components/database/hooks/use-database-views.ts
+++ b/src/components/database/hooks/use-database-views.ts
@@ -9,6 +9,10 @@ import {
   reorderViews,
   updateView,
 } from "@/lib/database";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+} from "@/lib/sentry";
 import type {
   DatabaseProperty,
   DatabaseView,
@@ -97,6 +101,9 @@ export function useDatabaseViews({
 
       const { data: newView, error } = await addView(pageId, name, type, config);
       if (error || !newView) {
+        if (error && !isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-views:create");
+        }
         toast.error("Failed to create view", { duration: 8000 });
         return;
       }
@@ -124,6 +131,9 @@ export function useDatabaseViews({
 
       const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
       if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-views:update-config");
+        }
         toast.error("Failed to update view configuration", { duration: 8000 });
         // Revert
         setViews((prev) =>
@@ -143,6 +153,9 @@ export function useDatabaseViews({
         name: newName,
       }, pageId);
       if (error || !updated) {
+        if (error && !isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-views:rename");
+        }
         toast.error("Failed to rename view", { duration: 8000 });
         return;
       }
@@ -158,6 +171,9 @@ export function useDatabaseViews({
     async (viewId: string) => {
       const { error } = await deleteView(viewId, pageId);
       if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-views:delete");
+        }
         toast.error(error.message || "Failed to delete view", {
           duration: 8000,
         });
@@ -192,6 +208,9 @@ export function useDatabaseViews({
         { ...source.config },
       );
       if (error || !newView) {
+        if (error && !isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-views:duplicate");
+        }
         toast.error("Failed to duplicate view", { duration: 8000 });
         return;
       }
@@ -220,6 +239,9 @@ export function useDatabaseViews({
 
       const { error } = await reorderViews(pageId, orderedIds);
       if (error) {
+        if (!isInsufficientPrivilegeError(error)) {
+          captureSupabaseError(error, "database-views:reorder");
+        }
         toast.error("Failed to reorder views", { duration: 8000 });
         // Reload to restore correct order
         const { data } = await loadDatabase(pageId);


### PR DESCRIPTION
Closes #731

## What

Adds `captureSupabaseError` calls to all mutation failure paths in `use-database-properties.ts` and `use-database-views.ts`, matching the existing pattern in `use-database-rows.ts`. This closes an observability blind spot where property and view mutations could fail in production without any Sentry signal.

## How

- Imported `captureSupabaseError` and `isInsufficientPrivilegeError` from `@/lib/sentry` in both hooks.
- Added Sentry capture at every mutation error site:
  - **Properties hook**: `add`, `rename`, `reorder`, `delete` — 4 operations
  - **Views hook**: `create`, `update-config`, `rename`, `delete`, `duplicate`, `reorder` — 6 operations
- Each site filters out `isInsufficientPrivilegeError` before capturing (RLS violations are expected for non-members).
- Context strings follow the `"database-properties:<op>"` / `"database-views:<op>"` convention.

## Testing

- Updated `use-database-properties.test.ts`: existing error tests now verify `captureSupabaseError` is called with the correct error and operation string. Added a dedicated test for insufficient privilege filtering on add and rename.
- Updated `use-database-views.test.ts`: existing error tests now verify `captureSupabaseError` is called for create, update-config, rename, delete, duplicate, and reorder failures. Added a dedicated test for insufficient privilege filtering on create.
- `pnpm lint && pnpm typecheck && pnpm test` — all 102 test files, 1288 tests pass.