### PR TITLE
feat: require Feature Builder and Bug Fixer to update quality.md test counts (#742)

### DIFF
--- a/.ona/automations/bug-fixer.yaml
+++ b/.ona/automations/bug-fixer.yaml
@@ -156,6 +156,39 @@ action:
                 Include the update in the same commit as the fix. Do NOT update speculatively —
                 only when the bug directly reveals a gap in the conventions.
 
+                ## Update Quality Test Counts
+
+                After all tests pass, update `.agents/quality.md` so test counts stay current.
+
+                1. **Count tests from runner output:**
+                   ```
+                   VITEST_TOTAL=$(pnpm test 2>&1 | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
+                   VITEST_FILES=$(pnpm test 2>&1 | grep -oP 'Test Files\s+\K\d+(?=\s+passed)' | tail -1)
+                   E2E_TOTAL=$(pnpm test:e2e 2>&1 | grep -oP '\d+(?=\s+passed)' | tail -1)
+                   E2E_FILES=$(ls e2e/*.spec.ts | wc -l)
+                   ```
+                   If the counts differ from what is in quality.md, update them.
+
+                2. **Update the Test Coverage Summary table** in quality.md with the new totals:
+                   - Unit/Integration (Vitest): files and tests from Vitest output
+                   - E2E (Playwright): files and tests from Playwright output
+                   - Total: sum of both
+
+                3. **Update the affected domain's row** in the "Current Grades" table:
+                   - If you added new test files, update the test count in the domain's Notes column.
+                   - If existing test files grew (more tests added), update those counts too.
+                   - Only update the domain(s) your bug fix touched — do not rewrite the entire table.
+
+                4. **Update the "Test files by domain" section:**
+                   - If you added new test files, add them to the appropriate domain's bullet list.
+                   - If existing test files have new test counts, update the count in parentheses.
+                   - Only update entries for files you added or modified.
+
+                5. **Add a History entry** at the bottom of the History table:
+                   `| <today's date> | <brief description of what changed: new files added, counts updated> |`
+
+                Include these quality.md changes in the same commit as the fix.
+
                 ## PR Creation
 
                 1. Commit with conventional commit message: `fix: <description> (#<issue-number>)`

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -194,6 +194,39 @@ action:
                 Do NOT update speculatively. Only update when the implementation introduced something
                 concrete and new. Most features will not require knowledge base updates.
 
+                ## Update Quality Test Counts
+
+                After all tests pass, update `.agents/quality.md` so test counts stay current.
+
+                1. **Count tests from runner output:**
+                   ```
+                   VITEST_TOTAL=$(pnpm test 2>&1 | grep -oP 'Tests\s+\K\d+(?=\s+passed)' | tail -1)
+                   VITEST_FILES=$(pnpm test 2>&1 | grep -oP 'Test Files\s+\K\d+(?=\s+passed)' | tail -1)
+                   E2E_TOTAL=$(pnpm test:e2e 2>&1 | grep -oP '\d+(?=\s+passed)' | tail -1)
+                   E2E_FILES=$(ls e2e/*.spec.ts | wc -l)
+                   ```
+                   If the counts differ from what is in quality.md, update them.
+
+                2. **Update the Test Coverage Summary table** in quality.md with the new totals:
+                   - Unit/Integration (Vitest): files and tests from Vitest output
+                   - E2E (Playwright): files and tests from Playwright output
+                   - Total: sum of both
+
+                3. **Update the affected domain's row** in the "Current Grades" table:
+                   - If you added new test files, update the test count in the domain's Notes column.
+                   - If existing test files grew (more tests added), update those counts too.
+                   - Only update the domain(s) your feature touched — do not rewrite the entire table.
+
+                4. **Update the "Test files by domain" section:**
+                   - If you added new test files, add them to the appropriate domain's bullet list.
+                   - If existing test files have new test counts, update the count in parentheses.
+                   - Only update entries for files you added or modified.
+
+                5. **Add a History entry** at the bottom of the History table:
+                   `| <today's date> | <brief description of what changed: new files added, counts updated> |`
+
+                Include these quality.md changes in the same commit as the feature.
+
                 ## PR Creation
 
                 1. Commit with conventional commit message: `feat: <description> (#<issue-number>)`


### PR DESCRIPTION
Closes #742

## What

Adds a "Update Quality Test Counts" step to both the Feature Builder and Bug Fixer automation prompts. This eliminates the recurring drift-then-fix cycle where quality.md test counts go stale after every feature or bug fix PR, requiring separate chore issues to update them.

## How

Added a new `## Update Quality Test Counts` section to both `.ona/automations/feature-builder.yaml` and `.ona/automations/bug-fixer.yaml`, placed after the "Update Knowledge Base" section and before "PR Creation". The step instructs the automation to:

1. Extract test counts from `pnpm test` and `pnpm test:e2e` output
2. Update the Test Coverage Summary table totals
3. Update only the affected domain's row in the Current Grades table
4. Update the test files by domain list for new/modified test files
5. Add a History entry

The step is incremental — it only touches the domain(s) affected by the current PR, not a full rewrite.

## Testing

- `pnpm lint` — 0 errors (39 pre-existing warnings)
- `pnpm typecheck` — passes
- `pnpm test` — 104 files, 1359 tests passed
- No code changes, only YAML automation prompt updates — no E2E or Storybook verification needed