### PR TITLE
test: add unit tests for filter-bar, filter-value-editor, and sort-menu (#759)

### DIFF
--- a/src/components/database/filter-bar.test.tsx
+++ b/src/components/database/filter-bar.test.tsx
@@ -1,0 +1,471 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import type { FilterRule } from "@/lib/database-filters";
+import { FilterBar, type FilterBarProps } from "./filter-bar";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock the DatePicker to avoid calendar rendering complexity in jsdom
+vi.mock("./property-types/date", () => ({
+  DatePicker: ({
+    onSelect,
+    onClose,
+  }: {
+    selectedDate: string | null;
+    onSelect: (iso: string) => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid="mock-date-picker">
+      <button onClick={() => onSelect("2025-06-15")}>Pick date</button>
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}));
+
+// Mock SelectOptionBadge to simplify select option rendering
+vi.mock("./property-types/select-option-badge", () => ({
+  SelectOptionBadge: ({ name }: { name: string }) => (
+    <span data-testid="select-option-badge">{name}</span>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProperty(
+  overrides: Partial<DatabaseProperty> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-text",
+    database_id: "db-1",
+    name: "Title",
+    type: "text",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const textProp = makeProperty({
+  id: "prop-text",
+  name: "Title",
+  type: "text",
+});
+const numberProp = makeProperty({
+  id: "prop-number",
+  name: "Amount",
+  type: "number",
+  position: 1,
+});
+const selectProp = makeProperty({
+  id: "prop-select",
+  name: "Status",
+  type: "select",
+  position: 2,
+  config: {
+    options: [
+      { id: "opt-1", name: "Active", color: "green" },
+      { id: "opt-2", name: "Inactive", color: "red" },
+    ],
+  },
+});
+const dateProp = makeProperty({
+  id: "prop-date",
+  name: "Due Date",
+  type: "date",
+  position: 3,
+});
+const checkboxProp = makeProperty({
+  id: "prop-checkbox",
+  name: "Done",
+  type: "checkbox",
+  position: 4,
+});
+const urlProp = makeProperty({
+  id: "prop-url",
+  name: "Website",
+  type: "url",
+  position: 5,
+});
+const emailProp = makeProperty({
+  id: "prop-email",
+  name: "Email",
+  type: "email",
+  position: 6,
+});
+const multiSelectProp = makeProperty({
+  id: "prop-multi",
+  name: "Tags",
+  type: "multi_select",
+  position: 7,
+  config: {
+    options: [
+      { id: "tag-1", name: "Frontend", color: "blue" },
+      { id: "tag-2", name: "Backend", color: "purple" },
+    ],
+  },
+});
+
+const allProperties: DatabaseProperty[] = [
+  textProp,
+  numberProp,
+  selectProp,
+  dateProp,
+  checkboxProp,
+  urlProp,
+  emailProp,
+  multiSelectProp,
+];
+
+function defaultProps(overrides: Partial<FilterBarProps> = {}): FilterBarProps {
+  return {
+    properties: allProperties,
+    filters: [],
+    onFiltersChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rendering active filter pills
+// ---------------------------------------------------------------------------
+
+describe("FilterBar — active filter pills", () => {
+  it("renders a pill for each active filter", () => {
+    const filters: FilterRule[] = [
+      { property_id: "prop-text", operator: "contains", value: "hello" },
+      { property_id: "prop-number", operator: "gt", value: 42 },
+    ];
+    render(<FilterBar {...defaultProps({ filters })} />);
+
+    expect(screen.getByTestId("db-filter-pill-0")).toHaveTextContent("Title");
+    expect(screen.getByTestId("db-filter-pill-0")).toHaveTextContent(
+      "contains",
+    );
+    expect(screen.getByTestId("db-filter-pill-0")).toHaveTextContent("hello");
+
+    expect(screen.getByTestId("db-filter-pill-1")).toHaveTextContent("Amount");
+    expect(screen.getByTestId("db-filter-pill-1")).toHaveTextContent(">");
+    expect(screen.getByTestId("db-filter-pill-1")).toHaveTextContent("42");
+  });
+
+  it("renders pills for select properties with resolved option names", () => {
+    const filters: FilterRule[] = [
+      { property_id: "prop-select", operator: "equals", value: "opt-1" },
+    ];
+    render(<FilterBar {...defaultProps({ filters })} />);
+
+    const pill = screen.getByTestId("db-filter-pill-0");
+    expect(pill).toHaveTextContent("Status");
+    expect(pill).toHaveTextContent("is");
+    expect(pill).toHaveTextContent("Active");
+  });
+
+  it("renders pills for is_empty operators without a value label", () => {
+    const filters: FilterRule[] = [
+      { property_id: "prop-text", operator: "is_empty", value: null },
+    ];
+    render(<FilterBar {...defaultProps({ filters })} />);
+
+    const pill = screen.getByTestId("db-filter-pill-0");
+    expect(pill).toHaveTextContent("Title");
+    expect(pill).toHaveTextContent("is empty");
+  });
+
+  it("renders pills for checkbox operators", () => {
+    const filters: FilterRule[] = [
+      { property_id: "prop-checkbox", operator: "is_checked", value: null },
+    ];
+    render(<FilterBar {...defaultProps({ filters })} />);
+
+    const pill = screen.getByTestId("db-filter-pill-0");
+    expect(pill).toHaveTextContent("Done");
+    expect(pill).toHaveTextContent("is checked");
+  });
+
+  it("renders no pills when filters array is empty", () => {
+    render(<FilterBar {...defaultProps()} />);
+    expect(screen.queryByTestId("db-filter-pill-0")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Removing a filter
+// ---------------------------------------------------------------------------
+
+describe("FilterBar — removing a filter", () => {
+  it("calls onFiltersChange without the removed filter when X is clicked", async () => {
+    const user = userEvent.setup();
+    const filters: FilterRule[] = [
+      { property_id: "prop-text", operator: "contains", value: "hello" },
+      { property_id: "prop-number", operator: "gt", value: 42 },
+    ];
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ filters, onFiltersChange })} />);
+
+    const removeBtn = screen.getByLabelText("Remove Title filter");
+    await user.click(removeBtn);
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { property_id: "prop-number", operator: "gt", value: 42 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adding a filter via the "Add filter" button
+// ---------------------------------------------------------------------------
+
+describe("FilterBar — adding a filter", () => {
+  it("opens property picker when 'Add filter' is clicked", async () => {
+    const user = userEvent.setup();
+    render(<FilterBar {...defaultProps()} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+
+    expect(
+      screen.getByTestId("db-filter-property-picker"),
+    ).toBeInTheDocument();
+    // All properties should be listed
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("shows operator picker after selecting a property", async () => {
+    const user = userEvent.setup();
+    render(<FilterBar {...defaultProps()} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Title"));
+
+    expect(
+      screen.getByTestId("db-filter-operator-picker"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows text-appropriate operators for text property", async () => {
+    const user = userEvent.setup();
+    render(<FilterBar {...defaultProps()} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Title"));
+
+    expect(screen.getByTestId("db-filter-operator-contains")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-equals")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-is_empty")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-is_not_empty")).toBeInTheDocument();
+    // Number-only operators should not appear
+    expect(screen.queryByTestId("db-filter-operator-gt")).not.toBeInTheDocument();
+  });
+
+  it("shows number-appropriate operators for number property", async () => {
+    const user = userEvent.setup();
+    render(<FilterBar {...defaultProps()} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Amount"));
+
+    expect(screen.getByTestId("db-filter-operator-equals")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-gt")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-lt")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-gte")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-lte")).toBeInTheDocument();
+    // Text-only operators should not appear
+    expect(
+      screen.queryByTestId("db-filter-operator-contains"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows checkbox-appropriate operators for checkbox property", async () => {
+    const user = userEvent.setup();
+    render(<FilterBar {...defaultProps()} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Done"));
+
+    expect(
+      screen.getByTestId("db-filter-operator-is_checked"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("db-filter-operator-is_not_checked"),
+    ).toBeInTheDocument();
+    // No other operators
+    expect(
+      screen.queryByTestId("db-filter-operator-contains"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows date-appropriate operators for date property", async () => {
+    const user = userEvent.setup();
+    render(<FilterBar {...defaultProps()} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Due Date"));
+
+    expect(screen.getByTestId("db-filter-operator-equals")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-before")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-after")).toBeInTheDocument();
+  });
+
+  it("adds filter immediately for is_empty operator (no value step)", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ onFiltersChange })} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Title"));
+    await user.click(screen.getByTestId("db-filter-operator-is_empty"));
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { property_id: "prop-text", operator: "is_empty", value: null },
+    ]);
+    // Dropdown should close
+    expect(
+      screen.queryByTestId("db-filter-operator-picker"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("adds filter immediately for is_checked operator (no value step)", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ onFiltersChange })} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Done"));
+    await user.click(screen.getByTestId("db-filter-operator-is_checked"));
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { property_id: "prop-checkbox", operator: "is_checked", value: null },
+    ]);
+  });
+
+  it("shows value editor for text 'contains' operator and commits on Enter", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ onFiltersChange })} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Title"));
+    await user.click(screen.getByTestId("db-filter-operator-contains"));
+
+    const input = screen.getByTestId("db-filter-value-input");
+    expect(input).toBeInTheDocument();
+
+    await user.type(input, "search term{Enter}");
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      {
+        property_id: "prop-text",
+        operator: "contains",
+        value: "search term",
+      },
+    ]);
+  });
+
+  it("shows select options for select property and commits on option click", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ onFiltersChange })} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Status"));
+    await user.click(screen.getByTestId("db-filter-operator-equals"));
+
+    // Select option badges should be visible
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Active"));
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { property_id: "prop-select", operator: "equals", value: "opt-1" },
+    ]);
+  });
+
+  it("shows date picker for date property and commits on date selection", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ onFiltersChange })} />);
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Due Date"));
+    await user.click(screen.getByTestId("db-filter-operator-equals"));
+
+    expect(screen.getByTestId("mock-date-picker")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Pick date"));
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      {
+        property_id: "prop-date",
+        operator: "equals",
+        value: "2025-06-15",
+      },
+    ]);
+  });
+
+  it("appends to existing filters when adding a new one", async () => {
+    const user = userEvent.setup();
+    const existingFilters: FilterRule[] = [
+      { property_id: "prop-text", operator: "contains", value: "existing" },
+    ];
+    const onFiltersChange = vi.fn();
+    render(
+      <FilterBar
+        {...defaultProps({ filters: existingFilters, onFiltersChange })}
+      />,
+    );
+
+    await user.click(screen.getByTestId("db-filter-add"));
+    await user.click(screen.getByText("Amount"));
+    await user.click(screen.getByTestId("db-filter-operator-is_empty"));
+
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { property_id: "prop-text", operator: "contains", value: "existing" },
+      { property_id: "prop-number", operator: "is_empty", value: null },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clearing all filters (removing one by one)
+// ---------------------------------------------------------------------------
+
+describe("FilterBar — clearing filters", () => {
+  it("removes the correct filter when there are multiple", async () => {
+    const user = userEvent.setup();
+    const filters: FilterRule[] = [
+      { property_id: "prop-text", operator: "contains", value: "a" },
+      { property_id: "prop-number", operator: "gt", value: 1 },
+    ];
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ filters, onFiltersChange })} />);
+
+    // Remove first filter
+    await user.click(screen.getByLabelText("Remove Title filter"));
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { property_id: "prop-number", operator: "gt", value: 1 },
+    ]);
+  });
+
+  it("produces an empty array when removing the last filter", async () => {
+    const user = userEvent.setup();
+    const filters: FilterRule[] = [
+      { property_id: "prop-number", operator: "gt", value: 1 },
+    ];
+    const onFiltersChange = vi.fn();
+    render(<FilterBar {...defaultProps({ filters, onFiltersChange })} />);
+
+    await user.click(screen.getByLabelText("Remove Amount filter"));
+    expect(onFiltersChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/database/filter-value-editor.test.tsx
+++ b/src/components/database/filter-value-editor.test.tsx
@@ -1,0 +1,537 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import {
+  FilterValueEditor,
+  PropertyPicker,
+  OperatorPicker,
+  getSelectOptions,
+  type FilterValueEditorProps,
+} from "./filter-value-editor";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock DatePicker to avoid calendar rendering in jsdom
+vi.mock("./property-types/date", () => ({
+  DatePicker: ({
+    onSelect,
+    onClose,
+  }: {
+    selectedDate: string | null;
+    onSelect: (iso: string) => void;
+    onClose: () => void;
+  }) => (
+    <div data-testid="mock-date-picker">
+      <button onClick={() => onSelect("2025-06-15")}>Pick date</button>
+      <button onClick={onClose}>Close date</button>
+    </div>
+  ),
+}));
+
+// Mock SelectOptionBadge
+vi.mock("./property-types/select-option-badge", () => ({
+  SelectOptionBadge: ({ name }: { name: string }) => (
+    <span data-testid="select-option-badge">{name}</span>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProperty(
+  overrides: Partial<DatabaseProperty> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Test Prop",
+    type: "text",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function defaultEditorProps(
+  overrides: Partial<FilterValueEditorProps> = {},
+): FilterValueEditorProps {
+  return {
+    property: makeProperty(),
+    valueInput: "",
+    onValueInputChange: vi.fn(),
+    onSubmit: vi.fn(),
+    onSelectValue: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getSelectOptions helper
+// ---------------------------------------------------------------------------
+
+describe("getSelectOptions", () => {
+  it("returns options array from config", () => {
+    const config = {
+      options: [
+        { id: "opt-1", name: "Active", color: "green" },
+        { id: "opt-2", name: "Inactive", color: "red" },
+      ],
+    };
+    const result = getSelectOptions(config);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Active");
+  });
+
+  it("returns empty array when config has no options", () => {
+    expect(getSelectOptions({})).toEqual([]);
+  });
+
+  it("returns empty array when options is not an array", () => {
+    expect(getSelectOptions({ options: "invalid" })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FilterValueEditor — text/number/URL/email/phone input rendering
+// ---------------------------------------------------------------------------
+
+describe("FilterValueEditor — text input types", () => {
+  it("renders a text input for text property", () => {
+    render(<FilterValueEditor {...defaultEditorProps()} />);
+
+    const input = screen.getByTestId("db-filter-value-input");
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute("type", "text");
+    expect(input).toHaveAttribute("placeholder", "Enter value…");
+  });
+
+  it("renders a text input for url property", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({
+          property: makeProperty({ type: "url", name: "Website" }),
+        })}
+      />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("renders a text input for email property", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({
+          property: makeProperty({ type: "email", name: "Email" }),
+        })}
+      />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("renders a text input for phone property", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({
+          property: makeProperty({ type: "phone", name: "Phone" }),
+        })}
+      />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("renders a number input for number property", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({
+          property: makeProperty({ type: "number", name: "Amount" }),
+        })}
+      />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    expect(input).toHaveAttribute("type", "number");
+    expect(input).toHaveAttribute("placeholder", "Enter number…");
+  });
+
+  it("displays the current valueInput", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ valueInput: "hello world" })}
+      />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    expect(input).toHaveValue("hello world");
+  });
+
+  it("calls onValueInputChange when typing", async () => {
+    const user = userEvent.setup();
+    const onValueInputChange = vi.fn();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ onValueInputChange })}
+      />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    await user.type(input, "a");
+
+    expect(onValueInputChange).toHaveBeenCalled();
+  });
+
+  it("calls onSubmit when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ onSubmit, valueInput: "test" })}
+      />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    await user.type(input, "{Enter}");
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <FilterValueEditor {...defaultEditorProps({ onClose })} />,
+    );
+
+    const input = screen.getByTestId("db-filter-value-input");
+    await user.type(input, "{Escape}");
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onSubmit when Apply button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ onSubmit, valueInput: "test" })}
+      />,
+    );
+
+    await user.click(screen.getByText("Apply"));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FilterValueEditor — select/multi_select dropdown rendering
+// ---------------------------------------------------------------------------
+
+describe("FilterValueEditor — select dropdown", () => {
+  const selectProperty = makeProperty({
+    type: "select",
+    name: "Priority",
+    config: {
+      options: [
+        { id: "opt-high", name: "High", color: "red" },
+        { id: "opt-med", name: "Medium", color: "yellow" },
+        { id: "opt-low", name: "Low", color: "green" },
+      ],
+    },
+  });
+
+  it("renders select options from property config", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: selectProperty })}
+      />,
+    );
+
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.getByText("Low")).toBeInTheDocument();
+  });
+
+  it("calls onSelectValue with option id when an option is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelectValue = vi.fn();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: selectProperty, onSelectValue })}
+      />,
+    );
+
+    await user.click(screen.getByText("High"));
+    expect(onSelectValue).toHaveBeenCalledWith("opt-high");
+  });
+
+  it("filters options by search query", async () => {
+    const user = userEvent.setup();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: selectProperty })}
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search options…");
+    await user.type(searchInput, "med");
+
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.queryByText("High")).not.toBeInTheDocument();
+    expect(screen.queryByText("Low")).not.toBeInTheDocument();
+  });
+
+  it("shows 'No options' when search matches nothing", async () => {
+    const user = userEvent.setup();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: selectProperty })}
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search options…");
+    await user.type(searchInput, "zzz");
+
+    expect(screen.getByText("No options")).toBeInTheDocument();
+  });
+
+  it("renders multi_select options the same way", () => {
+    const multiProp = makeProperty({
+      type: "multi_select",
+      name: "Tags",
+      config: {
+        options: [
+          { id: "tag-1", name: "Frontend", color: "blue" },
+          { id: "tag-2", name: "Backend", color: "purple" },
+        ],
+      },
+    });
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: multiProp })}
+      />,
+    );
+
+    expect(screen.getByText("Frontend")).toBeInTheDocument();
+    expect(screen.getByText("Backend")).toBeInTheDocument();
+  });
+
+  it("renders status options the same way as select", () => {
+    const statusProp = makeProperty({
+      type: "status",
+      name: "Status",
+      config: {
+        options: [
+          { id: "s-1", name: "Not Started", color: "gray" },
+          { id: "s-2", name: "In Progress", color: "blue" },
+        ],
+      },
+    });
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: statusProp })}
+      />,
+    );
+
+    expect(screen.getByText("Not Started")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+  });
+
+  it("closes select dropdown on Escape", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: selectProperty, onClose })}
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search options…");
+    await user.type(searchInput, "{Escape}");
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FilterValueEditor — date picker rendering
+// ---------------------------------------------------------------------------
+
+describe("FilterValueEditor — date picker", () => {
+  const dateProperty = makeProperty({ type: "date", name: "Due Date" });
+
+  it("renders the date picker for date property", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: dateProperty })}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-date-picker")).toBeInTheDocument();
+  });
+
+  it("calls onSelectValue when a date is picked", async () => {
+    const user = userEvent.setup();
+    const onSelectValue = vi.fn();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: dateProperty, onSelectValue })}
+      />,
+    );
+
+    await user.click(screen.getByText("Pick date"));
+    expect(onSelectValue).toHaveBeenCalledWith("2025-06-15");
+  });
+
+  it("renders date picker for created_time property", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({
+          property: makeProperty({ type: "created_time", name: "Created" }),
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-date-picker")).toBeInTheDocument();
+  });
+
+  it("renders date picker for updated_time property", () => {
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({
+          property: makeProperty({ type: "updated_time", name: "Updated" }),
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-date-picker")).toBeInTheDocument();
+  });
+
+  it("calls onClose when date picker close is triggered", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <FilterValueEditor
+        {...defaultEditorProps({ property: dateProperty, onClose })}
+      />,
+    );
+
+    await user.click(screen.getByText("Close date"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PropertyPicker
+// ---------------------------------------------------------------------------
+
+describe("PropertyPicker", () => {
+  const properties: DatabaseProperty[] = [
+    makeProperty({ id: "p1", name: "Title", type: "text" }),
+    makeProperty({ id: "p2", name: "Amount", type: "number", position: 1 }),
+    makeProperty({ id: "p3", name: "Status", type: "select", position: 2 }),
+  ];
+
+  it("renders all properties with their names", () => {
+    render(<PropertyPicker properties={properties} onSelect={vi.fn()} />);
+
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("calls onSelect with property id when clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<PropertyPicker properties={properties} onSelect={onSelect} />);
+
+    await user.click(screen.getByText("Amount"));
+    expect(onSelect).toHaveBeenCalledWith("p2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OperatorPicker
+// ---------------------------------------------------------------------------
+
+describe("OperatorPicker", () => {
+  it("renders text operators for text type", () => {
+    render(<OperatorPicker propertyType="text" onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("db-filter-operator-contains")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-equals")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-is_empty")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-is_not_empty")).toBeInTheDocument();
+  });
+
+  it("renders number operators for number type", () => {
+    render(<OperatorPicker propertyType="number" onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("db-filter-operator-equals")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-gt")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-lt")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-gte")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-lte")).toBeInTheDocument();
+  });
+
+  it("renders checkbox operators for checkbox type", () => {
+    render(<OperatorPicker propertyType="checkbox" onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("db-filter-operator-is_checked")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-is_not_checked")).toBeInTheDocument();
+  });
+
+  it("renders date operators for date type", () => {
+    render(<OperatorPicker propertyType="date" onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("db-filter-operator-equals")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-before")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-after")).toBeInTheDocument();
+  });
+
+  it("renders select operators for select type", () => {
+    render(<OperatorPicker propertyType="select" onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("db-filter-operator-equals")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-is_empty")).toBeInTheDocument();
+    expect(screen.getByTestId("db-filter-operator-is_not_empty")).toBeInTheDocument();
+    // Should not have text-specific operators
+    expect(
+      screen.queryByTestId("db-filter-operator-contains"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onSelect with operator when clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<OperatorPicker propertyType="text" onSelect={onSelect} />);
+
+    await user.click(screen.getByTestId("db-filter-operator-contains"));
+    expect(onSelect).toHaveBeenCalledWith("contains");
+  });
+
+  it("displays human-readable operator labels", () => {
+    render(<OperatorPicker propertyType="text" onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId("db-filter-operator-contains")).toHaveTextContent(
+      "contains",
+    );
+    expect(screen.getByTestId("db-filter-operator-equals")).toHaveTextContent(
+      "is",
+    );
+    expect(screen.getByTestId("db-filter-operator-is_empty")).toHaveTextContent(
+      "is empty",
+    );
+  });
+});

--- a/src/components/database/sort-menu.test.tsx
+++ b/src/components/database/sort-menu.test.tsx
@@ -1,0 +1,381 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import type { DatabaseProperty } from "@/lib/types";
+import type { SortRule } from "@/lib/database-filters";
+import { SortMenu, type SortMenuProps } from "./sort-menu";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProperty(
+  overrides: Partial<DatabaseProperty> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Title",
+    type: "text",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const textProp = makeProperty({ id: "prop-text", name: "Title", type: "text" });
+const numberProp = makeProperty({
+  id: "prop-number",
+  name: "Amount",
+  type: "number",
+  position: 1,
+});
+const dateProp = makeProperty({
+  id: "prop-date",
+  name: "Due Date",
+  type: "date",
+  position: 2,
+});
+const selectProp = makeProperty({
+  id: "prop-select",
+  name: "Status",
+  type: "select",
+  position: 3,
+});
+
+const allProperties: DatabaseProperty[] = [
+  textProp,
+  numberProp,
+  dateProp,
+  selectProp,
+];
+
+function defaultProps(overrides: Partial<SortMenuProps> = {}): SortMenuProps {
+  return {
+    properties: allProperties,
+    sorts: [],
+    onSortsChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** Open the sort menu by clicking the Sort button. */
+async function openMenu(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByTestId("db-sort-button"));
+}
+
+// ---------------------------------------------------------------------------
+// Rendering sort rules list
+// ---------------------------------------------------------------------------
+
+describe("SortMenu — rendering sort rules", () => {
+  it("shows 'No sorts applied' when sorts array is empty", async () => {
+    const user = userEvent.setup();
+    render(<SortMenu {...defaultProps()} />);
+
+    await openMenu(user);
+
+    expect(screen.getByText("No sorts applied")).toBeInTheDocument();
+  });
+
+  it("renders each sort rule with property name and direction", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+      { property_id: "prop-number", direction: "desc" },
+    ];
+    render(<SortMenu {...defaultProps({ sorts })} />);
+
+    await openMenu(user);
+
+    const rule0 = screen.getByTestId("db-sort-rule-0");
+    expect(rule0).toHaveTextContent("Title");
+    expect(rule0).toHaveTextContent("Asc");
+
+    const rule1 = screen.getByTestId("db-sort-rule-1");
+    expect(rule1).toHaveTextContent("Amount");
+    expect(rule1).toHaveTextContent("Desc");
+  });
+
+  it("shows sort count in the button when sorts are active", () => {
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+      { property_id: "prop-number", direction: "desc" },
+    ];
+    render(<SortMenu {...defaultProps({ sorts })} />);
+
+    expect(screen.getByTestId("db-sort-button")).toHaveTextContent("(2)");
+  });
+
+  it("does not show count when no sorts are active", () => {
+    render(<SortMenu {...defaultProps()} />);
+
+    const button = screen.getByTestId("db-sort-button");
+    expect(button).toHaveTextContent("Sort");
+    expect(button).not.toHaveTextContent("(");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adding a sort rule
+// ---------------------------------------------------------------------------
+
+describe("SortMenu — adding a sort rule", () => {
+  it("shows 'Add sort' button when menu is open and properties are available", async () => {
+    const user = userEvent.setup();
+    render(<SortMenu {...defaultProps()} />);
+
+    await openMenu(user);
+
+    expect(screen.getByText("Add sort")).toBeInTheDocument();
+  });
+
+  it("shows property picker when 'Add sort' is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SortMenu {...defaultProps()} />);
+
+    await openMenu(user);
+    await user.click(screen.getByText("Add sort"));
+
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByText("Amount")).toBeInTheDocument();
+    expect(screen.getByText("Due Date")).toBeInTheDocument();
+    expect(screen.getByText("Status")).toBeInTheDocument();
+  });
+
+  it("calls onSortsChange with new sort rule when property is selected", async () => {
+    const user = userEvent.setup();
+    const onSortsChange = vi.fn();
+    render(<SortMenu {...defaultProps({ onSortsChange })} />);
+
+    await openMenu(user);
+    await user.click(screen.getByText("Add sort"));
+    await user.click(screen.getByText("Amount"));
+
+    expect(onSortsChange).toHaveBeenCalledWith([
+      { property_id: "prop-number", direction: "asc" },
+    ]);
+  });
+
+  it("appends to existing sorts when adding a new one", async () => {
+    const user = userEvent.setup();
+    const existingSorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+    ];
+    const onSortsChange = vi.fn();
+    render(
+      <SortMenu {...defaultProps({ sorts: existingSorts, onSortsChange })} />,
+    );
+
+    await openMenu(user);
+    await user.click(screen.getByText("Add sort"));
+    await user.click(screen.getByText("Due Date"));
+
+    expect(onSortsChange).toHaveBeenCalledWith([
+      { property_id: "prop-text", direction: "asc" },
+      { property_id: "prop-date", direction: "asc" },
+    ]);
+  });
+
+  it("excludes already-sorted properties from the picker", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+    ];
+    render(<SortMenu {...defaultProps({ sorts })} />);
+
+    await openMenu(user);
+    await user.click(screen.getByText("Add sort"));
+
+    // Title is already sorted, should not appear in picker
+    // But it appears in the sort rules list above — query only the picker area
+    const buttons = screen.getAllByRole("button");
+    const pickerButtons = buttons.filter(
+      (btn) =>
+        btn.textContent?.includes("Amount") ||
+        btn.textContent?.includes("Due Date") ||
+        btn.textContent?.includes("Status"),
+    );
+    expect(pickerButtons.length).toBeGreaterThanOrEqual(3);
+
+    // Title should only appear in the sort rule, not as a pickable option
+    // The sort rule shows "Title" + "Asc", the picker should not have a standalone "Title" button
+    const titleButtons = buttons.filter(
+      (btn) =>
+        btn.textContent === "Title" &&
+        !btn.textContent?.includes("Asc"),
+    );
+    expect(titleButtons).toHaveLength(0);
+  });
+
+  it("hides 'Add sort' when all properties are already sorted", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = allProperties.map((p) => ({
+      property_id: p.id,
+      direction: "asc" as const,
+    }));
+    render(<SortMenu {...defaultProps({ sorts })} />);
+
+    await openMenu(user);
+
+    expect(screen.queryByText("Add sort")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Removing a sort rule
+// ---------------------------------------------------------------------------
+
+describe("SortMenu — removing a sort rule", () => {
+  it("calls onSortsChange without the removed sort", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+      { property_id: "prop-number", direction: "desc" },
+    ];
+    const onSortsChange = vi.fn();
+    render(<SortMenu {...defaultProps({ sorts, onSortsChange })} />);
+
+    await openMenu(user);
+
+    await user.click(screen.getByLabelText("Remove Title sort"));
+
+    expect(onSortsChange).toHaveBeenCalledWith([
+      { property_id: "prop-number", direction: "desc" },
+    ]);
+  });
+
+  it("produces empty array when removing the last sort", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+    ];
+    const onSortsChange = vi.fn();
+    render(<SortMenu {...defaultProps({ sorts, onSortsChange })} />);
+
+    await openMenu(user);
+
+    await user.click(screen.getByLabelText("Remove Title sort"));
+
+    expect(onSortsChange).toHaveBeenCalledWith([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Toggling sort direction
+// ---------------------------------------------------------------------------
+
+describe("SortMenu — toggling sort direction", () => {
+  it("toggles from asc to desc when direction button is clicked", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+    ];
+    const onSortsChange = vi.fn();
+    render(<SortMenu {...defaultProps({ sorts, onSortsChange })} />);
+
+    await openMenu(user);
+
+    await user.click(screen.getByTestId("db-sort-direction-0"));
+
+    expect(onSortsChange).toHaveBeenCalledWith([
+      { property_id: "prop-text", direction: "desc" },
+    ]);
+  });
+
+  it("toggles from desc to asc when direction button is clicked", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "desc" },
+    ];
+    const onSortsChange = vi.fn();
+    render(<SortMenu {...defaultProps({ sorts, onSortsChange })} />);
+
+    await openMenu(user);
+
+    await user.click(screen.getByTestId("db-sort-direction-0"));
+
+    expect(onSortsChange).toHaveBeenCalledWith([
+      { property_id: "prop-text", direction: "asc" },
+    ]);
+  });
+
+  it("only toggles the targeted sort rule, leaving others unchanged", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+      { property_id: "prop-number", direction: "desc" },
+    ];
+    const onSortsChange = vi.fn();
+    render(<SortMenu {...defaultProps({ sorts, onSortsChange })} />);
+
+    await openMenu(user);
+
+    await user.click(screen.getByTestId("db-sort-direction-1"));
+
+    expect(onSortsChange).toHaveBeenCalledWith([
+      { property_id: "prop-text", direction: "asc" },
+      { property_id: "prop-number", direction: "asc" },
+    ]);
+  });
+
+  it("displays correct direction label (Asc/Desc)", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+      { property_id: "prop-number", direction: "desc" },
+    ];
+    render(<SortMenu {...defaultProps({ sorts })} />);
+
+    await openMenu(user);
+
+    expect(screen.getByTestId("db-sort-direction-0")).toHaveTextContent("Asc");
+    expect(screen.getByTestId("db-sort-direction-1")).toHaveTextContent("Desc");
+  });
+
+  it("has correct aria-label for direction button", async () => {
+    const user = userEvent.setup();
+    const sorts: SortRule[] = [
+      { property_id: "prop-text", direction: "asc" },
+    ];
+    render(<SortMenu {...defaultProps({ sorts })} />);
+
+    await openMenu(user);
+
+    expect(screen.getByTestId("db-sort-direction-0")).toHaveAttribute(
+      "aria-label",
+      "Sort ascending",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Menu open/close behavior
+// ---------------------------------------------------------------------------
+
+describe("SortMenu — menu toggle", () => {
+  it("opens menu on button click", async () => {
+    const user = userEvent.setup();
+    render(<SortMenu {...defaultProps()} />);
+
+    expect(screen.queryByTestId("db-sort-menu")).not.toBeInTheDocument();
+
+    await openMenu(user);
+
+    expect(screen.getByTestId("db-sort-menu")).toBeInTheDocument();
+  });
+
+  it("closes menu on second button click", async () => {
+    const user = userEvent.setup();
+    render(<SortMenu {...defaultProps()} />);
+
+    await openMenu(user);
+    expect(screen.getByTestId("db-sort-menu")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("db-sort-button"));
+    expect(screen.queryByTestId("db-sort-menu")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #759

## What

Adds unit tests (Vitest + jsdom + Testing Library) for the three highest-churn database filter/sort components:

- **`filter-bar.test.tsx`** — 20 tests covering filter pill rendering, adding filters through the multi-step flow (property → operator → value), removing filters, and type-appropriate operator selection per property type.
- **`filter-value-editor.test.tsx`** — 34 tests covering the `FilterValueEditor` switch across all property types (text, number, url, email, phone, select, multi_select, status, date, created_time, updated_time), plus `PropertyPicker`, `OperatorPicker`, and the `getSelectOptions` helper.
- **`sort-menu.test.tsx`** — 19 tests covering sort rule rendering, adding/removing sort rules, toggling direction (asc↔desc), property picker exclusion of already-sorted properties, and menu open/close behavior.

## How

- Follows the existing test pattern from `view-tabs.test.tsx` — direct component rendering with mocked sub-components.
- Mocks `DatePicker` and `SelectOptionBadge` to avoid calendar/style rendering complexity in jsdom.
- Tests exercise the actual component logic (state transitions, callback arguments) rather than implementation details.

## Testing

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — passes
- `pnpm test` — 109 files, 1452 tests, all passing
- No E2E tests needed — this PR adds test-only files with no UI or interaction changes.