### PR TITLE
fix: classify version-history-panel fetch errors as transient network warnings (#810)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -229,8 +229,24 @@ captureSupabaseError(error, "editor:save");
 lazyCaptureException(error);
 ```
 
-Reserve `lazyCaptureException` for non-Supabase errors (e.g. Lexical editor
-framework errors, unexpected runtime exceptions).
+Reserve `lazyCaptureException` for errors that have no structured classification
+(e.g. Lexical editor framework errors, unexpected runtime exceptions).
+
+### Always use `captureApiError` for internal API fetch errors
+
+Non-Supabase fetch calls (e.g. `/api/pages/…/versions`) must use `captureApiError`
+from `@/lib/sentry`, not `lazyCaptureException`. This classifies transient network
+errors (`TypeError: Failed to fetch`, `Load failed`) at warning level.
+
+```typescript
+import { captureApiError } from "@/lib/sentry";
+
+// ✅ Correct — classifies transient network errors
+captureApiError(error, "versions:fetch");
+
+// ❌ Wrong — bypasses transient network classification
+lazyCaptureException(error);
+```
 
 ### Retrying transient network errors
 

--- a/src/components/version-history-panel.tsx
+++ b/src/components/version-history-panel.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { History, RotateCcw } from "lucide-react";
 import type { SerializedEditorState } from "lexical";
 import { toast } from "@/lib/toast";
-import { lazyCaptureException } from "@/lib/capture";
+import { captureApiError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -54,7 +54,7 @@ export function VersionHistoryPanel({
       const data = (await res.json()) as { versions: VersionSummary[] };
       setVersions(data.versions);
     } catch (error) {
-      lazyCaptureException(error);
+      captureApiError(error, "versions:fetch");
       toast.error("Failed to load version history", { duration: 8000 });
     } finally {
       setLoading(false);
@@ -83,7 +83,7 @@ export function VersionHistoryPanel({
         };
         onPreview(data.version.content);
       } catch (error) {
-        lazyCaptureException(error);
+        captureApiError(error, "versions:select");
         toast.error("Failed to load version preview", { duration: 8000 });
         setSelectedId(null);
       }
@@ -114,7 +114,7 @@ export function VersionHistoryPanel({
       onOpenChange(false);
       toast.success("Version restored");
     } catch (error) {
-      lazyCaptureException(error);
+      captureApiError(error, "versions:restore");
       toast.error("Failed to restore version", { duration: 8000 });
     } finally {
       setRestoring(false);

--- a/src/lib/sentry.test.ts
+++ b/src/lib/sentry.test.ts
@@ -106,7 +106,8 @@ describe("error handling conventions", () => {
           // Check if Sentry capture exists anywhere in the same file
           const hasSentryCapture =
             content.includes("Sentry.captureException") ||
-            content.includes("captureSupabaseError");
+            content.includes("captureSupabaseError") ||
+            content.includes("captureApiError");
 
           if (!hasSentryCapture) {
             violations.push(`${rel}:${i + 1}`);
@@ -117,7 +118,7 @@ describe("error handling conventions", () => {
 
     expect(
       violations,
-      `console.error without Sentry capture found outside allowlist. Add Sentry.captureException or captureSupabaseError:\n${violations.join("\n")}`,
+      `console.error without Sentry capture found outside allowlist. Add Sentry.captureException, captureSupabaseError, or captureApiError:\n${violations.join("\n")}`,
     ).toEqual([]);
   });
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -371,6 +371,28 @@ export function isTransientNetworkError(error: Error): boolean {
 }
 
 /**
+ * Report an internal API fetch error to Sentry with structured context.
+ *
+ * Use this for non-Supabase fetch calls (e.g. `/api/pages/…/versions`).
+ * Transient network errors are captured at `warning` level to reduce noise.
+ * All other errors are captured at `error` level.
+ */
+export function captureApiError(error: unknown, operation: string): void {
+  const extra: Record<string, string> = { operation };
+
+  if (error instanceof Error) {
+    extra.message = error.message;
+
+    if (isTransientNetworkError(error)) {
+      lazyCaptureException(error, { extra, level: "warning" });
+      return;
+    }
+  }
+
+  lazyCaptureException(error, { extra });
+}
+
+/**
  * Report a Supabase error to Sentry with structured context.
  *
  * Accepts both PostgrestError (from query/mutation results) and generic Error

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -21,6 +21,7 @@ import {
   isSupabaseAuthLockError,
   isSupabaseAuthLockContention,
   captureSupabaseError,
+  captureApiError,
   isNextjsInternalNoise,
   isReactLexicalDomConflict,
 } from "./sentry";
@@ -1073,5 +1074,80 @@ describe("isSupabaseAuthLockContention", () => {
   it("returns false when exception is missing", () => {
     const event = { type: undefined } as ErrorEvent;
     expect(isSupabaseAuthLockContention(event)).toBe(false);
+  });
+});
+
+describe("captureApiError", () => {
+  beforeEach(() => {
+    captureExceptionMock.mockClear();
+  });
+
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it("captures transient network errors at warning level", async () => {
+    const error = new Error("TypeError: Failed to fetch");
+    captureApiError(error, "versions:fetch");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("versions:fetch");
+    expect(opts.extra.message).toBe("TypeError: Failed to fetch");
+  });
+
+  it("captures 'Failed to fetch' at warning level", async () => {
+    const error = new Error("Failed to fetch");
+    captureApiError(error, "versions:select");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("versions:select");
+  });
+
+  it("captures 'Load failed' (Safari) at warning level", async () => {
+    const error = new Error("Load failed");
+    captureApiError(error, "versions:restore");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("versions:restore");
+  });
+
+  it("captures non-transient errors at error level (default)", async () => {
+    const error = new Error("Failed to restore version: 500");
+    captureApiError(error, "versions:restore");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.level).toBeUndefined();
+    expect(opts.extra.operation).toBe("versions:restore");
+    expect(opts.extra.message).toBe("Failed to restore version: 500");
+  });
+
+  it("captures non-Error values at error level", async () => {
+    captureApiError("string error", "versions:fetch");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [err, opts] = captureExceptionMock.mock.calls[0];
+    expect(err).toBe("string error");
+    expect(opts.level).toBeUndefined();
+    expect(opts.extra.operation).toBe("versions:fetch");
+  });
+
+  it("includes operation in extra for all captures", async () => {
+    const error = new Error("some error");
+    captureApiError(error, "versions:select");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.extra.operation).toBe("versions:select");
   });
 });


### PR DESCRIPTION
Closes #810

## What

The version history panel (`version-history-panel.tsx`) used `lazyCaptureException(error)` directly in all three fetch catch blocks (`fetchVersions`, `handleSelectVersion`, `handleRestore`). This bypassed `isTransientNetworkError` classification, causing transient `TypeError: Failed to fetch` errors to be reported at error level instead of warning level in Sentry (MEMO-25).

## How

Added a `captureApiError(error, operation)` helper in `src/lib/sentry.ts` for non-Supabase internal API fetch errors. It checks `isTransientNetworkError` and downgrades transient failures to warning level, mirroring the pattern `captureSupabaseError` uses for Supabase errors. Replaced all three `lazyCaptureException` calls in `version-history-panel.tsx` with `captureApiError`.

Also updated:
- `sentry.test.ts` static analysis to recognize `captureApiError` alongside `captureSupabaseError`
- `.agents/conventions.md` to document the new convention for internal API fetch error handling

## Testing

- 6 new unit tests in `sentry.unit.test.ts` verify `captureApiError` captures transient network errors (`TypeError: Failed to fetch`, `Failed to fetch`, `Load failed`) at warning level and non-transient errors at error level
- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 1671 tests pass