### PR TITLE
fix: disable Sentry in E2E test sessions (#811)

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -19,6 +19,13 @@ export const test = base.extend<{ authenticatedPage: Page }>({
     const context = await browser.newContext();
     const page = await context.newPage();
 
+    // Disable Sentry in E2E sessions to prevent simulated errors from
+    // generating real Sentry events in production. The flag is checked
+    // by the beforeSend filter in instrumentation-client.ts.
+    await page.addInitScript(() => {
+      (window as unknown as Record<string, unknown>).__SENTRY_DISABLED__ = true;
+    });
+
     await page.goto("/sign-in");
 
     // Wait for React hydration to complete before filling controlled inputs.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -9,6 +9,7 @@ import("@sentry/nextjs").then(async (Sentry) => {
   // The filter functions only inspect the event object — they have no
   // Sentry runtime dependency.
   const {
+    isE2ETestSession,
     isNextjsInternalNoise,
     isReactLexicalDomConflict,
     isSupabaseAuthLockContention,
@@ -31,6 +32,7 @@ import("@sentry/nextjs").then(async (Sentry) => {
     integrations: [Sentry.replayIntegration()],
 
     beforeSend(event) {
+      if (isE2ETestSession()) return null;
       if (isNextjsInternalNoise(event)) return null;
       if (isReactLexicalDomConflict(event)) return null;
       if (isSupabaseAuthLockContention(event)) return null;

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -5,6 +5,19 @@ import { lazyCaptureException } from "@/lib/capture";
 export { lazyCaptureException } from "@/lib/capture";
 
 /**
+ * Returns true when the current browser session is an E2E test run.
+ * Playwright's auth fixture sets `window.__SENTRY_DISABLED__` via
+ * `addInitScript` to prevent simulated errors from generating real
+ * Sentry events in production.
+ */
+export function isE2ETestSession(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    (window as unknown as Record<string, unknown>).__SENTRY_DISABLED__ === true
+  );
+}
+
+/**
  * Duck-type check for Supabase PostgrestError. Avoids importing the class
  * from `@supabase/supabase-js` which would pull the entire SDK (~59 kB)
  * into every page bundle.

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ErrorEvent } from "@sentry/nextjs";
 import { PostgrestError } from "@supabase/supabase-js";
 
@@ -24,6 +24,7 @@ import {
   captureApiError,
   isNextjsInternalNoise,
   isReactLexicalDomConflict,
+  isE2ETestSession,
 } from "./sentry";
 
 function makePostgrestError(
@@ -1149,5 +1150,32 @@ describe("captureApiError", () => {
     expect(captureExceptionMock).toHaveBeenCalledOnce();
     const [, opts] = captureExceptionMock.mock.calls[0];
     expect(opts.extra.operation).toBe("versions:select");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isE2ETestSession — prevents simulated E2E errors from reaching Sentry
+// ---------------------------------------------------------------------------
+
+describe("isE2ETestSession", () => {
+  const win = window as unknown as Record<string, unknown>;
+
+  afterEach(() => {
+    delete win.__SENTRY_DISABLED__;
+  });
+
+  it("returns true when __SENTRY_DISABLED__ is set on window", () => {
+    win.__SENTRY_DISABLED__ = true;
+    expect(isE2ETestSession()).toBe(true);
+  });
+
+  it("returns false when __SENTRY_DISABLED__ is not set", () => {
+    delete win.__SENTRY_DISABLED__;
+    expect(isE2ETestSession()).toBe(false);
+  });
+
+  it("returns false when __SENTRY_DISABLED__ is a non-true value", () => {
+    win.__SENTRY_DISABLED__ = "true";
+    expect(isE2ETestSession()).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #811

## What

E2E error-recovery tests (`database-error-recovery.spec.ts`) use Playwright `page.route()` to intercept Supabase REST calls and return simulated PGRST500 errors. These simulated errors flow through `captureSupabaseError()` → `lazyCaptureException()` → real Sentry events in production, creating noise that obscures genuine errors (Sentry MEMO-26, MEMO-27, MEMO-28).

## How

Set `window.__SENTRY_DISABLED__ = true` via Playwright's `addInitScript` in the E2E auth fixture (`e2e/fixtures/auth.ts`). The Sentry `beforeSend` filter in `instrumentation-client.ts` checks this flag and drops all events when it's set. The detection logic is extracted into a testable `isE2ETestSession()` function in `src/lib/sentry.ts`.

## Testing

- Added 3 unit tests for `isE2ETestSession()` in `sentry.unit.test.ts`: flag set (returns true), flag absent (returns false), non-boolean value (returns false).
- `pnpm lint && pnpm typecheck && pnpm test` all pass (0 errors, 1668 tests).
- E2E tests require the dev server and auth credentials — CI will validate.