### PR TITLE
feat: add ARIA roles and labels to editor callout blocks (#788)

### DIFF
--- a/src/components/editor/callout-node.test.ts
+++ b/src/components/editor/callout-node.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { createHeadlessEditor } from "@lexical/headless";
+import { $getRoot } from "lexical";
+import {
+  CalloutNode,
+  $createCalloutNode,
+  type CalloutVariant,
+} from "./callout-node";
+
+function createEditor() {
+  return createHeadlessEditor({ nodes: [CalloutNode] });
+}
+
+/**
+ * Helper: create a CalloutNode inside a headless editor and return
+ * the DOM element produced by createDOM().
+ */
+function createCalloutDOM(
+  emoji?: string,
+  variant?: CalloutVariant
+): HTMLElement {
+  const editor = createEditor();
+  let dom!: HTMLElement;
+  editor.update(
+    () => {
+      const node = $createCalloutNode(emoji, variant);
+      $getRoot().append(node);
+      dom = node.createDOM();
+    },
+    { discrete: true }
+  );
+  return dom;
+}
+
+describe("CalloutNode ARIA attributes", () => {
+  it("createDOM sets role='note' on the container", () => {
+    const dom = createCalloutDOM();
+    expect(dom.getAttribute("role")).toBe("note");
+  });
+
+  it("createDOM sets aria-label matching the variant (default: info)", () => {
+    const dom = createCalloutDOM();
+    expect(dom.getAttribute("aria-label")).toBe("Info callout");
+  });
+
+  it.each([
+    ["info", "Info callout"],
+    ["warning", "Warning callout"],
+    ["success", "Success callout"],
+    ["error", "Error callout"],
+  ] as const)(
+    "createDOM sets aria-label='%s' for variant %s",
+    (variant, expectedLabel) => {
+      const dom = createCalloutDOM("💡", variant);
+      expect(dom.getAttribute("aria-label")).toBe(expectedLabel);
+    }
+  );
+
+  it("emoji span has aria-hidden='true'", () => {
+    const dom = createCalloutDOM();
+    const emojiSpan = dom.querySelector(".callout-emoji");
+    expect(emojiSpan).not.toBeNull();
+    expect(emojiSpan!.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("CalloutNode updateDOM updates aria-label on variant change", () => {
+  it("updates aria-label when variant changes", () => {
+    const editor = createEditor();
+    let dom!: HTMLElement;
+    let prevNode!: CalloutNode;
+
+    // Create initial node with variant "info"
+    editor.update(
+      () => {
+        const node = $createCalloutNode("💡", "info");
+        $getRoot().append(node);
+        dom = node.createDOM();
+        prevNode = node;
+      },
+      { discrete: true }
+    );
+
+    expect(dom.getAttribute("aria-label")).toBe("Info callout");
+
+    // Update variant to "warning"
+    editor.update(
+      () => {
+        const node = $createCalloutNode("⚠️", "warning");
+        $getRoot().append(node);
+        node.updateDOM(prevNode, dom);
+      },
+      { discrete: true }
+    );
+
+    expect(dom.getAttribute("aria-label")).toBe("Warning callout");
+  });
+
+  it("does not change aria-label when only emoji changes", () => {
+    const editor = createEditor();
+    let dom!: HTMLElement;
+    let prevNode!: CalloutNode;
+
+    editor.update(
+      () => {
+        const node = $createCalloutNode("💡", "success");
+        $getRoot().append(node);
+        dom = node.createDOM();
+        prevNode = node;
+      },
+      { discrete: true }
+    );
+
+    expect(dom.getAttribute("aria-label")).toBe("Success callout");
+
+    editor.update(
+      () => {
+        const node = $createCalloutNode("✅", "success");
+        $getRoot().append(node);
+        node.updateDOM(prevNode, dom);
+      },
+      { discrete: true }
+    );
+
+    // aria-label should remain the same since variant didn't change
+    expect(dom.getAttribute("aria-label")).toBe("Success callout");
+  });
+});

--- a/src/components/editor/callout-node.tsx
+++ b/src/components/editor/callout-node.tsx
@@ -31,6 +31,13 @@ const VARIANT_CLASSES: Record<CalloutVariant, string> = {
   error: "border-l-destructive bg-muted",
 };
 
+const VARIANT_LABELS: Record<CalloutVariant, string> = {
+  info: "Info callout",
+  warning: "Warning callout",
+  success: "Success callout",
+  error: "Error callout",
+};
+
 const BASE_CLASSES = "mt-3 flex gap-3 border-l-2 p-4 text-sm";
 
 export class CalloutNode extends ElementNode {
@@ -72,10 +79,13 @@ export class CalloutNode extends ElementNode {
   createDOM(): HTMLElement {
     const div = document.createElement("div");
     div.className = `${BASE_CLASSES} ${VARIANT_CLASSES[this.__variant]}`;
+    div.role = "note";
+    div.setAttribute("aria-label", VARIANT_LABELS[this.__variant]);
 
     const emojiSpan = document.createElement("span");
     emojiSpan.className = "callout-emoji select-none text-lg shrink-0";
     emojiSpan.contentEditable = "false";
+    emojiSpan.setAttribute("aria-hidden", "true");
     emojiSpan.textContent = this.__emoji;
     div.appendChild(emojiSpan);
 
@@ -85,6 +95,7 @@ export class CalloutNode extends ElementNode {
   updateDOM(prevNode: CalloutNode, dom: HTMLElement): boolean {
     if (prevNode.__variant !== this.__variant) {
       dom.className = `${BASE_CLASSES} ${VARIANT_CLASSES[this.__variant]}`;
+      dom.setAttribute("aria-label", VARIANT_LABELS[this.__variant]);
     }
     if (prevNode.__emoji !== this.__emoji) {
       const emojiSpan = dom.querySelector(".callout-emoji");

--- a/src/components/editor/editor-theme.stories.tsx
+++ b/src/components/editor/editor-theme.stories.tsx
@@ -144,22 +144,56 @@ export const HorizontalRule: Story = {
 };
 
 export const Callouts: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Callout blocks use `role=\"note\"` and `aria-label` with the variant name " +
+          "(e.g. \"Info callout\") so screen readers can distinguish them from regular " +
+          "content. The emoji span has `aria-hidden=\"true\"` to avoid redundant output.",
+      },
+    },
+  },
   render: () => (
     <div className="mx-auto max-w-2xl space-y-2">
-      <div className="mt-3 flex gap-3 border-l-2 border-l-accent bg-muted p-4 text-sm">
-        <span className="shrink-0 text-lg">💡</span>
+      <div
+        className="mt-3 flex gap-3 border-l-2 border-l-accent bg-muted p-4 text-sm"
+        role="note"
+        aria-label="Info callout"
+      >
+        <span className="shrink-0 text-lg" aria-hidden="true">
+          💡
+        </span>
         <span>Info callout — useful tips and information.</span>
       </div>
-      <div className="mt-3 flex gap-3 border-l-2 border-l-code-type bg-muted p-4 text-sm">
-        <span className="shrink-0 text-lg">⚠️</span>
+      <div
+        className="mt-3 flex gap-3 border-l-2 border-l-code-type bg-muted p-4 text-sm"
+        role="note"
+        aria-label="Warning callout"
+      >
+        <span className="shrink-0 text-lg" aria-hidden="true">
+          ⚠️
+        </span>
         <span>Warning callout — proceed with caution.</span>
       </div>
-      <div className="mt-3 flex gap-3 border-l-2 border-l-code-string bg-muted p-4 text-sm">
-        <span className="shrink-0 text-lg">✅</span>
+      <div
+        className="mt-3 flex gap-3 border-l-2 border-l-code-string bg-muted p-4 text-sm"
+        role="note"
+        aria-label="Success callout"
+      >
+        <span className="shrink-0 text-lg" aria-hidden="true">
+          ✅
+        </span>
         <span>Success callout — operation completed.</span>
       </div>
-      <div className="mt-3 flex gap-3 border-l-2 border-l-destructive bg-muted p-4 text-sm">
-        <span className="shrink-0 text-lg">❌</span>
+      <div
+        className="mt-3 flex gap-3 border-l-2 border-l-destructive bg-muted p-4 text-sm"
+        role="note"
+        aria-label="Error callout"
+      >
+        <span className="shrink-0 text-lg" aria-hidden="true">
+          ❌
+        </span>
         <span>Error callout — something went wrong.</span>
       </div>
     </div>


### PR DESCRIPTION
Closes #788

## What

Adds semantic ARIA attributes to `CalloutNode` so screen readers can distinguish callout blocks from regular content and identify their variant (info, warning, success, error).

## How

- `CalloutNode.createDOM()` sets `role="note"` and `aria-label` (e.g. "Info callout") on the container div
- `CalloutNode.updateDOM()` updates `aria-label` when the variant changes
- The emoji span gets `aria-hidden="true"` to avoid redundant screen reader output
- A `VARIANT_LABELS` map provides human-readable labels for each variant

## Testing

- 9 unit tests using `createHeadlessEditor` verify ARIA attributes on `createDOM()` and `updateDOM()` at the DOM level
- Storybook callout story updated with matching ARIA attributes and an accessibility docs note
- Verified in Playwright that all 4 callout variants render with correct `role="note"`, `aria-label`, and `aria-hidden` attributes
- `pnpm lint && pnpm typecheck && pnpm test` all pass (1627 tests)