### PR TITLE
fix: add List and Calendar sections to keyboard shortcuts dialog (#796)

### DIFF
--- a/src/components/keyboard-shortcuts-dialog.stories.tsx
+++ b/src/components/keyboard-shortcuts-dialog.stories.tsx
@@ -82,6 +82,41 @@ const macSections: ShortcutSection[] = [
       { keys: ["Shift", "Tab"], description: "Move to previous cell" },
     ],
   },
+  {
+    title: "Database Board",
+    shortcuts: [
+      { keys: ["↑", "↓"], description: "Navigate between cards in a column" },
+      { keys: ["←", "→"], description: "Navigate between columns" },
+      { keys: ["Enter"], description: "Open the focused card" },
+      { keys: ["Escape"], description: "Clear card focus" },
+    ],
+  },
+  {
+    title: "Database Gallery",
+    shortcuts: [
+      { keys: ["←", "→"], description: "Navigate between cards" },
+      { keys: ["↑", "↓"], description: "Navigate between rows" },
+      { keys: ["Enter"], description: "Open the focused card" },
+      { keys: ["Escape"], description: "Clear card focus" },
+    ],
+  },
+  {
+    title: "Database List",
+    shortcuts: [
+      { keys: ["↑", "↓"], description: "Navigate between rows" },
+      { keys: ["Enter"], description: "Open focused row" },
+      { keys: ["Home"], description: "Jump to first row" },
+      { keys: ["End"], description: "Jump to last row" },
+      { keys: ["Escape"], description: "Clear focus" },
+    ],
+  },
+  {
+    title: "Database Calendar",
+    shortcuts: [
+      { keys: ["←"], description: "Previous month" },
+      { keys: ["→"], description: "Next month" },
+    ],
+  },
 ];
 
 function ShortcutsContent({ sections }: { sections: ShortcutSection[] }) {

--- a/src/components/keyboard-shortcuts-dialog.tsx
+++ b/src/components/keyboard-shortcuts-dialog.tsx
@@ -89,6 +89,23 @@ function getShortcutSections(isMac: boolean): ShortcutSection[] {
         { keys: ["Escape"], description: "Clear card focus" },
       ],
     },
+    {
+      title: "Database List",
+      shortcuts: [
+        { keys: ["↑", "↓"], description: "Navigate between rows" },
+        { keys: ["Enter"], description: "Open focused row" },
+        { keys: ["Home"], description: "Jump to first row" },
+        { keys: ["End"], description: "Jump to last row" },
+        { keys: ["Escape"], description: "Clear focus" },
+      ],
+    },
+    {
+      title: "Database Calendar",
+      shortcuts: [
+        { keys: ["←"], description: "Previous month" },
+        { keys: ["→"], description: "Next month" },
+      ],
+    },
   ];
 }
 


### PR DESCRIPTION
Closes #796

## What

The keyboard shortcuts dialog documented shortcuts for Table, Board, and Gallery database views but omitted List and Calendar views. Both views have keyboard navigation implemented (`list-keyboard.ts` supports ↑/↓/Enter/Home/End/Escape; `calendar-view.tsx` supports ←/→ for month navigation), but users had no way to discover these shortcuts.

## How

Added two new entries to the `getShortcutSections` array in `keyboard-shortcuts-dialog.tsx`:
- **Database List**: ↑/↓ (navigate rows), Enter (open focused row), Home/End (jump to first/last row), Escape (clear focus)
- **Database Calendar**: ←/→ (previous/next month)

Also updated the Storybook story (`keyboard-shortcuts-dialog.stories.tsx`) which was missing the Board, Gallery, List, and Calendar sections from its hardcoded `macSections` array.

## Testing

- `pnpm lint` — passes (no new warnings)
- `pnpm typecheck` — passes
- `pnpm test` — all 123 test files, 1657 tests pass
- Visual regression baselines unchanged (new sections are below the scroll fold in the dialog's `max-h-[80vh]` container)
- No E2E tests exist for this dialog; the change is purely additive static data with no interaction or selector changes