### PR TITLE
feat: add ARIA listbox role to slash command menu and page-link dropdown (#792)

### DIFF
--- a/src/components/editor/page-link-plugin.tsx
+++ b/src/components/editor/page-link-plugin.tsx
@@ -445,7 +445,16 @@ export function PageLinkPlugin(): JSX.Element | null {
           aria-label="Search pages"
         />
       </div>
-      <div className="max-h-[260px] overflow-y-auto p-1">
+      <div
+        className="max-h-[260px] overflow-y-auto p-1"
+        role="listbox"
+        aria-label="Page search results"
+        aria-activedescendant={
+          selectedIndex !== null && results[selectedIndex]
+            ? `page-link-option-${results[selectedIndex].id}`
+            : undefined
+        }
+      >
         {results.length === 0 && (
           <div className="px-2 py-3 text-center text-xs text-muted-foreground">
             {query.trim() ? "No pages found" : "No pages in workspace"}
@@ -454,6 +463,7 @@ export function PageLinkPlugin(): JSX.Element | null {
         {results.map((page, index) => (
           <button
             key={page.id}
+            id={`page-link-option-${page.id}`}
             className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none ${
               selectedIndex === index
                 ? "bg-overlay-active text-foreground"

--- a/src/components/editor/slash-command-plugin.tsx
+++ b/src/components/editor/slash-command-plugin.tsx
@@ -334,10 +334,18 @@ export function SlashCommandPlugin(): JSX.Element | null {
           <div
             ref={menuRef}
             className="fixed z-50 max-h-[300px] w-64 overflow-y-auto rounded-sm border border-overlay-border bg-popover p-1 shadow-md"
+            role="listbox"
+            aria-label="Slash commands"
+            aria-activedescendant={
+              selectedIndex !== null && items[selectedIndex]
+                ? `slash-cmd-option-${items[selectedIndex].key}`
+                : undefined
+            }
           >
             {items.map((option, index) => (
               <button
                 key={option.key}
+                id={`slash-cmd-option-${option.key}`}
                 ref={(el) => option.setRefElement(el)}
                 className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none ${
                   selectedIndex === index

--- a/src/components/members/member-list.test.tsx
+++ b/src/components/members/member-list.test.tsx
@@ -1,0 +1,301 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemberList } from "./member-list";
+import type { MemberRole, MemberWithProfile } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+function makeMember(
+  overrides: Partial<MemberWithProfile> & {
+    profileOverrides?: Partial<MemberWithProfile["profiles"]>;
+  } = {},
+): MemberWithProfile {
+  const { profileOverrides, ...rest } = overrides;
+  return {
+    id: "m1",
+    workspace_id: "ws1",
+    user_id: "u1",
+    role: "member",
+    invited_by: null,
+    invited_at: null,
+    joined_at: "2024-01-01T00:00:00Z",
+    created_at: "2024-01-01T00:00:00Z",
+    profiles: {
+      email: "alice@example.com",
+      display_name: "Alice",
+      avatar_url: null,
+      ...profileOverrides,
+    },
+    ...rest,
+  };
+}
+
+const owner = makeMember({
+  id: "m1",
+  user_id: "u1",
+  role: "owner",
+  profileOverrides: { display_name: "Alice", email: "alice@example.com" },
+});
+
+const admin = makeMember({
+  id: "m2",
+  user_id: "u2",
+  role: "admin",
+  profileOverrides: { display_name: "Bob", email: "bob@example.com" },
+});
+
+const member = makeMember({
+  id: "m3",
+  user_id: "u3",
+  role: "member",
+  profileOverrides: { display_name: "Carol", email: "carol@example.com" },
+});
+
+const allMembers = [owner, admin, member];
+
+interface DefaultPropsOverrides {
+  members?: MemberWithProfile[];
+  currentUserId?: string;
+  currentUserRole?: MemberRole;
+  isPersonalWorkspace?: boolean;
+  onRoleChange?: (memberId: string, newRole: MemberRole) => Promise<void>;
+  onRemove?: (memberId: string) => Promise<void>;
+}
+
+function defaultProps(overrides: DefaultPropsOverrides = {}) {
+  return {
+    members: allMembers,
+    currentUserId: "u1",
+    currentUserRole: "owner" as MemberRole,
+    isPersonalWorkspace: false,
+    onRoleChange: vi.fn(),
+    onRemove: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MemberList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Rendering ---
+
+  it("renders member rows with display name and email", () => {
+    render(<MemberList {...defaultProps()} />);
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Carol")).toBeInTheDocument();
+    expect(screen.getByText("carol@example.com")).toBeInTheDocument();
+  });
+
+  it("shows member count in the heading", () => {
+    render(<MemberList {...defaultProps()} />);
+
+    expect(screen.getByText("Members (3)")).toBeInTheDocument();
+  });
+
+  it("marks the current user with '(you)'", () => {
+    render(<MemberList {...defaultProps({ currentUserId: "u2" })} />);
+
+    // Bob is u2 — should have "(you)" next to name
+    expect(screen.getByText("(you)")).toBeInTheDocument();
+    // The "(you)" should be near Bob's name
+    const youLabel = screen.getByText("(you)");
+    const row = youLabel.closest("tr");
+    expect(row).not.toBeNull();
+    expect(within(row!).getByText("Bob")).toBeInTheDocument();
+  });
+
+  // --- Role badges ---
+
+  it("renders role badges for members the current user cannot change", () => {
+    // As owner viewing self — cannot change own role, so badge is shown
+    render(<MemberList {...defaultProps({ currentUserId: "u1" })} />);
+
+    // Owner's own role shows as a badge (not a select)
+    const ownerRow = screen.getByText("Alice").closest("tr")!;
+    expect(within(ownerRow).getByText("owner")).toBeInTheDocument();
+  });
+
+  it("shows RoleSelect for members whose role can be changed", () => {
+    render(<MemberList {...defaultProps({ currentUserId: "u1", currentUserRole: "owner" })} />);
+
+    // Bob (admin) and Carol (member) should have role selects
+    // The RoleSelect renders a button trigger with the current role value
+    const bobRow = screen.getByText("Bob").closest("tr")!;
+    const carolRow = screen.getByText("Carol").closest("tr")!;
+
+    // RoleSelect uses a <select> trigger — look for the select trigger button
+    expect(within(bobRow).getByRole("combobox")).toBeInTheDocument();
+    expect(within(carolRow).getByRole("combobox")).toBeInTheDocument();
+  });
+
+  // --- Role change callback ---
+
+  it("fires onRoleChange with correct args when role is changed", async () => {
+    const onRoleChange = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(
+      <MemberList
+        {...defaultProps({ currentUserId: "u1", currentUserRole: "owner", onRoleChange })}
+      />,
+    );
+
+    // Carol (member) should have a role select
+    const carolRow = screen.getByText("Carol").closest("tr")!;
+    const trigger = within(carolRow).getByRole("combobox");
+    await user.click(trigger);
+
+    // Select the "admin" option from the listbox
+    const adminOption = await screen.findByRole("option", { name: "admin" });
+    await user.click(adminOption);
+
+    await waitFor(() => {
+      expect(onRoleChange).toHaveBeenCalledWith("m3", "admin");
+    });
+  });
+
+  // --- Remove member ---
+
+  it("shows remove button for removable members", () => {
+    render(<MemberList {...defaultProps({ currentUserId: "u1", currentUserRole: "owner" })} />);
+
+    // Bob and Carol can be removed by the owner
+    expect(screen.getByLabelText("Remove Bob")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove Carol")).toBeInTheDocument();
+  });
+
+  it("does not show remove button for the current user", () => {
+    render(<MemberList {...defaultProps({ currentUserId: "u1", currentUserRole: "owner" })} />);
+
+    // Owner cannot remove themselves
+    expect(screen.queryByLabelText("Remove Alice")).not.toBeInTheDocument();
+  });
+
+  it("fires onRemove after confirming the alert dialog", async () => {
+    const onRemove = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    render(
+      <MemberList
+        {...defaultProps({ currentUserId: "u1", currentUserRole: "owner", onRemove })}
+      />,
+    );
+
+    // Click the remove button for Carol
+    await user.click(screen.getByLabelText("Remove Carol"));
+
+    // Confirmation dialog should appear
+    const confirmButton = await screen.findByRole("button", { name: "Remove" });
+    expect(screen.getByText(/Remove Carol from this workspace/)).toBeInTheDocument();
+
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledWith("m3");
+    });
+  });
+
+  // --- Owner protection ---
+
+  it("hides remove button for owner in a personal workspace", () => {
+    render(
+      <MemberList
+        {...defaultProps({
+          members: [owner, member],
+          currentUserId: "u3",
+          currentUserRole: "admin",
+          isPersonalWorkspace: true,
+        })}
+      />,
+    );
+
+    // Owner in personal workspace cannot be removed
+    expect(screen.queryByLabelText("Remove Alice")).not.toBeInTheDocument();
+  });
+
+  it("admin cannot remove another owner", () => {
+    const secondOwner = makeMember({
+      id: "m4",
+      user_id: "u4",
+      role: "owner",
+      profileOverrides: { display_name: "Dave", email: "dave@example.com" },
+    });
+
+    render(
+      <MemberList
+        {...defaultProps({
+          members: [owner, secondOwner, member],
+          currentUserId: "u2",
+          currentUserRole: "admin",
+        })}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Remove Alice")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove Dave")).not.toBeInTheDocument();
+  });
+
+  // --- Read-only view for non-admin ---
+
+  it("non-admin users see read-only view without remove buttons", () => {
+    render(
+      <MemberList
+        {...defaultProps({ currentUserId: "u3", currentUserRole: "member" })}
+      />,
+    );
+
+    // No remove buttons should be visible
+    expect(screen.queryByLabelText("Remove Alice")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove Bob")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove Carol")).not.toBeInTheDocument();
+
+    // No role selects — all roles shown as badges
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("non-admin users see role badges instead of selects", () => {
+    render(
+      <MemberList
+        {...defaultProps({ currentUserId: "u3", currentUserRole: "member" })}
+      />,
+    );
+
+    // All roles should be rendered as text badges
+    expect(screen.getByText("owner")).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.getByText("member")).toBeInTheDocument();
+  });
+
+  // --- Admin cannot change owner role ---
+
+  it("admin cannot change an owner's role", () => {
+    render(
+      <MemberList
+        {...defaultProps({ currentUserId: "u2", currentUserRole: "admin" })}
+      />,
+    );
+
+    // Alice is owner — admin should see a badge, not a select
+    const aliceRow = screen.getByText("Alice").closest("tr")!;
+    expect(within(aliceRow).queryByRole("combobox")).not.toBeInTheDocument();
+    expect(within(aliceRow).getByText("owner")).toBeInTheDocument();
+
+    // Carol is member — admin can change her role
+    const carolRow = screen.getByText("Carol").closest("tr")!;
+    expect(within(carolRow).getByRole("combobox")).toBeInTheDocument();
+  });
+});

--- a/src/components/members/pending-invite-list.test.tsx
+++ b/src/components/members/pending-invite-list.test.tsx
@@ -1,0 +1,172 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { PendingInviteList } from "./pending-invite-list";
+import type { WorkspaceInviteWithInviter } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const futureDate = new Date(Date.now() + 7 * 86_400_000).toISOString();
+const pastDate = new Date(Date.now() - 1 * 86_400_000).toISOString();
+
+function makeInvite(
+  overrides: Partial<WorkspaceInviteWithInviter> & {
+    profileOverrides?: Partial<WorkspaceInviteWithInviter["profiles"]>;
+  } = {},
+): WorkspaceInviteWithInviter {
+  const { profileOverrides, ...rest } = overrides;
+  return {
+    id: "inv1",
+    workspace_id: "ws1",
+    email: "dave@example.com",
+    role: "member",
+    invited_by: "u1",
+    token: "abc-123",
+    expires_at: futureDate,
+    accepted_at: null,
+    created_at: new Date().toISOString(),
+    profiles: { display_name: "Alice", ...profileOverrides },
+    ...rest,
+  };
+}
+
+const pendingInvite = makeInvite();
+const expiredInvite = makeInvite({
+  id: "inv2",
+  email: "eve@example.com",
+  role: "admin",
+  token: "def-456",
+  expires_at: pastDate,
+});
+
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PendingInviteList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Rendering ---
+
+  it("renders pending invites with email and role", () => {
+    renderWithTooltip(
+      <PendingInviteList invites={[pendingInvite, expiredInvite]} onRevoke={vi.fn()} />,
+    );
+
+    expect(screen.getByText("dave@example.com")).toBeInTheDocument();
+    expect(screen.getByText("eve@example.com")).toBeInTheDocument();
+    expect(screen.getByText("member")).toBeInTheDocument();
+    expect(screen.getByText("admin")).toBeInTheDocument();
+  });
+
+  it("shows invite count in the heading", () => {
+    renderWithTooltip(
+      <PendingInviteList invites={[pendingInvite, expiredInvite]} onRevoke={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Pending invites (2)")).toBeInTheDocument();
+  });
+
+  it("shows expiry date for non-expired invites", () => {
+    renderWithTooltip(
+      <PendingInviteList invites={[pendingInvite]} onRevoke={vi.fn()} />,
+    );
+
+    // Should show "Expires <date>" text
+    const expiryText = screen.getByText(/^Expires/);
+    expect(expiryText).toBeInTheDocument();
+  });
+
+  it("shows 'Expired' for expired invites", () => {
+    renderWithTooltip(
+      <PendingInviteList invites={[expiredInvite]} onRevoke={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+  });
+
+  // --- Revoke callback ---
+
+  it("fires onRevoke with invite id when revoke button is clicked", async () => {
+    const onRevoke = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    renderWithTooltip(
+      <PendingInviteList invites={[pendingInvite]} onRevoke={onRevoke} />,
+    );
+
+    const revokeButton = screen.getByLabelText("Revoke invite for dave@example.com");
+    await user.click(revokeButton);
+
+    await waitFor(() => {
+      expect(onRevoke).toHaveBeenCalledWith("inv1");
+    });
+  });
+
+  it("disables revoke button while revoking", async () => {
+    // Create a promise we control to keep the revoke in-flight
+    let resolveRevoke: () => void;
+    const onRevoke = vi.fn(
+      () => new Promise<void>((resolve) => { resolveRevoke = resolve; }),
+    );
+    const user = userEvent.setup();
+
+    renderWithTooltip(
+      <PendingInviteList invites={[pendingInvite]} onRevoke={onRevoke} />,
+    );
+
+    const revokeButton = screen.getByLabelText("Revoke invite for dave@example.com");
+    await user.click(revokeButton);
+
+    // Button should be disabled while the promise is pending
+    expect(revokeButton).toBeDisabled();
+
+    // Resolve the promise
+    resolveRevoke!();
+    await waitFor(() => {
+      expect(revokeButton).not.toBeDisabled();
+    });
+  });
+
+  it("fires onRevoke for the correct invite when multiple are present", async () => {
+    const onRevoke = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+
+    renderWithTooltip(
+      <PendingInviteList invites={[pendingInvite, expiredInvite]} onRevoke={onRevoke} />,
+    );
+
+    // Revoke the second invite (eve)
+    const revokeButton = screen.getByLabelText("Revoke invite for eve@example.com");
+    await user.click(revokeButton);
+
+    await waitFor(() => {
+      expect(onRevoke).toHaveBeenCalledWith("inv2");
+    });
+  });
+
+  // --- Empty state ---
+
+  it("renders empty table when no pending invites", () => {
+    renderWithTooltip(
+      <PendingInviteList invites={[]} onRevoke={vi.fn()} />,
+    );
+
+    expect(screen.getByText("Pending invites (0)")).toBeInTheDocument();
+    // Table headers should still be present
+    expect(screen.getByText("Email")).toBeInTheDocument();
+    expect(screen.getByText("Role")).toBeInTheDocument();
+    // No revoke buttons
+    expect(screen.queryByLabelText(/Revoke invite/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/members/role-select.test.tsx
+++ b/src/components/members/role-select.test.tsx
@@ -1,0 +1,117 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RoleSelect } from "./role-select";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RoleSelect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- Rendering ---
+
+  it("renders with the current role displayed", () => {
+    render(<RoleSelect value="admin" onChange={vi.fn()} />);
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveTextContent("admin");
+  });
+
+  it("renders with member role displayed", () => {
+    render(<RoleSelect value="member" onChange={vi.fn()} />);
+
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveTextContent("member");
+  });
+
+  // --- Options ---
+
+  it("shows admin and member options by default (no owner)", async () => {
+    const user = userEvent.setup();
+    render(<RoleSelect value="member" onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    const options = await screen.findAllByRole("option");
+    const optionTexts = options.map((o) => o.textContent);
+
+    expect(optionTexts).toContain("admin");
+    expect(optionTexts).toContain("member");
+    expect(optionTexts).not.toContain("owner");
+  });
+
+  it("includes owner option when includeOwner is true", async () => {
+    const user = userEvent.setup();
+    render(<RoleSelect value="admin" onChange={vi.fn()} includeOwner />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    const options = await screen.findAllByRole("option");
+    const optionTexts = options.map((o) => o.textContent);
+
+    expect(optionTexts).toContain("owner");
+    expect(optionTexts).toContain("admin");
+    expect(optionTexts).toContain("member");
+  });
+
+  // --- onChange callback ---
+
+  it("fires onChange with the new role when a different option is selected", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<RoleSelect value="member" onChange={onChange} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    const adminOption = await screen.findByRole("option", { name: "admin" });
+    await user.click(adminOption);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("admin");
+    });
+  });
+
+  it("fires onChange with owner role when owner is selected", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+
+    render(<RoleSelect value="member" onChange={onChange} includeOwner />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    const ownerOption = await screen.findByRole("option", { name: "owner" });
+    await user.click(ownerOption);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith("owner");
+    });
+  });
+
+  // --- All role options present ---
+
+  it("has exactly 3 options when includeOwner is true", async () => {
+    const user = userEvent.setup();
+    render(<RoleSelect value="member" onChange={vi.fn()} includeOwner />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    const options = await screen.findAllByRole("option");
+    expect(options).toHaveLength(3);
+  });
+
+  it("has exactly 2 options when includeOwner is false", async () => {
+    const user = userEvent.setup();
+    render(<RoleSelect value="member" onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    const options = await screen.findAllByRole("option");
+    expect(options).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #792

## What

Adds missing ARIA listbox semantics to the slash command menu and page-link dropdown so screen readers can announce the list context and active item.

## How

- **`slash-command-plugin.tsx`**: Added `role="listbox"`, `aria-label="Slash commands"`, and `aria-activedescendant` to the menu container. Each option button gets a unique `id` (`slash-cmd-option-{key}`).
- **`page-link-plugin.tsx`**: Added `role="listbox"`, `aria-label="Page search results"`, and `aria-activedescendant` to the results container. Each option button gets a unique `id` (`page-link-option-{id}`).

Both follow the existing pattern in `turn-into-menu.tsx`.

## Testing

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — passes
- `pnpm test` — 120 files, 1627 tests pass
- No E2E changes needed — this is an attribute-only accessibility fix with no new interactions