### PR TITLE
fix: remove overly strict click target guard in calendar cell handler (#780)

### DIFF
--- a/e2e/database-calendar.spec.ts
+++ b/e2e/database-calendar.spec.ts
@@ -466,28 +466,31 @@ test.describe("Database calendar view", () => {
     await navigateToDatabase(page);
     await switchToCalendarView(page);
 
-    // Pick a day that has no items (day 20)
-    // Find the cell with day number "20" in the current month.
-    // Calendar cells have a span with the day number and are direct children
-    // of the grid. We need to click the cell background (not an item).
+    // Pick a day that has no items (day 20).
+    // The cell contains a <span> with the day number and a <div> for items.
+    // Clicking anywhere on the cell (including child elements) should trigger
+    // onAddRow — interactive children (links, buttons) call stopPropagation.
 
-    // Count existing links before adding
+    // Count existing "Untitled" links before adding
     const linksBefore = await page.locator("a").filter({
       hasText: "Untitled",
     }).count();
 
-    // Find the cell for day 20 — it's a div containing a span with "20"
-    // We click the cell div itself (not the span) to trigger onAddRow.
+    // Find the cell for day 20 via its gridcell role and day number
     const day20Span = page.locator("span").filter({ hasText: /^20$/ }).first();
     await expect(day20Span).toBeVisible({ timeout: 5_000 });
 
-    // Click the parent cell div (the cell background)
+    // Click the cell — the click may land on a child element (span, div),
+    // which is fine since the handler no longer requires e.target === e.currentTarget.
     const day20Cell = day20Span.locator("..");
     await day20Cell.click({ position: { x: 40, y: 60 } });
 
-    // A new "Untitled" item should appear on day 20
+    // Wait for the async row creation to complete and the new "Untitled"
+    // link to appear in the DOM. The row is created via Supabase then
+    // optimistically added to state, so we need to poll.
     const untitledLinks = page.locator("a").filter({ hasText: "Untitled" });
-    const linksAfter = await untitledLinks.count();
-    expect(linksAfter).toBeGreaterThan(linksBefore);
+    await expect(untitledLinks).toHaveCount(linksBefore + 1, {
+      timeout: 10_000,
+    });
   });
 });

--- a/src/components/database/views/calendar-view.test.tsx
+++ b/src/components/database/views/calendar-view.test.tsx
@@ -249,6 +249,34 @@ describe("CalendarView", () => {
     });
   });
 
+  // --- Clicking day number span triggers onAddRow (#780) ---
+
+  it("clicking the day number span inside a cell triggers onAddRow", () => {
+    const onAddRow = vi.fn();
+    const dateProp = makeDateProperty();
+
+    render(
+      <CalendarView
+        {...defaultProps({
+          rows: [],
+          properties: [dateProp],
+          onAddRow,
+        })}
+      />,
+    );
+
+    // Click the day number span (a child of the cell div), not the cell itself.
+    // Before the fix for #780, this would not trigger onAddRow because the
+    // handler checked e.target === e.currentTarget.
+    const march5Cell = screen.getByRole("gridcell", { name: "2025-03-05" });
+    const daySpan = within(march5Cell).getByText("5");
+    fireEvent.click(daySpan);
+
+    expect(onAddRow).toHaveBeenCalledWith({
+      "prop-date": { date: "2025-03-05" },
+    });
+  });
+
   // --- No date property configured ---
 
   it("shows prompt when no date property is configured", () => {

--- a/src/components/database/views/calendar-view.tsx
+++ b/src/components/database/views/calendar-view.tsx
@@ -166,10 +166,10 @@ export const CalendarView = memo(function CalendarView({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  // Cell click handler — create a new row with the date pre-filled
-  function handleCellClick(date: string, e: React.MouseEvent) {
-    // Only trigger on clicks directly on the cell background, not on items
-    if (e.target !== e.currentTarget) return;
+  // Cell click handler — create a new row with the date pre-filled.
+  // Interactive children (CalendarItem links, overflow button) already call
+  // e.stopPropagation(), so clicks on them never reach this handler.
+  function handleCellClick(date: string) {
     if (!onAddRow || !datePropertyId) return;
     onAddRow({ [datePropertyId]: { date } });
   }
@@ -281,7 +281,7 @@ export const CalendarView = memo(function CalendarView({
 interface CalendarDayCellProps {
   cell: CalendarCell;
   workspaceSlug: string;
-  onClick?: (date: string, e: React.MouseEvent) => void;
+  onClick?: (date: string) => void;
 }
 
 function CalendarDayCell({ cell, workspaceSlug, onClick }: CalendarDayCellProps) {
@@ -329,7 +329,7 @@ function CalendarDayCell({ cell, workspaceSlug, onClick }: CalendarDayCellProps)
         cell.isToday && "bg-accent/10",
         onClick && "cursor-pointer",
       )}
-      onClick={onClick ? (e) => onClick(cell.date, e) : undefined}
+      onClick={onClick ? () => onClick(cell.date) : undefined}
     >
       {/* Day number */}
       <span


### PR DESCRIPTION
Closes #780

## What

Clicking on a calendar date cell to create a new row did not work. The `handleCellClick` handler used `e.target !== e.currentTarget` to prevent triggering on item clicks, but this guard was too strict — it blocked clicks on any child element (day number `<span>`, items container `<div>`), which together cover most of the cell's clickable area. Only clicks landing exactly on the cell div's padding pixels would pass.

## How

Removed the `e.target !== e.currentTarget` guard from `handleCellClick`. This guard was redundant because interactive children (`CalendarItem` links and the overflow `<button>`) already call `e.stopPropagation()`, preventing their clicks from bubbling up to the cell handler. Simplified the handler signature to remove the unused `React.MouseEvent` parameter.

## Testing

- Added a Vitest regression test that clicks the day number `<span>` inside a cell and verifies `onAddRow` fires (this would have failed before the fix).
- Updated the E2E test to use Playwright's `toHaveCount` assertion with a timeout instead of an immediate synchronous count, properly waiting for the async row creation to complete.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (1612 tests).
- `pnpm test:e2e -- e2e/database-calendar.spec.ts` passes (4/4 tests including the previously failing one).