### PR TITLE
test: add unit tests for board-view and calendar-view rendering logic (#765)

### DIFF
--- a/src/components/database/views/board-view.test.tsx
+++ b/src/components/database/views/board-view.test.tsx
@@ -1,0 +1,381 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+  SelectOption,
+} from "@/lib/types";
+import { BoardView, type BoardViewProps } from "./board-view";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock next/link to render a plain <a>
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock the property-type registry — we only need a minimal Renderer
+vi.mock("@/components/database/property-types/index", () => ({
+  getPropertyTypeConfig: (type: string) => ({
+    Renderer: ({ value }: { value: Record<string, unknown> }) => (
+      <span data-testid={`prop-renderer-${type}`}>
+        {String(value.text ?? value.option_id ?? "")}
+      </span>
+    ),
+  }),
+}));
+
+// Mock formula evaluation — return a display value for formula properties
+vi.mock("@/components/database/property-types/formula", () => ({
+  evaluateFormulaForRow: () => ({ _display: "formula-result" }),
+}));
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+const STATUS_OPTIONS: SelectOption[] = [
+  { id: "opt-todo", name: "To Do", color: "blue" },
+  { id: "opt-doing", name: "In Progress", color: "yellow" },
+  { id: "opt-done", name: "Done", color: "green" },
+];
+
+function makeProperty(
+  overrides: Partial<DatabaseProperty> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-status",
+    database_id: "db-1",
+    name: "Status",
+    type: "select",
+    config: { options: STATUS_OPTIONS },
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeTextProperty(
+  overrides: Partial<DatabaseProperty> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-text",
+    database_id: "db-1",
+    name: "Notes",
+    type: "text",
+    config: {},
+    position: 1,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRow(
+  id: string,
+  title: string,
+  optionId: string | null,
+  propertyId = "prop-status",
+  extraValues: Record<string, { id: string; row_id: string; property_id: string; value: Record<string, unknown>; created_at: string; updated_at: string }> = {},
+): DatabaseRow {
+  const values: DatabaseRow["values"] = { ...extraValues };
+  if (optionId) {
+    values[propertyId] = {
+      id: `rv-${id}`,
+      row_id: id,
+      property_id: propertyId,
+      value: { option_id: optionId },
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+  }
+  return {
+    page: {
+      id,
+      title,
+      icon: null,
+      cover_url: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      created_by: "user-1",
+    },
+    values,
+  };
+}
+
+function defaultProps(overrides: Partial<BoardViewProps> = {}): BoardViewProps {
+  const statusProp = makeProperty();
+  return {
+    rows: [
+      makeRow("row-1", "Task A", "opt-todo"),
+      makeRow("row-2", "Task B", "opt-doing"),
+      makeRow("row-3", "Task C", "opt-done"),
+    ],
+    properties: [statusProp],
+    viewConfig: { group_by: "prop-status" },
+    workspaceSlug: "ws",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BoardView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Column grouping ---
+
+  it("renders columns grouped by the selected select property", () => {
+    render(<BoardView {...defaultProps()} />);
+
+    // Each option becomes a column, plus the uncategorized column
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.getByText("No value")).toBeInTheDocument();
+  });
+
+  // --- Card rendering ---
+
+  it("cards display row title", () => {
+    render(<BoardView {...defaultProps()} />);
+
+    expect(screen.getByText("Task A")).toBeInTheDocument();
+    expect(screen.getByText("Task B")).toBeInTheDocument();
+    expect(screen.getByText("Task C")).toBeInTheDocument();
+  });
+
+  it("cards display visible properties", () => {
+    const statusProp = makeProperty();
+    const textProp = makeTextProperty();
+    const rows = [
+      makeRow("row-1", "Task A", "opt-todo", "prop-status", {
+        "prop-text": {
+          id: "rv-text-1",
+          row_id: "row-1",
+          property_id: "prop-text",
+          value: { text: "Some notes" },
+          created_at: "2025-01-01T00:00:00Z",
+          updated_at: "2025-01-01T00:00:00Z",
+        },
+      }),
+    ];
+
+    render(
+      <BoardView
+        {...defaultProps({
+          rows,
+          properties: [statusProp, textProp],
+          viewConfig: {
+            group_by: "prop-status",
+            visible_properties: ["prop-text"],
+          },
+        })}
+      />,
+    );
+
+    // The text property renderer should be called with the value
+    expect(screen.getByTestId("prop-renderer-text")).toBeInTheDocument();
+    expect(screen.getByText("Some notes")).toBeInTheDocument();
+  });
+
+  // --- Uncategorized column ---
+
+  it("renders 'No value' column for rows without a value", () => {
+    const statusProp = makeProperty();
+    const rows = [
+      makeRow("row-1", "Task A", "opt-todo"),
+      makeRow("row-no-status", "Unassigned Task", null),
+    ];
+
+    render(
+      <BoardView
+        {...defaultProps({ rows, properties: [statusProp] })}
+      />,
+    );
+
+    const noValueColumn = screen.getByTestId("db-board-column-__uncategorized__");
+    expect(within(noValueColumn).getByText("Unassigned Task")).toBeInTheDocument();
+  });
+
+  // --- Empty column placeholder ---
+
+  it("empty column shows column header with zero count", () => {
+    const statusProp = makeProperty();
+    // Only put rows in "To Do" — "In Progress" and "Done" will be empty
+    const rows = [makeRow("row-1", "Task A", "opt-todo")];
+
+    render(
+      <BoardView
+        {...defaultProps({
+          rows,
+          properties: [statusProp],
+          viewConfig: { group_by: "prop-status", hide_empty_groups: false },
+        })}
+      />,
+    );
+
+    // "In Progress" column exists but has 0 cards
+    const inProgressColumn = screen.getByTestId("db-board-column-opt-doing");
+    expect(within(inProgressColumn).getByText("In Progress")).toBeInTheDocument();
+    expect(within(inProgressColumn).getByText("0")).toBeInTheDocument();
+  });
+
+  // --- Add-row button ---
+
+  it("add-row button in each column calls the correct callback", async () => {
+    const user = userEvent.setup();
+    const onAddRow = vi.fn();
+
+    render(<BoardView {...defaultProps({ onAddRow })} />);
+
+    // Click the "+ New" button in the "To Do" column
+    const todoColumn = screen.getByTestId("db-board-column-opt-todo");
+    const addButton = within(todoColumn).getByRole("button", {
+      name: /add card to to do/i,
+    });
+    await user.click(addButton);
+
+    expect(onAddRow).toHaveBeenCalledWith({
+      "prop-status": { option_id: "opt-todo" },
+    });
+  });
+
+  it("add-row button in uncategorized column calls onAddRow without initial values", async () => {
+    const user = userEvent.setup();
+    const onAddRow = vi.fn();
+
+    render(<BoardView {...defaultProps({ onAddRow })} />);
+
+    const uncatColumn = screen.getByTestId("db-board-column-__uncategorized__");
+    const addButton = within(uncatColumn).getByRole("button", {
+      name: /add card to no value/i,
+    });
+    await user.click(addButton);
+
+    // Uncategorized column calls onAddRow with no initial values
+    expect(onAddRow).toHaveBeenCalledWith();
+  });
+
+  // --- Drag-and-drop ---
+
+  it("drag-and-drop fires onCardMove with correct source/target data", () => {
+    const onCardMove = vi.fn();
+
+    render(<BoardView {...defaultProps({ onCardMove })} />);
+
+    const card = screen.getByTestId("db-board-card-row-1");
+    const doneColumn = screen.getByTestId("db-board-column-opt-done");
+
+    // jsdom doesn't support real DataTransfer — provide a mock on the event
+    const dataTransfer = {
+      effectAllowed: "uninitialized",
+      dropEffect: "none",
+      setData: vi.fn(),
+      getData: vi.fn(),
+    };
+
+    fireEvent.dragStart(card, { dataTransfer });
+    fireEvent.dragOver(doneColumn, { dataTransfer });
+    fireEvent.drop(doneColumn, { dataTransfer });
+
+    expect(onCardMove).toHaveBeenCalledWith("row-1", "prop-status", "opt-done");
+  });
+
+  // --- No group_by configured ---
+
+  it("shows configuration prompt when no group_by property is set", () => {
+    render(
+      <BoardView
+        {...defaultProps({ viewConfig: {} })}
+      />,
+    );
+
+    expect(
+      screen.getByText(/select a .+group by.+ property/i),
+    ).toBeInTheDocument();
+  });
+
+  // --- Loading state ---
+
+  it("shows skeleton when loading", () => {
+    const { container } = render(
+      <BoardView {...defaultProps({ loading: true })} />,
+    );
+
+    // Skeleton renders animated pulse elements, no real columns
+    expect(screen.queryByText("To Do")).not.toBeInTheDocument();
+    const pulseElements = container.querySelectorAll(".animate-pulse");
+    expect(pulseElements.length).toBeGreaterThan(0);
+  });
+
+  // --- Card links ---
+
+  it("cards link to the correct page URL", () => {
+    render(<BoardView {...defaultProps()} />);
+
+    const card = screen.getByTestId("db-board-card-row-1");
+    expect(card).toHaveAttribute("href", "/ws/row-1");
+  });
+
+  // --- Column count ---
+
+  it("column header shows the correct row count", () => {
+    const statusProp = makeProperty();
+    const rows = [
+      makeRow("row-1", "Task A", "opt-todo"),
+      makeRow("row-2", "Task B", "opt-todo"),
+      makeRow("row-3", "Task C", "opt-done"),
+    ];
+
+    render(
+      <BoardView {...defaultProps({ rows, properties: [statusProp] })} />,
+    );
+
+    const todoColumn = screen.getByTestId("db-board-column-opt-todo");
+    // "To Do" column should show count of 2
+    expect(within(todoColumn).getByText("2")).toBeInTheDocument();
+  });
+
+  // --- hide_empty_groups ---
+
+  it("hides empty columns when hide_empty_groups is true", () => {
+    const statusProp = makeProperty();
+    const rows = [makeRow("row-1", "Task A", "opt-todo")];
+
+    render(
+      <BoardView
+        {...defaultProps({
+          rows,
+          properties: [statusProp],
+          viewConfig: { group_by: "prop-status", hide_empty_groups: true },
+        })}
+      />,
+    );
+
+    // "To Do" should exist, "In Progress" and "Done" should not
+    expect(screen.getByText("To Do")).toBeInTheDocument();
+    expect(screen.queryByText("In Progress")).not.toBeInTheDocument();
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/database/views/calendar-view.test.tsx
+++ b/src/components/database/views/calendar-view.test.tsx
@@ -1,0 +1,355 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, within, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type {
+  DatabaseProperty,
+  DatabaseRow,
+} from "@/lib/types";
+import { CalendarView, type CalendarViewProps } from "./calendar-view";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock next/link to render a plain <a>
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock the Button component to avoid base-ui dependency issues in jsdom
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    "aria-label": ariaLabel,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    "aria-label"?: string;
+    variant?: string;
+    size?: string;
+    className?: string;
+  }) => (
+    <button onClick={onClick} aria-label={ariaLabel} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeDateProperty(
+  overrides: Partial<DatabaseProperty> = {},
+): DatabaseProperty {
+  return {
+    id: "prop-date",
+    database_id: "db-1",
+    name: "Due Date",
+    type: "date",
+    config: {},
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRow(
+  id: string,
+  title: string,
+  dateValue: string | null,
+  propertyId = "prop-date",
+): DatabaseRow {
+  const values: DatabaseRow["values"] = {};
+  if (dateValue) {
+    values[propertyId] = {
+      id: `rv-${id}`,
+      row_id: id,
+      property_id: propertyId,
+      value: { date: dateValue },
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+  }
+  return {
+    page: {
+      id,
+      title,
+      icon: null,
+      cover_url: null,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+      created_by: "user-1",
+    },
+    values,
+  };
+}
+
+function defaultProps(
+  overrides: Partial<CalendarViewProps> = {},
+): CalendarViewProps {
+  const dateProp = makeDateProperty();
+  return {
+    rows: [
+      makeRow("row-1", "Task A", "2025-03-10"),
+      makeRow("row-2", "Task B", "2025-03-15"),
+      makeRow("row-3", "Task C", "2025-03-15"),
+    ],
+    properties: [dateProp],
+    viewConfig: { date_property: "prop-date" },
+    workspaceSlug: "ws",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CalendarView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Fix the current date so initial state and "Today" behavior are deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2025, 2, 20)); // March 20, 2025
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // --- Grid rendering ---
+
+  it("renders a month grid with correct day headers", () => {
+    render(<CalendarView {...defaultProps()} />);
+
+    for (const day of ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]) {
+      expect(screen.getByRole("columnheader", { name: day })).toBeInTheDocument();
+    }
+
+    expect(screen.getByText("March 2025")).toBeInTheDocument();
+  });
+
+  // --- Items on correct dates ---
+
+  it("items appear on the correct date cells", () => {
+    render(<CalendarView {...defaultProps()} />);
+
+    const march10Cell = screen.getByRole("gridcell", { name: "2025-03-10" });
+    expect(within(march10Cell).getByText("Task A")).toBeInTheDocument();
+
+    const march15Cell = screen.getByRole("gridcell", { name: "2025-03-15" });
+    expect(within(march15Cell).getByText("Task B")).toBeInTheDocument();
+    expect(within(march15Cell).getByText("Task C")).toBeInTheDocument();
+  });
+
+  // --- Previous/next month navigation ---
+
+  it("previous month navigation updates the displayed month", () => {
+    render(<CalendarView {...defaultProps()} />);
+
+    expect(screen.getByText("March 2025")).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Previous month" }));
+    });
+
+    expect(screen.getByText("February 2025")).toBeInTheDocument();
+    expect(screen.queryByText("March 2025")).not.toBeInTheDocument();
+  });
+
+  it("next month navigation updates the displayed month", () => {
+    render(<CalendarView {...defaultProps()} />);
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Next month" }));
+    });
+
+    expect(screen.getByText("April 2025")).toBeInTheDocument();
+    expect(screen.queryByText("March 2025")).not.toBeInTheDocument();
+  });
+
+  // --- Today button ---
+
+  it("'Today' button returns to current month after navigating away", () => {
+    render(<CalendarView {...defaultProps()} />);
+
+    // Navigate away
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Next month" }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Next month" }));
+    });
+    expect(screen.getByText("May 2025")).toBeInTheDocument();
+
+    // Click "Today" to return
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Today" }));
+    });
+
+    expect(screen.getByText("March 2025")).toBeInTheDocument();
+  });
+
+  // --- Items without a date ---
+
+  it("items without a date value are excluded from the grid", () => {
+    const dateProp = makeDateProperty();
+    const rows = [
+      makeRow("row-1", "Has Date", "2025-03-10"),
+      makeRow("row-no-date", "No Date Task", null),
+    ];
+
+    render(
+      <CalendarView
+        {...defaultProps({ rows, properties: [dateProp] })}
+      />,
+    );
+
+    expect(screen.getByText("Has Date")).toBeInTheDocument();
+    expect(screen.queryByText("No Date Task")).not.toBeInTheDocument();
+  });
+
+  // --- Empty day cells clickable ---
+
+  it("empty day cells are clickable to add a row on that date", () => {
+    const onAddRow = vi.fn();
+    const dateProp = makeDateProperty();
+
+    render(
+      <CalendarView
+        {...defaultProps({
+          rows: [],
+          properties: [dateProp],
+          onAddRow,
+        })}
+      />,
+    );
+
+    // Click directly on the March 5 cell (empty, no items)
+    const march5Cell = screen.getByRole("gridcell", { name: "2025-03-05" });
+    fireEvent.click(march5Cell);
+
+    expect(onAddRow).toHaveBeenCalledWith({
+      "prop-date": { date: "2025-03-05" },
+    });
+  });
+
+  // --- No date property configured ---
+
+  it("shows prompt when no date property is configured", () => {
+    render(
+      <CalendarView
+        {...defaultProps({ viewConfig: {} })}
+      />,
+    );
+
+    expect(
+      screen.getByText("Select a date property to position items on the calendar"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows prompt to add a date property when none exist", () => {
+    render(
+      <CalendarView
+        {...defaultProps({
+          properties: [
+            {
+              id: "prop-text",
+              database_id: "db-1",
+              name: "Notes",
+              type: "text",
+              config: {},
+              position: 0,
+              created_at: "2025-01-01T00:00:00Z",
+              updated_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+          viewConfig: {},
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText("Add a date property to use calendar view"),
+    ).toBeInTheDocument();
+  });
+
+  // --- Loading state ---
+
+  it("shows skeleton when loading", () => {
+    const { container } = render(
+      <CalendarView {...defaultProps({ loading: true })} />,
+    );
+
+    expect(screen.queryByText("March 2025")).not.toBeInTheDocument();
+    const pulseElements = container.querySelectorAll(".animate-pulse");
+    expect(pulseElements.length).toBeGreaterThan(0);
+  });
+
+  // --- Year rollover ---
+
+  it("navigating previous from January goes to December of previous year", () => {
+    vi.setSystemTime(new Date(2025, 0, 15)); // January 2025
+
+    render(<CalendarView {...defaultProps()} />);
+
+    expect(screen.getByText("January 2025")).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Previous month" }));
+    });
+
+    expect(screen.getByText("December 2024")).toBeInTheDocument();
+  });
+
+  it("navigating next from December goes to January of next year", () => {
+    vi.setSystemTime(new Date(2025, 11, 15)); // December 2025
+
+    render(<CalendarView {...defaultProps()} />);
+
+    expect(screen.getByText("December 2025")).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Next month" }));
+    });
+
+    expect(screen.getByText("January 2026")).toBeInTheDocument();
+  });
+
+  // --- Item links ---
+
+  it("calendar items link to the correct page URL", () => {
+    render(<CalendarView {...defaultProps()} />);
+
+    const link = screen.getByText("Task A").closest("a");
+    expect(link).toHaveAttribute("href", "/ws/row-1");
+  });
+
+  // --- Grid completeness ---
+
+  it("grid fills complete weeks with overflow days from adjacent months", () => {
+    render(<CalendarView {...defaultProps()} />);
+
+    // March 2025 starts on Saturday (day index 6), so there are
+    // overflow days from February. Total cells must be a multiple of 7.
+    const grid = screen.getByRole("grid");
+    const cells = within(grid).getAllByRole("gridcell");
+    expect(cells.length % 7).toBe(0);
+    expect(cells.length).toBeGreaterThanOrEqual(28);
+  });
+});


### PR DESCRIPTION
Closes #765

## What

Adds unit tests (Vitest + jsdom) for the rendering logic of `board-view.tsx` (13 tests) and `calendar-view.tsx` (14 tests) — the two largest database view components.

## How

### board-view.test.tsx (13 tests)
- Columns grouped by select property options
- Cards display row title and visible properties
- "No value" column renders for rows without a status value
- Empty columns show header with zero count
- Add-row button in each column calls `onAddRow` with correct initial values
- Add-row in uncategorized column calls `onAddRow` without initial values
- Drag-and-drop fires `onCardMove` with correct source/target data
- Configuration prompt when no `group_by` property is set
- Loading skeleton state
- Card links point to correct page URL
- Column header shows correct row count
- `hide_empty_groups` hides columns with no rows

### calendar-view.test.tsx (14 tests)
- Month grid renders with correct day headers (Sun–Sat)
- Items appear on the correct date cells
- Previous/next month navigation updates displayed month
- "Today" button returns to current month
- Items without a date value are excluded from the grid
- Empty day cells are clickable to add a row on that date
- Configuration prompts (no date property configured, no date properties exist)
- Loading skeleton state
- Year rollover: January → December (prev), December → January (next)
- Calendar items link to correct page URL
- Grid fills complete weeks with overflow days from adjacent months

## Testing

- `pnpm lint` — passes (no new warnings)
- `pnpm typecheck` — passes
- `pnpm test` — 1510 tests pass (113 test files), including 27 new tests
- No E2E tests needed — this PR adds test files only, no interactive UI changes