### PR TITLE
fix: show error state when database view fails to load (#745)

### DIFF
--- a/src/components/database/database-view-client.stories.tsx
+++ b/src/components/database/database-view-client.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
+import { AlertCircle } from "lucide-react";
 import { ViewTabs } from "./view-tabs";
+import { Button } from "@/components/ui/button";
 import type { DatabaseView } from "@/lib/types";
 
 // DatabaseViewClient depends on next/navigation, Supabase, and dynamic imports.
@@ -117,6 +119,29 @@ export const ComingSoonView: Story = {
         />
         <div className="flex h-48 items-center justify-center text-sm text-muted-foreground">
           Board view coming soon
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const ErrorState: Story = {
+  render: () => (
+    <div className="mx-auto max-w-3xl space-y-4">
+      <div>
+        <span className="text-3xl">📊</span>
+        <h1 className="mt-1 text-3xl font-bold text-foreground">
+          Project Tracker
+        </h1>
+      </div>
+      <div className="flex min-h-[40vh] flex-col items-center justify-center p-6">
+        <div className="flex flex-col items-center gap-4 text-center">
+          <AlertCircle className="h-12 w-12 text-muted-foreground" />
+          <h2 className="text-lg font-medium">Something went wrong</h2>
+          <p className="max-w-sm text-sm text-muted-foreground">
+            Failed to load database. Please check your connection and try again.
+          </p>
+          <Button onClick={fn()}>Try again</Button>
         </div>
       </div>
     </div>

--- a/src/components/database/database-view-client.test.tsx
+++ b/src/components/database/database-view-client.test.tsx
@@ -1,0 +1,284 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const loadDatabaseMock = vi.fn();
+const loadWorkspaceMembersMock = vi.fn();
+const captureSupabaseErrorMock = vi.fn();
+
+vi.mock("@/lib/database", () => ({
+  loadDatabase: (...args: unknown[]) => loadDatabaseMock(...args),
+  loadWorkspaceMembers: (...args: unknown[]) => loadWorkspaceMembersMock(...args),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: (...args: unknown[]) => captureSupabaseErrorMock(...args),
+  isInsufficientPrivilegeError: () => false,
+}));
+
+vi.mock("@/lib/capture", () => ({
+  lazyCaptureException: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+// Mock next/dynamic to render children synchronously
+vi.mock("next/dynamic", () => ({
+  default: () => {
+    function DynamicStub() {
+      return null;
+    }
+    return DynamicStub;
+  },
+}));
+
+vi.mock("@/components/page-title", () => ({
+  PageTitle: () => <div data-testid="page-title" />,
+}));
+
+vi.mock("@/components/page-icon", () => ({
+  PageIcon: () => <div data-testid="page-icon" />,
+}));
+
+vi.mock("@/components/page-cover", () => ({
+  PageCover: () => <div data-testid="page-cover" />,
+}));
+
+vi.mock("@/components/database/view-tabs", () => ({
+  ViewTabs: () => <div data-testid="view-tabs" />,
+  VIEW_TYPE_LABELS: {
+    table: "Table",
+    board: "Board",
+    list: "List",
+    calendar: "Calendar",
+    gallery: "Gallery",
+  },
+}));
+
+vi.mock("@/components/database/sort-menu", () => ({
+  SortMenu: () => null,
+}));
+
+vi.mock("@/components/database/filter-bar", () => ({
+  FilterBar: () => null,
+}));
+
+vi.mock("@/components/database/rename-property-dialog", () => ({
+  RenamePropertyDialog: () => null,
+}));
+
+vi.mock("@/components/database/database-view-helpers", () => ({
+  ViewConfigDropdown: () => null,
+  ComingSoonPlaceholder: () => null,
+  DatabaseSkeleton: () => <div data-testid="database-skeleton">Loading...</div>,
+}));
+
+vi.mock("@/components/database/csv-export-button", () => ({
+  CSVExportButton: () => null,
+}));
+
+vi.mock("@/components/database/hooks/use-database-views", () => ({
+  useDatabaseViews: () => ({
+    activeViewId: "view-1",
+    activeView: { id: "view-1", type: "table", config: {}, name: "Default", position: 0, database_id: "db-1", created_at: "", updated_at: "" },
+    handleViewChange: vi.fn(),
+    handleAddView: vi.fn(),
+    handleViewConfigChange: vi.fn(),
+    handleRenameView: vi.fn(),
+    handleDeleteView: vi.fn(),
+    handleDuplicateView: vi.fn(),
+    handleReorderViews: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/database/hooks/use-database-rows", () => ({
+  useDatabaseRows: () => ({
+    handleAddRow: vi.fn(),
+    handleCardMove: vi.fn(),
+    handleCellUpdate: vi.fn(),
+    handleDeleteRow: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/database/hooks/use-database-properties", () => ({
+  useDatabaseProperties: () => ({
+    renameDialogOpen: false,
+    setRenameDialogOpen: vi.fn(),
+    renamingProperty: null,
+    handleAddColumn: vi.fn(),
+    handleColumnHeaderClick: vi.fn(),
+    handlePropertyRename: vi.fn(),
+    handleColumnReorder: vi.fn(),
+    handleDeleteColumn: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/database/hooks/use-database-filters", () => ({
+  useDatabaseFilters: () => ({
+    activeSorts: [],
+    activeFilters: [],
+    displayedRows: [],
+    handleSortsChange: vi.fn(),
+    handleFiltersChange: vi.fn(),
+    handleSortToggle: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { DatabaseViewClient } from "./database-view-client";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const defaultProps = {
+  pageId: "page-1",
+  pageTitle: "Test Database",
+  pageIcon: null,
+  pageCoverUrl: null,
+  initialContent: null,
+  workspaceId: "ws-1",
+  workspaceSlug: "test-workspace",
+  userId: "user-1",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DatabaseViewClient error state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadWorkspaceMembersMock.mockResolvedValue({ data: [], error: null });
+  });
+
+  it("renders error state when loadDatabase returns an error", async () => {
+    const dbError = Object.assign(new Error("relation not found"), {
+      code: "PGRST205",
+      details: "",
+      hint: "",
+    });
+    loadDatabaseMock.mockResolvedValue({ data: null, error: dbError });
+
+    await act(async () => {
+      render(<DatabaseViewClient {...defaultProps} />);
+    });
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText("Failed to load database. Please check your connection and try again."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("reports the error to Sentry via captureSupabaseError", async () => {
+    const dbError = Object.assign(new Error("network error"), {
+      code: "PGRST000",
+      details: "",
+      hint: "",
+    });
+    loadDatabaseMock.mockResolvedValue({ data: null, error: dbError });
+
+    await act(async () => {
+      render(<DatabaseViewClient {...defaultProps} />);
+    });
+
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      dbError,
+      "database-view-client.load",
+    );
+  });
+
+  it("renders error state when loadDatabase returns null data without error", async () => {
+    loadDatabaseMock.mockResolvedValue({ data: null, error: null });
+
+    await act(async () => {
+      render(<DatabaseViewClient {...defaultProps} />);
+    });
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("retries loading when 'Try again' is clicked", async () => {
+    const user = userEvent.setup();
+    const dbError = Object.assign(new Error("timeout"), {
+      code: "57014",
+      details: "",
+      hint: "",
+    });
+
+    // First call fails, second succeeds
+    loadDatabaseMock
+      .mockResolvedValueOnce({ data: null, error: dbError })
+      .mockResolvedValueOnce({
+        data: { properties: [], views: [], rows: [] },
+        error: null,
+      });
+
+    await act(async () => {
+      render(<DatabaseViewClient {...defaultProps} />);
+    });
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Try again" }));
+    });
+
+    // After retry succeeds, error state should be gone
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+  });
+
+  it("does not show error state when initialData is provided", async () => {
+    const propsWithData = {
+      ...defaultProps,
+      initialData: {
+        properties: [],
+        views: [],
+        rows: [],
+      },
+    };
+
+    await act(async () => {
+      render(<DatabaseViewClient {...propsWithData} />);
+    });
+
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+    expect(loadDatabaseMock).not.toHaveBeenCalled();
+  });
+
+  it("shows loading skeleton before error state", async () => {
+    let resolveLoad: (value: unknown) => void;
+    const loadPromise = new Promise((resolve) => {
+      resolveLoad = resolve;
+    });
+    loadDatabaseMock.mockReturnValue(loadPromise);
+
+    await act(async () => {
+      render(<DatabaseViewClient {...defaultProps} />);
+    });
+
+    // Should show skeleton while loading
+    expect(screen.getByTestId("database-skeleton")).toBeInTheDocument();
+
+    // Resolve with error
+    await act(async () => {
+      resolveLoad!({ data: null, error: new Error("fail") });
+    });
+
+    // Should now show error state
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.queryByTestId("database-skeleton")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import type { SerializedEditorState } from "lexical";
+import { AlertCircle } from "lucide-react";
 import { PageTitle } from "@/components/page-title";
 import { PageIcon } from "@/components/page-icon";
 import { PageCover } from "@/components/page-cover";
@@ -17,7 +18,12 @@ import {
   DatabaseSkeleton,
 } from "@/components/database/database-view-helpers";
 import { CSVExportButton } from "@/components/database/csv-export-button";
+import { Button } from "@/components/ui/button";
 import { loadDatabase, loadWorkspaceMembers } from "@/lib/database";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+} from "@/lib/sentry";
 import { useDatabaseViews } from "@/components/database/hooks/use-database-views";
 import { useDatabaseRows } from "@/components/database/hooks/use-database-rows";
 import { useDatabaseProperties } from "@/components/database/hooks/use-database-properties";
@@ -121,10 +127,15 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
   );
   const [rows, setRows] = useState<DatabaseRow[]>(initialData?.rows ?? []);
   const [loading, setLoading] = useState(!hasInitialData);
+  const [error, setError] = useState<string | null>(null);
+
+  // Incrementing this counter re-triggers the load effect (used by "Try again")
+  const [retryCount, setRetryCount] = useState(0);
 
   // Load database data and workspace members on mount (skipped when
   // server-prefetched initialData is provided — eliminates the second
-  // skeleton flash during database page navigation, #682)
+  // skeleton flash during database page navigation, #682).
+  // Bumping retryCount re-runs this effect for the "Try again" button.
   useEffect(() => {
     if (hasInitialData) return;
 
@@ -132,6 +143,8 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
 
     async function load() {
       setLoading(true);
+      setError(null);
+
       const [dbResult, membersResult] = await Promise.all([
         loadDatabase(pageId),
         loadWorkspaceMembers(workspaceId),
@@ -139,6 +152,12 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       if (cancelled) return;
 
       if (dbResult.error || !dbResult.data) {
+        if (dbResult.error && !isInsufficientPrivilegeError(dbResult.error)) {
+          // loadDatabase already reports individual query errors to Sentry;
+          // this catches any error shape that slipped through without a report.
+          captureSupabaseError(dbResult.error, "database-view-client.load");
+        }
+        setError("Failed to load database. Please check your connection and try again.");
         setLoading(false);
         return;
       }
@@ -156,6 +175,7 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       setProperties(enrichedProperties);
       setViews(dbResult.data.views);
       setRows(dbResult.data.rows);
+      setError(null);
       setLoading(false);
     }
 
@@ -163,7 +183,12 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
     return () => {
       cancelled = true;
     };
-  }, [pageId, workspaceId, hasInitialData]);
+  }, [pageId, workspaceId, hasInitialData, retryCount]);
+
+  // Retry handler for the error state "Try again" button
+  const handleRetry = useCallback(() => {
+    setRetryCount((c) => c + 1);
+  }, []);
 
   // --- Hooks ---
 
@@ -256,6 +281,17 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       <div className="mt-6">
         {loading ? (
           <DatabaseSkeleton />
+        ) : error ? (
+          <div className="flex min-h-[40vh] flex-col items-center justify-center p-6">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <AlertCircle className="h-12 w-12 text-muted-foreground" />
+              <h2 className="text-lg font-medium">Something went wrong</h2>
+              <p className="max-w-sm text-sm text-muted-foreground">
+                {error}
+              </p>
+              <Button onClick={handleRetry}>Try again</Button>
+            </div>
+          </div>
         ) : (
           <>
             {views.length > 0 && (


### PR DESCRIPTION
Closes #745

## What

When `loadDatabase` fails (network error, RLS violation, deleted database), the `DatabaseViewClient` component silently sets `loading=false` and renders an empty database view with no error message, no retry option, and no indication that something went wrong.

## How

Added an `error` state variable alongside `loading`. When `loadDatabase` returns an error or null data, the component now:
- Sets a user-facing error message
- Reports the error to Sentry via `captureSupabaseError` (with `isInsufficientPrivilegeError` guard per conventions)
- Renders an error state UI (AlertCircle icon + message + "Try again" button) matching the design spec pattern
- Uses a `retryCount` state to re-trigger the load effect when "Try again" is clicked

## Testing

- Added `database-view-client.test.tsx` with 6 tests covering:
  - Error state renders when `loadDatabase` returns an error
  - Error is reported to Sentry via `captureSupabaseError`
  - Error state renders when `loadDatabase` returns null data without error
  - "Try again" button retries the load and clears error on success
  - No error state when `initialData` is provided (server-prefetched)
  - Loading skeleton shows before error state
- Added `ErrorState` Storybook story to `database-view-client.stories.tsx`
- `pnpm lint && pnpm typecheck && pnpm test` all pass (105 test files, 1365 tests)