### PR TITLE
test: add unit tests for row-properties-header and rename-property-dialog (#760)

### DIFF
--- a/src/components/database/rename-property-dialog.test.tsx
+++ b/src/components/database/rename-property-dialog.test.tsx
@@ -1,0 +1,260 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RenamePropertyDialog } from "./rename-property-dialog";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderDialog(
+  overrides: Partial<Parameters<typeof RenamePropertyDialog>[0]> = {},
+) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    propertyName: "Status",
+    onRename: vi.fn(),
+    ...overrides,
+  };
+  const result = render(<RenamePropertyDialog {...props} />);
+  return { ...result, props };
+}
+
+function getInput() {
+  return screen.getByLabelText("Name");
+}
+
+function getRenameButton() {
+  return screen.getByRole("button", { name: "Rename" });
+}
+
+function getCancelButton() {
+  return screen.getByRole("button", { name: "Cancel" });
+}
+
+/** Advance past the 50ms auto-select timer in the RenameForm. */
+function flushAutoSelect() {
+  vi.advanceTimersByTime(60);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Dialog opens with current property name pre-filled
+// ---------------------------------------------------------------------------
+
+describe("RenamePropertyDialog — initial state", () => {
+  it("opens with the current property name pre-filled in the input", () => {
+    renderDialog({ propertyName: "Priority" });
+    flushAutoSelect();
+
+    const input = getInput();
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue("Priority");
+  });
+
+  it("shows dialog title and description", () => {
+    renderDialog();
+    flushAutoSelect();
+
+    expect(screen.getByText("Rename property")).toBeInTheDocument();
+    expect(
+      screen.getByText("Enter a new name for this property."),
+    ).toBeInTheDocument();
+  });
+
+  it("disables Rename button when name is unchanged", () => {
+    renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    expect(getRenameButton()).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validates non-empty name
+// ---------------------------------------------------------------------------
+
+describe("RenamePropertyDialog — validation", () => {
+  it("disables Rename button when input is empty", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    await user.clear(getInput());
+
+    expect(getRenameButton()).toBeDisabled();
+  });
+
+  it("disables Rename button when input is only whitespace", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.clear(input);
+    await user.type(input, "   ");
+
+    expect(getRenameButton()).toBeDisabled();
+  });
+
+  it("enables Rename button when a different non-empty name is entered", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.clear(input);
+    await user.type(input, "Priority");
+
+    expect(getRenameButton()).toBeEnabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Calls rename callback with new name on submit
+// ---------------------------------------------------------------------------
+
+describe("RenamePropertyDialog — submit", () => {
+  it("calls onRename with trimmed new name when Rename button is clicked", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    const { props } = renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.clear(input);
+    await user.type(input, "Priority");
+    await user.click(getRenameButton());
+
+    expect(props.onRename).toHaveBeenCalledWith("Priority");
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onRename with trimmed new name on Enter key", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    const { props } = renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.clear(input);
+    await user.type(input, "Priority{Enter}");
+
+    expect(props.onRename).toHaveBeenCalledWith("Priority");
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("trims whitespace from the new name", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    const { props } = renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.clear(input);
+    await user.type(input, "  New Name  {Enter}");
+
+    expect(props.onRename).toHaveBeenCalledWith("New Name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Closes dialog on cancel
+// ---------------------------------------------------------------------------
+
+describe("RenamePropertyDialog — cancel", () => {
+  it("calls onOpenChange(false) when Cancel button is clicked", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    const { props } = renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    await user.click(getCancelButton());
+
+    expect(props.onRename).not.toHaveBeenCalled();
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("cancels without calling onRename when name is unchanged and Enter is pressed", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    const { props } = renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.type(input, "{Enter}");
+
+    expect(props.onRename).not.toHaveBeenCalled();
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("cancels without calling onRename when input is empty and Enter is pressed", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    const { props } = renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.clear(input);
+    await user.type(input, "{Enter}");
+
+    expect(props.onRename).not.toHaveBeenCalled();
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handles duplicate name error (component delegates to onRename callback —
+// the parent is responsible for duplicate detection)
+// ---------------------------------------------------------------------------
+
+describe("RenamePropertyDialog — duplicate name handling", () => {
+  it("passes the new name to onRename for the parent to validate duplicates", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+    });
+    const { props } = renderDialog({ propertyName: "Status" });
+    flushAutoSelect();
+
+    const input = getInput();
+    await user.clear(input);
+    await user.type(input, "ExistingName{Enter}");
+
+    expect(props.onRename).toHaveBeenCalledWith("ExistingName");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Does not render form when closed
+// ---------------------------------------------------------------------------
+
+describe("RenamePropertyDialog — closed state", () => {
+  it("does not render the form when open is false", () => {
+    renderDialog({ open: false });
+
+    expect(screen.queryByLabelText("Name")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rename property")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/database/row-properties-header.test.tsx
+++ b/src/components/database/row-properties-header.test.tsx
@@ -1,0 +1,505 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DatabaseProperty, PropertyType, RowValue } from "@/lib/types";
+import {
+  RowPropertiesHeader,
+  type RowPropertiesHeaderProps,
+} from "./row-properties-header";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock editor that renders a data-testid and stores callbacks via data attributes
+// so tests can retrieve onChange/onBlur without mutating module-level variables
+// inside a React component (which triggers the React compiler lint rule).
+const mockEditorRender = vi.fn();
+
+function MockEditor(props: {
+  value: Record<string, unknown>;
+  property: DatabaseProperty;
+  onChange: (v: Record<string, unknown>) => void;
+  onBlur: () => void;
+}) {
+  mockEditorRender(props);
+  return (
+    <div data-testid="mock-editor">
+      {String(props.value?.text ?? props.value?.number ?? "")}
+    </div>
+  );
+}
+
+function MockRenderer({
+  value,
+}: {
+  value: Record<string, unknown>;
+  property: DatabaseProperty;
+}) {
+  return (
+    <div data-testid="mock-renderer">
+      {String(value?.text ?? value?.number ?? value?.date ?? "")}
+    </div>
+  );
+}
+
+vi.mock("@/components/database/property-types", () => ({
+  getPropertyTypeConfig: (type: PropertyType) => {
+    if (
+      type === "created_time" ||
+      type === "updated_time" ||
+      type === "created_by"
+    ) {
+      return { Renderer: MockRenderer, Editor: null };
+    }
+    if (type === "formula") {
+      return { Renderer: MockRenderer, Editor: null };
+    }
+    return { Renderer: MockRenderer, Editor: MockEditor };
+  },
+}));
+
+const mockUpdateRowValue = vi.fn<
+  (rowId: string, propertyId: string, value: Record<string, unknown>) => Promise<{ data: null; error: null }>
+>().mockResolvedValue({ data: null, error: null });
+
+const mockUpdateProperty = vi.fn<
+  (propertyId: string, updates: Record<string, unknown>) => Promise<{ data: null; error: null }>
+>().mockResolvedValue({ data: null, error: null });
+
+vi.mock("@/lib/database", () => ({
+  updateRowValue: (...args: [string, string, Record<string, unknown>]) =>
+    mockUpdateRowValue(...args),
+  updateProperty: (...args: [string, Record<string, unknown>]) =>
+    mockUpdateProperty(...args),
+}));
+
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: vi.fn(),
+  isInsufficientPrivilegeError: () => false,
+}));
+
+vi.mock("@/components/database/property-types/formula", () => ({
+  evaluateFormulaForRow: () => ({ _display: "42", _error: null }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProp(overrides: Partial<DatabaseProperty> = {}): DatabaseProperty {
+  return {
+    id: "prop-1",
+    database_id: "db-1",
+    name: "Name",
+    type: "text",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeValue(
+  propertyId: string,
+  val: Record<string, unknown> = { text: "hello" },
+): RowValue {
+  return {
+    id: `val-${propertyId}`,
+    row_id: "page-1",
+    property_id: propertyId,
+    value: val,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+const defaultProps: RowPropertiesHeaderProps = {
+  pageId: "page-1",
+  properties: [
+    makeProp({ id: "prop-1", name: "Title", type: "text", position: 0 }),
+    makeProp({ id: "prop-2", name: "Count", type: "number", position: 1 }),
+    makeProp({ id: "prop-3", name: "Status", type: "select", position: 2 }),
+  ],
+  values: {
+    "prop-1": makeValue("prop-1", { text: "Hello" }),
+    "prop-2": makeValue("prop-2", { number: 42 }),
+    "prop-3": makeValue("prop-3", { selected: "active" }),
+  },
+  pageCreatedAt: "2025-06-01T10:00:00Z",
+  pageUpdatedAt: "2025-06-15T14:30:00Z",
+  pageCreatedBy: "user-abc",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Renders property names and values
+// ---------------------------------------------------------------------------
+
+describe("RowPropertiesHeader — rendering", () => {
+  it("renders property names and values for a row", () => {
+    render(<RowPropertiesHeader {...defaultProps} />);
+
+    expect(screen.getByTestId("db-row-property-name-prop-1")).toHaveTextContent(
+      "Title",
+    );
+    expect(screen.getByTestId("db-row-property-name-prop-2")).toHaveTextContent(
+      "Count",
+    );
+    expect(screen.getByTestId("db-row-property-name-prop-3")).toHaveTextContent(
+      "Status",
+    );
+
+    // Values are rendered via MockRenderer
+    const renderers = screen.getAllByTestId("mock-renderer");
+    expect(renderers.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("returns null when properties array is empty", () => {
+    const { container } = render(
+      <RowPropertiesHeader {...defaultProps} properties={[]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Renders correct editor per property type
+// ---------------------------------------------------------------------------
+
+describe("RowPropertiesHeader — property type editors", () => {
+  it("renders MockRenderer for text property in view mode", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({ id: "prop-1", name: "Title", type: "text" }),
+        ]}
+        values={{
+          "prop-1": makeValue("prop-1", { text: "Hello" }),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-renderer")).toHaveTextContent("Hello");
+  });
+
+  it("renders MockRenderer for number property in view mode", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({ id: "prop-2", name: "Count", type: "number" }),
+        ]}
+        values={{
+          "prop-2": makeValue("prop-2", { number: 42 }),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-renderer")).toHaveTextContent("42");
+  });
+
+  it("renders MockRenderer for select property in view mode", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({ id: "prop-3", name: "Status", type: "select" }),
+        ]}
+        values={{
+          "prop-3": makeValue("prop-3", { text: "active" }),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-renderer")).toHaveTextContent("active");
+  });
+
+  it("renders MockRenderer for date property in view mode", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({ id: "prop-d", name: "Due", type: "date" }),
+        ]}
+        values={{
+          "prop-d": makeValue("prop-d", { date: "2025-06-01" }),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-renderer")).toHaveTextContent("2025-06-01");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handles empty/null values
+// ---------------------------------------------------------------------------
+
+describe("RowPropertiesHeader — empty/null values", () => {
+  it("renders 'Empty' when a property has no value", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({ id: "prop-1", name: "Title", type: "text" }),
+        ]}
+        values={{}}
+      />,
+    );
+
+    expect(screen.getByText("Empty")).toBeInTheDocument();
+  });
+
+  it("renders 'Empty' when value object is empty", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({ id: "prop-1", name: "Title", type: "text" }),
+        ]}
+        values={{
+          "prop-1": makeValue("prop-1", {}),
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Empty")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Calls update callback on value change
+// ---------------------------------------------------------------------------
+
+describe("RowPropertiesHeader — update callback", () => {
+  it("calls updateRowValue when a property value is changed and blurred", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({ id: "prop-1", name: "Title", type: "text" }),
+        ]}
+        values={{
+          "prop-1": makeValue("prop-1", { text: "Hello" }),
+        }}
+      />,
+    );
+
+    // Click the renderer button to enter edit mode
+    const rendererButton = screen.getByRole("button");
+    await user.click(rendererButton);
+
+    // MockEditor should now be rendered
+    expect(screen.getByTestId("mock-editor")).toBeInTheDocument();
+
+    // Retrieve onChange from the last MockEditor render call
+    const firstCall = mockEditorRender.mock.calls.at(-1)![0];
+
+    // Simulate a value change via the editor's onChange
+    act(() => {
+      firstCall.onChange({ text: "Updated" });
+    });
+
+    // After state update, the component re-renders with a new onBlur that
+    // captures the updated currentValue. Retrieve the fresh callback.
+    const reRenderedCall = mockEditorRender.mock.calls.at(-1)![0];
+
+    // Simulate blur to persist
+    await act(async () => {
+      reRenderedCall.onBlur();
+    });
+
+    expect(mockUpdateRowValue).toHaveBeenCalledWith(
+      "page-1",
+      "prop-1",
+      { text: "Updated" },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Computed properties render as read-only
+// ---------------------------------------------------------------------------
+
+describe("RowPropertiesHeader — computed properties", () => {
+  it("renders created_time as formatted read-only date", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({
+            id: "prop-ct",
+            name: "Created",
+            type: "created_time",
+          }),
+        ]}
+        values={{}}
+      />,
+    );
+
+    // formatDate produces "Jun 1, 2025" for "2025-06-01T10:00:00Z"
+    expect(screen.getByText("Jun 1, 2025")).toBeInTheDocument();
+  });
+
+  it("renders updated_time as formatted read-only date", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({
+            id: "prop-ut",
+            name: "Updated",
+            type: "updated_time",
+          }),
+        ]}
+        values={{}}
+      />,
+    );
+
+    expect(screen.getByText("Jun 15, 2025")).toBeInTheDocument();
+  });
+
+  it("renders created_by as read-only text", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({
+            id: "prop-cb",
+            name: "Created By",
+            type: "created_by",
+          }),
+        ]}
+        values={{}}
+      />,
+    );
+
+    expect(screen.getByText("user-abc")).toBeInTheDocument();
+  });
+
+  it("does not show an editor for computed properties on click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({
+            id: "prop-ct",
+            name: "Created",
+            type: "created_time",
+          }),
+        ]}
+        values={{}}
+      />,
+    );
+
+    // The computed value is a span, not a button — no click handler
+    const computedValue = screen.getByText("Jun 1, 2025");
+    await user.click(computedValue);
+
+    expect(screen.queryByTestId("mock-editor")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formula properties render as read-only
+// ---------------------------------------------------------------------------
+
+describe("RowPropertiesHeader — formula properties", () => {
+  it("renders formula result as read-only", () => {
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={[
+          makeProp({
+            id: "prop-f",
+            name: "Formula",
+            type: "formula",
+            config: { expression: "1 + 1" },
+          }),
+        ]}
+        values={{}}
+      />,
+    );
+
+    // evaluateFormulaForRow mock returns { _display: "42" }
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collapse / expand behavior
+// ---------------------------------------------------------------------------
+
+describe("RowPropertiesHeader — collapse/expand", () => {
+  it("collapses properties beyond the limit and shows expand button", () => {
+    const manyProps = Array.from({ length: 8 }, (_, i) =>
+      makeProp({ id: `prop-${i}`, name: `Prop ${i}`, type: "text", position: i }),
+    );
+    const manyValues: Record<string, RowValue> = {};
+    manyProps.forEach((p) => {
+      manyValues[p.id] = makeValue(p.id, { text: `val-${p.id}` });
+    });
+
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={manyProps}
+        values={manyValues}
+      />,
+    );
+
+    // Only first 5 should be visible (COLLAPSED_LIMIT = 5)
+    expect(screen.getByText("Prop 0")).toBeInTheDocument();
+    expect(screen.getByText("Prop 4")).toBeInTheDocument();
+    expect(screen.queryByText("Prop 5")).not.toBeInTheDocument();
+
+    // Should show "Show 3 more" button
+    expect(screen.getByText("Show 3 more")).toBeInTheDocument();
+  });
+
+  it("expands all properties when expand button is clicked", async () => {
+    const user = userEvent.setup();
+    const manyProps = Array.from({ length: 8 }, (_, i) =>
+      makeProp({ id: `prop-${i}`, name: `Prop ${i}`, type: "text", position: i }),
+    );
+    const manyValues: Record<string, RowValue> = {};
+    manyProps.forEach((p) => {
+      manyValues[p.id] = makeValue(p.id, { text: `val-${p.id}` });
+    });
+
+    render(
+      <RowPropertiesHeader
+        {...defaultProps}
+        properties={manyProps}
+        values={manyValues}
+      />,
+    );
+
+    await user.click(screen.getByText("Show 3 more"));
+
+    // All 8 properties should now be visible
+    expect(screen.getByText("Prop 5")).toBeInTheDocument();
+    expect(screen.getByText("Prop 7")).toBeInTheDocument();
+
+    // Button should now say "Show less"
+    expect(screen.getByText("Show less")).toBeInTheDocument();
+  });
+
+  it("does not show collapse button when properties are within limit", () => {
+    render(<RowPropertiesHeader {...defaultProps} />);
+
+    expect(screen.queryByText(/Show \d+ more/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Show less")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #760

## What

Adds component-level unit tests (Vitest + jsdom) for two untested database components:

- **`row-properties-header`** (17 tests) — rendering property names/values, correct editor per type, empty/null value handling, update callback on blur, computed properties as read-only, formula display, and collapse/expand behavior.
- **`rename-property-dialog`** (14 tests) — initial state with pre-filled name, empty/whitespace validation, submit via button and Enter key, cancel behavior, duplicate name delegation, and closed state.

## How

- Mocks the property-type registry (`getPropertyTypeConfig`) with controlled `MockRenderer`/`MockEditor` components, following the pattern in `table-cell.test.tsx`.
- Mocks `@/lib/database` (`updateRowValue`, `updateProperty`) and `@/components/database/property-types/formula` (`evaluateFormulaForRow`) to isolate component logic.
- Uses `vi.useFakeTimers` for the rename dialog to handle the 50ms auto-select timer in `RenameForm`.
- Uses `mockEditorRender` spy to capture editor callbacks across re-renders, avoiding module-level variable mutation inside React components (React compiler lint rule).

## Testing

- `pnpm lint` — 0 errors (39 pre-existing warnings)
- `pnpm typecheck` — passes
- `pnpm test` — 1410 tests pass (108 files), including 31 new tests