### PR TITLE
feat: add retry actions to database mutation error toasts (#797)

### DIFF
--- a/src/components/database/hooks/use-database-properties.test.ts
+++ b/src/components/database/hooks/use-database-properties.test.ts
@@ -225,9 +225,7 @@ describe("useDatabaseProperties", () => {
         await result.current.handleAddColumn("text");
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add column", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add column", expect.objectContaining({ duration: 8000 }));
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-properties:add");
       expect(setProperties).not.toHaveBeenCalled();
     });
@@ -246,9 +244,7 @@ describe("useDatabaseProperties", () => {
         await result.current.handleAddColumn("text");
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add column", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add column", expect.objectContaining({ duration: 8000 }));
       expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
     });
 
@@ -280,6 +276,35 @@ describe("useDatabaseProperties", () => {
 
       // Only one addProperty call should have been made
       expect(addPropertyMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes a Retry action that re-invokes handleAddColumn", async () => {
+      addPropertyMock.mockResolvedValue({
+        data: null,
+        error: new Error("network error"),
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleAddColumn("text");
+      });
+
+      const call = toastErrorMock.mock.calls[0];
+      expect(call[1]).toMatchObject({
+        action: { label: "Retry", onClick: expect.any(Function) },
+      });
+
+      // Invoke the retry callback — it should call addProperty again
+      addPropertyMock.mockClear();
+      addPropertyMock.mockResolvedValue({
+        data: makeProp("p-new", "Text", 2),
+        error: null,
+      });
+      await act(async () => {
+        call[1].action.onClick();
+      });
+      expect(addPropertyMock).toHaveBeenCalled();
     });
   });
 
@@ -343,7 +368,7 @@ describe("useDatabaseProperties", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to rename property",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-properties:rename");
       // Revert call: second setProperties call restores old name
@@ -451,7 +476,7 @@ describe("useDatabaseProperties", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to reorder columns",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-properties:reorder");
       // Revert: second setProperties call restores original
@@ -654,7 +679,7 @@ describe("useDatabaseProperties", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to delete column",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-view:delete-column");
       // Properties and views reverted

--- a/src/components/database/hooks/use-database-properties.ts
+++ b/src/components/database/hooks/use-database-properties.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   addProperty,
@@ -61,6 +61,9 @@ export function useDatabaseProperties({
   setViews,
   setRows,
 }: UseDatabasePropertiesParams): UseDatabasePropertiesReturn {
+  // Ref holds the latest handlers so retry closures always call the current version
+  const handlersRef = useRef<UseDatabasePropertiesReturn>(null);
+
   // Rename property dialog state
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [renamingProperty, setRenamingProperty] = useState<{
@@ -87,7 +90,13 @@ export function useDatabaseProperties({
           if (error && !isInsufficientPrivilegeError(error)) {
             captureSupabaseError(error, "database-properties:add");
           }
-          toast.error("Failed to add column", { duration: 8000 });
+          toast.error("Failed to add column", {
+            duration: 8000,
+            action: {
+              label: "Retry",
+              onClick: () => void handlersRef.current?.handleAddColumn(type),
+            },
+          });
           return;
         }
         setProperties((prev) => [...prev, newProp]);
@@ -123,7 +132,13 @@ export function useDatabaseProperties({
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-properties:rename");
         }
-        toast.error("Failed to rename property", { duration: 8000 });
+        toast.error("Failed to rename property", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handlePropertyRename(newName),
+          },
+        });
         // Revert
         setProperties((prev) =>
           prev.map((p) => (p.id === propertyId ? { ...p, name: oldName } : p)),
@@ -152,7 +167,13 @@ export function useDatabaseProperties({
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-properties:reorder");
         }
-        toast.error("Failed to reorder columns", { duration: 8000 });
+        toast.error("Failed to reorder columns", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleColumnReorder(orderedPropertyIds),
+          },
+        });
         setProperties(prevProperties);
       }
     },
@@ -210,7 +231,13 @@ export function useDatabaseProperties({
           if (!isInsufficientPrivilegeError(error)) {
             captureSupabaseError(error, "database-view:delete-column");
           }
-          toast.error("Failed to delete column", { duration: 8000 });
+          toast.error("Failed to delete column", {
+            duration: 8000,
+            action: {
+              label: "Retry",
+              onClick: () => handlersRef.current?.handleDeleteColumn(propertyId),
+            },
+          });
           // Revert all state
           setProperties(prevProperties);
           setViews(prevViews);
@@ -255,7 +282,7 @@ export function useDatabaseProperties({
   );
 
 
-  return {
+  const handlers: UseDatabasePropertiesReturn = {
     renameDialogOpen,
     setRenameDialogOpen,
     renamingProperty,
@@ -265,4 +292,7 @@ export function useDatabaseProperties({
     handleColumnReorder,
     handleDeleteColumn,
   };
+  useEffect(() => { handlersRef.current = handlers; });
+
+  return handlers;
 }

--- a/src/components/database/hooks/use-database-rows.test.ts
+++ b/src/components/database/hooks/use-database-rows.test.ts
@@ -185,9 +185,7 @@ describe("useDatabaseRows", () => {
         await result.current.handleAddRow();
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add row", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add row", expect.objectContaining({ duration: 8000 }));
       expect(setRows).not.toHaveBeenCalled();
     });
 
@@ -200,10 +198,34 @@ describe("useDatabaseRows", () => {
         await result.current.handleAddRow();
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add row", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to add row", expect.objectContaining({ duration: 8000 }));
       expect(setRows).not.toHaveBeenCalled();
+    });
+
+    it("passes a Retry action that re-invokes handleAddRow", async () => {
+      addRowMock.mockResolvedValue({
+        data: null,
+        error: new Error("network error"),
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleAddRow({ "prop-1": { option_id: "opt-a" } });
+      });
+
+      const call = toastErrorMock.mock.calls[0];
+      expect(call[1]).toMatchObject({
+        action: { label: "Retry", onClick: expect.any(Function) },
+      });
+
+      // Invoke the retry callback — it should call addRow again
+      addRowMock.mockClear();
+      addRowMock.mockResolvedValue({ data: null, error: null });
+      await act(async () => {
+        call[1].action.onClick();
+      });
+      expect(addRowMock).toHaveBeenCalledWith("db-1", "user-1", { "prop-1": { option_id: "opt-a" } });
     });
   });
 
@@ -269,9 +291,7 @@ describe("useDatabaseRows", () => {
         dbError,
         "database-view:move-card",
       );
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to move card", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to move card", expect.objectContaining({ duration: 8000 }));
     });
 
     it("skips captureSupabaseError for insufficient privilege errors", async () => {
@@ -286,9 +306,7 @@ describe("useDatabaseRows", () => {
       });
 
       expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to move card", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to move card", expect.objectContaining({ duration: 8000 }));
     });
   });
 
@@ -396,9 +414,7 @@ describe("useDatabaseRows", () => {
         });
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update cell", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update cell", expect.objectContaining({ duration: 8000 }));
       // Rollback: setRows called with the snapshot (not a function)
       const lastSetRowsCall = setRows.mock.calls[setRows.mock.calls.length - 1][0];
       // The rollback sets rows directly (not via updater function)
@@ -443,7 +459,7 @@ describe("useDatabaseRows", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to save new option",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       // Both rows and properties should be rolled back
       const lastSetRowsCall = setRows.mock.calls[setRows.mock.calls.length - 1][0];
@@ -467,8 +483,25 @@ describe("useDatabaseRows", () => {
       });
 
       expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update cell", {
-        duration: 8000,
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to update cell", expect.objectContaining({ duration: 8000 }));
+    });
+
+    it("passes a Retry action that re-invokes handleCellUpdate with original value", async () => {
+      updateRowValueMock.mockResolvedValue({
+        data: null,
+        error: new Error("network error"),
+      });
+
+      const { result } = setup();
+
+      const originalValue = { text: "hello", _newOptions: [{ id: "o1", name: "New", color: "blue" }] };
+      await act(async () => {
+        await result.current.handleCellUpdate("row-1", "prop-1", originalValue);
+      });
+
+      const call = toastErrorMock.mock.calls[0];
+      expect(call[1]).toMatchObject({
+        action: { label: "Retry", onClick: expect.any(Function) },
       });
     });
   });
@@ -603,9 +636,7 @@ describe("useDatabaseRows", () => {
         vi.advanceTimersByTime(5500);
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to delete row", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to delete row", expect.objectContaining({ duration: 8000 }));
       expect(loadDatabaseMock).toHaveBeenCalledWith("db-1");
       // setRows called with reloaded data
       const lastCall = setRows.mock.calls[setRows.mock.calls.length - 1][0];
@@ -630,9 +661,7 @@ describe("useDatabaseRows", () => {
       });
 
       expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to delete row", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to delete row", expect.objectContaining({ duration: 8000 }));
     });
   });
 });

--- a/src/components/database/hooks/use-database-rows.ts
+++ b/src/components/database/hooks/use-database-rows.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import {
   addRow,
@@ -42,6 +42,9 @@ export function useDatabaseRows({
   setRows,
   setProperties,
 }: UseDatabaseRowsParams): UseDatabaseRowsReturn {
+  // Ref holds the latest handlers so retry closures always call the current version
+  const handlersRef = useRef<UseDatabaseRowsReturn>(null);
+
   const handleAddRow = useCallback(
     async (initialValues?: Record<string, Record<string, unknown>>) => {
       const { data: rowPage, error } = await addRow(
@@ -50,7 +53,13 @@ export function useDatabaseRows({
         initialValues,
       );
       if (error || !rowPage) {
-        toast.error("Failed to add row", { duration: 8000 });
+        toast.error("Failed to add row", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleAddRow(initialValues),
+          },
+        });
         return;
       }
       // Build optimistic row_values from initialValues
@@ -113,7 +122,13 @@ export function useDatabaseRows({
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-view:move-card");
         }
-        toast.error("Failed to move card", { duration: 8000 });
+        toast.error("Failed to move card", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleCardMove(rowId, propertyId, newOptionId),
+          },
+        });
       }
     },
     [pageId, setRows],
@@ -173,6 +188,12 @@ export function useDatabaseRows({
       // Persist to DB: update property config first, then row value
       let shouldRollback = false;
 
+      // Retry uses the original value (with _newOptions) so the full operation reruns
+      const retryAction = {
+        label: "Retry",
+        onClick: () => void handlersRef.current?.handleCellUpdate(rowId, propertyId, value),
+      };
+
       if (newOptions) {
         const { error: configError } = await updateProperty(propertyId, {
           config: { options: newOptions },
@@ -181,7 +202,10 @@ export function useDatabaseRows({
           if (!isInsufficientPrivilegeError(configError)) {
             captureSupabaseError(configError, "database-view:update-property-options");
           }
-          toast.error("Failed to save new option", { duration: 8000 });
+          toast.error("Failed to save new option", {
+            duration: 8000,
+            action: retryAction,
+          });
           shouldRollback = true;
         }
       }
@@ -191,7 +215,10 @@ export function useDatabaseRows({
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-view:update-cell");
         }
-        toast.error("Failed to update cell", { duration: 8000 });
+        toast.error("Failed to update cell", {
+          duration: 8000,
+          action: retryAction,
+        });
         shouldRollback = true;
       }
 
@@ -230,7 +257,13 @@ export function useDatabaseRows({
           if (!isInsufficientPrivilegeError(error)) {
             captureSupabaseError(error, "database-view:delete-row");
           }
-          toast.error("Failed to delete row", { duration: 8000 });
+          toast.error("Failed to delete row", {
+            duration: 8000,
+            action: {
+              label: "Retry",
+              onClick: () => handlersRef.current?.handleDeleteRow(rowId),
+            },
+          });
           // Reload to restore
           const { data } = await loadDatabase(pageId);
           if (data) setRows(data.rows);
@@ -257,10 +290,13 @@ export function useDatabaseRows({
     [pageId, setRows],
   );
 
-  return {
+  const handlers: UseDatabaseRowsReturn = {
     handleAddRow,
     handleCardMove,
     handleCellUpdate,
     handleDeleteRow,
   };
+  useEffect(() => { handlersRef.current = handlers; });
+
+  return handlers;
 }

--- a/src/components/database/hooks/use-database-views.test.ts
+++ b/src/components/database/hooks/use-database-views.test.ts
@@ -316,9 +316,7 @@ describe("useDatabaseViews", () => {
         await result.current.handleAddView("table");
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to create view", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to create view", expect.objectContaining({ duration: 8000 }));
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:create");
       expect(setViews).not.toHaveBeenCalled();
     });
@@ -339,6 +337,35 @@ describe("useDatabaseViews", () => {
 
       expect(toastErrorMock).toHaveBeenCalled();
       expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
+    });
+
+    it("passes a Retry action that re-invokes handleAddView", async () => {
+      addViewMock.mockResolvedValue({
+        data: null,
+        error: new Error("network error"),
+      });
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.handleAddView("board");
+      });
+
+      const call = toastErrorMock.mock.calls[0];
+      expect(call[1]).toMatchObject({
+        action: { label: "Retry", onClick: expect.any(Function) },
+      });
+
+      // Invoke the retry callback — it should call addView again
+      addViewMock.mockClear();
+      addViewMock.mockResolvedValue({
+        data: makeView("view-new", { type: "board" }),
+        error: null,
+      });
+      await act(async () => {
+        call[1].action.onClick();
+      });
+      expect(addViewMock).toHaveBeenCalled();
     });
   });
 
@@ -395,7 +422,7 @@ describe("useDatabaseViews", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to update view configuration",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:update-config");
       // Revert: second setViews call restores original config
@@ -456,9 +483,7 @@ describe("useDatabaseViews", () => {
         await result.current.handleRenameView("view-1", "New Name");
       });
 
-      expect(toastErrorMock).toHaveBeenCalledWith("Failed to rename view", {
-        duration: 8000,
-      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to rename view", expect.objectContaining({ duration: 8000 }));
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:rename");
       expect(setViews).not.toHaveBeenCalled();
     });
@@ -505,7 +530,7 @@ describe("useDatabaseViews", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Cannot delete last view",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:delete");
       expect(setViews).not.toHaveBeenCalled();
@@ -524,7 +549,7 @@ describe("useDatabaseViews", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to delete view",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
     });
   });
@@ -597,7 +622,7 @@ describe("useDatabaseViews", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to duplicate view",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:duplicate");
       expect(setViews).not.toHaveBeenCalled();
@@ -668,7 +693,7 @@ describe("useDatabaseViews", () => {
 
       expect(toastErrorMock).toHaveBeenCalledWith(
         "Failed to reorder views",
-        { duration: 8000 },
+        expect.objectContaining({ duration: 8000 }),
       );
       expect(captureSupabaseErrorMock).toHaveBeenCalledWith(error, "database-views:reorder");
       expect(loadDatabaseMock).toHaveBeenCalledWith("db-1");

--- a/src/components/database/hooks/use-database-views.ts
+++ b/src/components/database/hooks/use-database-views.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { VIEW_TYPE_LABELS } from "@/components/database/view-tabs";
@@ -53,6 +53,9 @@ export function useDatabaseViews({
   views,
   setViews,
 }: UseDatabaseViewsParams): UseDatabaseViewsReturn {
+  // Ref holds the latest handlers so retry closures always call the current version
+  const handlersRef = useRef<UseDatabaseViewsReturn>(null);
+
   const searchParams = useSearchParams();
 
   // Active view: from URL ?view= param, or first view by position
@@ -104,7 +107,13 @@ export function useDatabaseViews({
         if (error && !isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-views:create");
         }
-        toast.error("Failed to create view", { duration: 8000 });
+        toast.error("Failed to create view", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleAddView(type),
+          },
+        });
         return;
       }
       setViews((prev) => [...prev, newView]);
@@ -134,7 +143,13 @@ export function useDatabaseViews({
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-views:update-config");
         }
-        toast.error("Failed to update view configuration", { duration: 8000 });
+        toast.error("Failed to update view configuration", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleViewConfigChange(configPatch),
+          },
+        });
         // Revert
         setViews((prev) =>
           prev.map((v) =>
@@ -156,7 +171,13 @@ export function useDatabaseViews({
         if (error && !isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-views:rename");
         }
-        toast.error("Failed to rename view", { duration: 8000 });
+        toast.error("Failed to rename view", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleRenameView(viewId, newName),
+          },
+        });
         return;
       }
       setViews((prev) =>
@@ -176,6 +197,10 @@ export function useDatabaseViews({
         }
         toast.error(error.message || "Failed to delete view", {
           duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleDeleteView(viewId),
+          },
         });
         return;
       }
@@ -211,7 +236,13 @@ export function useDatabaseViews({
         if (error && !isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-views:duplicate");
         }
-        toast.error("Failed to duplicate view", { duration: 8000 });
+        toast.error("Failed to duplicate view", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleDuplicateView(viewId),
+          },
+        });
         return;
       }
       setViews((prev) => [...prev, newView]);
@@ -242,7 +273,13 @@ export function useDatabaseViews({
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-views:reorder");
         }
-        toast.error("Failed to reorder views", { duration: 8000 });
+        toast.error("Failed to reorder views", {
+          duration: 8000,
+          action: {
+            label: "Retry",
+            onClick: () => void handlersRef.current?.handleReorderViews(orderedIds),
+          },
+        });
         // Reload to restore correct order
         const { data } = await loadDatabase(pageId);
         if (data) setViews(data.views);
@@ -251,7 +288,7 @@ export function useDatabaseViews({
     [pageId, setViews],
   );
 
-  return {
+  const handlers: UseDatabaseViewsReturn = {
     activeViewId,
     activeView,
     handleViewChange,
@@ -262,4 +299,7 @@ export function useDatabaseViews({
     handleDuplicateView,
     handleReorderViews,
   };
+  useEffect(() => { handlersRef.current = handlers; });
+
+  return handlers;
 }


### PR DESCRIPTION
Closes #797

## What

Adds a "Retry" action button to all 15 database mutation error toasts across `use-database-rows`, `use-database-properties`, and `use-database-views`. When a transient network error causes a mutation to fail, users can now recover with one click instead of manually redoing the operation.

## How

Each error toast now includes a `{ action: { label: "Retry", onClick: ... } }` option using sonner's built-in action support. The retry callback captures the original arguments in a closure and re-invokes the full operation (including optimistic updates and rollback).

To avoid self-referencing `useCallback` declarations (which triggers the `react-hooks/immutability` lint rule), a `handlersRef` pattern is used: a ref holds the latest handler functions, updated via `useEffect`, and retry closures call through the ref.

**Operations with retry actions:**
- `use-database-rows.ts`: add row, move card, update cell, save new option, delete row
- `use-database-properties.ts`: add column, rename property, reorder columns, delete column
- `use-database-views.ts`: create view, update config, rename view, delete view, duplicate view, reorder views

## Testing

- Updated existing toast assertions to use `expect.objectContaining` so they remain focused on their original concern
- Added retry-specific tests (one per hook) that verify the retry callback is passed to `toast.error` and re-invokes the operation when clicked
- `pnpm lint && pnpm typecheck && pnpm test` — all pass (0 errors, 1661 tests green)