### PR TITLE
feat: add data-testid attributes to editor components (#790)

### DIFF
--- a/e2e/editor-auto-save.spec.ts
+++ b/e2e/editor-auto-save.spec.ts
@@ -63,7 +63,7 @@ test.describe("Editor auto-save", () => {
     await expect(editor).toBeVisible({ timeout: 10_000 });
 
     // The save status container is below the editor
-    const saveIndicator = page.locator("main .text-muted-foreground").last();
+    const saveIndicator = page.getByTestId("editor-save-status");
 
     // Type content to trigger auto-save
     await editor.click();

--- a/e2e/editor-callout-collapsible.spec.ts
+++ b/e2e/editor-callout-collapsible.spec.ts
@@ -32,17 +32,17 @@ test.describe("Callout block", () => {
     await insertViaSlashCommand(page, "Callout");
 
     // The callout renders as a div with border-l-2 and an emoji span
-    const callout = editor.locator(".callout-emoji").first();
-    await expect(callout).toBeVisible({ timeout: 3_000 });
+    const calloutContainer = editor.getByTestId("editor-callout").first();
+    await expect(calloutContainer).toBeVisible({ timeout: 3_000 });
 
     // Verify the callout container has distinct styling (border-l-2 class)
     // that differentiates it from a code block
-    const calloutContainer = callout.locator("..");
     await expect(calloutContainer).toHaveClass(/border-l-2/);
     await expect(calloutContainer).toHaveClass(/bg-muted/);
 
     // The emoji should be the default 💡
-    await expect(callout).toHaveText("💡");
+    const calloutEmoji = calloutContainer.getByTestId("editor-callout-emoji");
+    await expect(calloutEmoji).toHaveText("💡");
 
     // Verify it does NOT look like a code block — code blocks use <code>
     // elements, callouts use a div with border-l styling
@@ -78,7 +78,7 @@ test.describe("Collapsible/Toggle block", () => {
     await expect(content).toBeVisible();
 
     // Click the chevron toggle button to collapse
-    const chevron = details.locator(".collapsible-toggle").first();
+    const chevron = details.getByTestId("editor-collapsible-toggle").first();
     await expect(chevron).toBeVisible();
     await chevron.click();
 
@@ -122,7 +122,7 @@ test.describe("Collapsible/Toggle block", () => {
     await expect(contentArea).toContainText("My custom toggle content");
 
     // Collapse and re-expand to verify content persists
-    const chevron = details.locator(".collapsible-toggle").first();
+    const chevron = details.getByTestId("editor-collapsible-toggle").first();
     await chevron.click();
     await expect(details).not.toHaveAttribute("open", "", { timeout: 2_000 });
 

--- a/e2e/editor-drag.spec.ts
+++ b/e2e/editor-drag.spec.ts
@@ -39,7 +39,7 @@ test.describe("Editor drag-and-drop", () => {
     await block.hover();
 
     // The drag handle should become visible
-    const dragHandle = page.locator(".memo-draggable-block-menu");
+    const dragHandle = page.getByTestId("editor-drag-handle");
     await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
   });
 
@@ -69,7 +69,7 @@ test.describe("Editor drag-and-drop", () => {
 
     await page.mouse.move(blockBox.x + blockBox.width / 2, blockBox.y + blockBox.height / 2);
 
-    const dragHandle = page.locator(".memo-draggable-block-menu");
+    const dragHandle = page.getByTestId("editor-drag-handle");
     await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
 
     // Move cursor left toward the drag handle
@@ -107,7 +107,7 @@ test.describe("Editor drag-and-drop", () => {
     await expect(blockOne).toBeVisible({ timeout: 3_000 });
     await blockOne.hover();
 
-    const dragHandle = page.locator(".memo-draggable-block-menu");
+    const dragHandle = page.getByTestId("editor-drag-handle");
     await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
 
     // Verify the drag handle has the draggable attribute
@@ -139,7 +139,7 @@ test.describe("Editor drag-and-drop", () => {
     await expect(block).toBeVisible({ timeout: 3_000 });
     await block.hover();
 
-    const dragHandle = page.locator(".memo-draggable-block-menu");
+    const dragHandle = page.getByTestId("editor-drag-handle");
     await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
 
     const handleBox = await dragHandle.boundingBox();

--- a/e2e/editor-turn-into.spec.ts
+++ b/e2e/editor-turn-into.spec.ts
@@ -37,7 +37,7 @@ async function openTurnIntoMenu(
   block: Locator,
 ): Promise<Locator> {
   await block.hover();
-  const dragHandle = page.locator(".memo-draggable-block-menu");
+  const dragHandle = page.getByTestId("editor-drag-handle");
   await expect(dragHandle).toHaveCSS("opacity", "1", { timeout: 2_000 });
   await dragHandle.click();
 

--- a/src/components/editor/callout-node.tsx
+++ b/src/components/editor/callout-node.tsx
@@ -81,11 +81,13 @@ export class CalloutNode extends ElementNode {
     div.className = `${BASE_CLASSES} ${VARIANT_CLASSES[this.__variant]}`;
     div.role = "note";
     div.setAttribute("aria-label", VARIANT_LABELS[this.__variant]);
+    div.setAttribute("data-testid", "editor-callout");
 
     const emojiSpan = document.createElement("span");
     emojiSpan.className = "callout-emoji select-none text-lg shrink-0";
     emojiSpan.contentEditable = "false";
     emojiSpan.setAttribute("aria-hidden", "true");
+    emojiSpan.setAttribute("data-testid", "editor-callout-emoji");
     emojiSpan.textContent = this.__emoji;
     div.appendChild(emojiSpan);
 

--- a/src/components/editor/collapsible-node.tsx
+++ b/src/components/editor/collapsible-node.tsx
@@ -58,6 +58,7 @@ export class CollapsibleContainerNode extends ElementNode {
     const details = document.createElement("details");
     details.className =
       "mt-3 border border-overlay-border text-sm rounded-sm";
+    details.setAttribute("data-testid", "editor-collapsible");
     if (this.__open) {
       details.open = true;
     }
@@ -136,6 +137,7 @@ export class CollapsibleTitleNode extends ElementNode {
     chevron.className =
       "collapsible-toggle flex-shrink-0 flex items-center justify-center w-5 h-5 rounded-sm text-muted-foreground hover:text-foreground hover:bg-overlay-active transition-transform duration-150";
     chevron.setAttribute("aria-label", "Toggle section");
+    chevron.setAttribute("data-testid", "editor-collapsible-toggle");
     chevron.innerHTML =
       '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"></polyline></svg>';
     summary.prepend(chevron);

--- a/src/components/editor/draggable-block-plugin.tsx
+++ b/src/components/editor/draggable-block-plugin.tsx
@@ -437,6 +437,7 @@ export function DraggableBlockPlugin({
         aria-label="Drag to reorder block, click for block menu"
         role="button"
         tabIndex={0}
+        data-testid="editor-drag-handle"
       >
         <GripVertical className="h-5 w-5 text-muted-foreground hover:text-foreground" />
       </div>

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -437,7 +437,7 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
         {editorRef && <EditorRefPlugin editorRef={editorRef} />}
       </LexicalComposer>
       {!readOnly && (
-        <div className="mt-2 h-5 text-xs text-muted-foreground">
+        <div className="mt-2 h-5 text-xs text-muted-foreground" data-testid="editor-save-status">
           {saveStatus === "saving" && "Saving..."}
           {saveStatus === "saved" && "Saved"}
           {saveStatus === "error" && (

--- a/src/components/editor/floating-image-toolbar-plugin.tsx
+++ b/src/components/editor/floating-image-toolbar-plugin.tsx
@@ -183,11 +183,13 @@ export function FloatingImageToolbarPlugin({
           role="toolbar"
           aria-label="Image tools"
           onMouseDown={(e) => e.preventDefault()}
+          data-testid="editor-image-toolbar"
         >
           <ToolbarButton
             active={selectedImageNode.alignment === "left"}
             onClick={() => setAlignment("left")}
             label="Align left"
+            testId="editor-image-align-left"
           >
             <AlignLeft className="h-4 w-4" />
           </ToolbarButton>
@@ -195,6 +197,7 @@ export function FloatingImageToolbarPlugin({
             active={selectedImageNode.alignment === "center"}
             onClick={() => setAlignment("center")}
             label="Align center"
+            testId="editor-image-align-center"
           >
             <AlignCenter className="h-4 w-4" />
           </ToolbarButton>
@@ -202,6 +205,7 @@ export function FloatingImageToolbarPlugin({
             active={selectedImageNode.alignment === "right"}
             onClick={() => setAlignment("right")}
             label="Align right"
+            testId="editor-image-align-right"
           >
             <AlignRight className="h-4 w-4" />
           </ToolbarButton>
@@ -210,6 +214,7 @@ export function FloatingImageToolbarPlugin({
             active={false}
             onClick={() => setCropOpen(true)}
             label="Crop image"
+            testId="editor-image-crop"
           >
             <Crop className="h-4 w-4" />
           </ToolbarButton>
@@ -217,6 +222,7 @@ export function FloatingImageToolbarPlugin({
             active={false}
             onClick={() => setExpandOpen(true)}
             label="Expand image"
+            testId="editor-image-expand"
           >
             <Maximize2 className="h-4 w-4" />
           </ToolbarButton>
@@ -224,6 +230,7 @@ export function FloatingImageToolbarPlugin({
             active={false}
             onClick={handleDownload}
             label="Download image"
+            testId="editor-image-download"
           >
             <Download className="h-4 w-4" />
           </ToolbarButton>
@@ -249,11 +256,13 @@ function ToolbarButton({
   active,
   onClick,
   label,
+  testId,
   children,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
+  testId?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -267,6 +276,7 @@ function ToolbarButton({
       onClick={onClick}
       aria-label={label}
       aria-pressed={active}
+      data-testid={testId}
     >
       {children}
     </button>

--- a/src/components/editor/floating-link-editor-plugin.tsx
+++ b/src/components/editor/floating-link-editor-plugin.tsx
@@ -201,6 +201,7 @@ export function FloatingLinkEditorPlugin({
       ref={editorRef}
       className="fixed z-50 flex items-center gap-1 border border-overlay-border bg-popover px-2 py-1.5 shadow-md rounded-sm"
       onMouseDown={(e) => e.stopPropagation()}
+      data-testid="editor-link-editor"
     >
       {isEditing ? (
         <>
@@ -212,12 +213,14 @@ export function FloatingLinkEditorPlugin({
             onKeyDown={handleKeyDown}
             className="h-6 w-48 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground"
             placeholder="Enter URL..."
+            data-testid="editor-link-input"
           />
           <button
             type="button"
             className="flex h-11 w-11 sm:h-6 sm:w-6 items-center justify-center text-muted-foreground hover:text-foreground"
             onClick={handleSave}
             aria-label="Save link"
+            data-testid="editor-link-save"
           >
             <Check className="h-3.5 w-3.5" />
           </button>
@@ -229,6 +232,7 @@ export function FloatingLinkEditorPlugin({
               setEditedUrl(linkUrl);
             }}
             aria-label="Cancel"
+            data-testid="editor-link-cancel"
           >
             <X className="h-3.5 w-3.5" />
           </button>
@@ -240,6 +244,7 @@ export function FloatingLinkEditorPlugin({
             target="_blank"
             rel="noopener noreferrer"
             className="max-w-[200px] truncate text-xs text-accent hover:underline"
+            data-testid="editor-link-url"
           >
             {linkUrl}
           </a>
@@ -248,6 +253,7 @@ export function FloatingLinkEditorPlugin({
             className="flex h-11 w-11 sm:h-6 sm:w-6 items-center justify-center text-muted-foreground hover:text-foreground"
             onClick={() => window.open(linkUrl, "_blank", "noopener")}
             aria-label="Open link"
+            data-testid="editor-link-open"
           >
             <ExternalLink className="h-3.5 w-3.5" />
           </button>
@@ -256,6 +262,7 @@ export function FloatingLinkEditorPlugin({
             className="flex h-11 w-11 sm:h-6 sm:w-6 items-center justify-center text-muted-foreground hover:text-foreground"
             onClick={() => setIsEditing(true)}
             aria-label="Edit link"
+            data-testid="editor-link-edit"
           >
             <Pencil className="h-3.5 w-3.5" />
           </button>
@@ -264,6 +271,7 @@ export function FloatingLinkEditorPlugin({
             className="flex h-11 w-11 sm:h-6 sm:w-6 items-center justify-center text-destructive hover:text-destructive/80"
             onClick={handleRemove}
             aria-label="Remove link"
+            data-testid="editor-link-remove"
           >
             <Trash2 className="h-3.5 w-3.5" />
           </button>

--- a/src/components/editor/floating-toolbar-plugin.tsx
+++ b/src/components/editor/floating-toolbar-plugin.tsx
@@ -172,11 +172,13 @@ export function FloatingToolbarPlugin({
       className="fixed z-50 flex items-center gap-0.5 border border-overlay-border bg-popover p-1 shadow-md"
       role="toolbar"
       aria-label="Text formatting"
+      data-testid="editor-toolbar"
     >
       <ToolbarButton
         active={isBold}
         onClick={formatBold}
         label="Bold (⌘+B)"
+        testId="editor-toolbar-bold"
       >
         <Bold className="h-4 w-4" />
       </ToolbarButton>
@@ -184,6 +186,7 @@ export function FloatingToolbarPlugin({
         active={isItalic}
         onClick={formatItalic}
         label="Italic (⌘+I)"
+        testId="editor-toolbar-italic"
       >
         <Italic className="h-4 w-4" />
       </ToolbarButton>
@@ -191,6 +194,7 @@ export function FloatingToolbarPlugin({
         active={isUnderline}
         onClick={formatUnderline}
         label="Underline (⌘+U)"
+        testId="editor-toolbar-underline"
       >
         <Underline className="h-4 w-4" />
       </ToolbarButton>
@@ -198,6 +202,7 @@ export function FloatingToolbarPlugin({
         active={isStrikethrough}
         onClick={formatStrikethrough}
         label="Strikethrough"
+        testId="editor-toolbar-strikethrough"
       >
         <Strikethrough className="h-4 w-4" />
       </ToolbarButton>
@@ -205,6 +210,7 @@ export function FloatingToolbarPlugin({
         active={isCode}
         onClick={formatCode}
         label="Inline code"
+        testId="editor-toolbar-code"
       >
         <Code className="h-4 w-4" />
       </ToolbarButton>
@@ -212,6 +218,7 @@ export function FloatingToolbarPlugin({
         active={isLink}
         onClick={toggleLink}
         label="Link (⌘+K)"
+        testId="editor-toolbar-link"
       >
         <Link className="h-4 w-4" />
       </ToolbarButton>
@@ -224,11 +231,13 @@ function ToolbarButton({
   active,
   onClick,
   label,
+  testId,
   children,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
+  testId?: string;
   children: ReactNode;
 }) {
   return (
@@ -243,6 +252,7 @@ function ToolbarButton({
       onClick={onClick}
       aria-label={label}
       aria-pressed={active}
+      data-testid={testId}
     >
       {children}
     </button>

--- a/src/components/editor/image-node.tsx
+++ b/src/components/editor/image-node.tsx
@@ -274,6 +274,7 @@ function ImageComponent({
     <figure
       className={`mt-3 flex flex-col ${ALIGNMENT_CLASSES[alignment]}`}
       data-image-node-key={nodeKey}
+      data-testid="editor-image"
     >
       <div className="relative inline-block">
         {/* eslint-disable-next-line @next/next/no-img-element -- Lexical DecoratorNode with user-uploaded dynamic URLs */}

--- a/src/components/editor/slash-command-plugin.tsx
+++ b/src/components/editor/slash-command-plugin.tsx
@@ -336,6 +336,7 @@ export function SlashCommandPlugin(): JSX.Element | null {
             className="fixed z-50 max-h-[300px] w-64 overflow-y-auto rounded-sm border border-overlay-border bg-popover p-1 shadow-md"
             role="listbox"
             aria-label="Slash commands"
+            data-testid="editor-slash-menu"
             aria-activedescendant={
               selectedIndex !== null && items[selectedIndex]
                 ? `slash-cmd-option-${items[selectedIndex].key}`
@@ -356,6 +357,7 @@ export function SlashCommandPlugin(): JSX.Element | null {
                 onMouseEnter={() => setHighlightedIndex(index)}
                 role="option"
                 aria-selected={selectedIndex === index}
+                data-testid={`editor-slash-item-${option.title.toLowerCase().replace(/\s+/g, "-")}`}
               >
                 <span className="flex h-8 w-8 shrink-0 items-center justify-center text-muted-foreground">
                   {option.icon}


### PR DESCRIPTION
Closes #790

## What

Adds stable `data-testid` attributes to editor components and migrates E2E tests from fragile CSS class selectors to `getByTestId()`.

## Why

Editor E2E tests used CSS selectors (`.callout-emoji`, `.collapsible-toggle`, `.memo-draggable-block-menu`, `main .text-muted-foreground`) that break when styling or DOM structure changes. This caused frequent E2E regressions after UI refactors.

## Changes

**Components — `data-testid` attributes added:**
- Slash command menu: `editor-slash-menu` (container), `editor-slash-item-{name}` (items)
- Floating text toolbar: `editor-toolbar` (container), `editor-toolbar-{bold,italic,underline,strikethrough,code,link}` (buttons)
- Floating link editor: `editor-link-editor` (container), `editor-link-input`, `editor-link-save`, `editor-link-cancel`, `editor-link-url`, `editor-link-open`, `editor-link-edit`, `editor-link-remove`
- Drag handle: `editor-drag-handle`
- Callout: `editor-callout` (container), `editor-callout-emoji`
- Collapsible: `editor-collapsible` (container), `editor-collapsible-toggle`
- Image: `editor-image` (figure)
- Image toolbar: `editor-image-toolbar` (container), `editor-image-{align-left,align-center,align-right,crop,expand,download}`
- Save status: `editor-save-status`

**E2E tests updated:**
- `editor-callout-collapsible.spec.ts` — `.callout-emoji` → `getByTestId("editor-callout-emoji")`, `.collapsible-toggle` → `getByTestId("editor-collapsible-toggle")`
- `editor-drag.spec.ts` — `.memo-draggable-block-menu` → `getByTestId("editor-drag-handle")`
- `editor-turn-into.spec.ts` — `.memo-draggable-block-menu` → `getByTestId("editor-drag-handle")`
- `editor-auto-save.spec.ts` — `main .text-muted-foreground` → `getByTestId("editor-save-status")`

## Testing

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — passes
- `pnpm test` — 124 files, 1678 tests pass
- E2E: all modified editor specs pass (callout-collapsible, drag, turn-into, auto-save, slash-commands, image-upload)
- 3 pre-existing flaky E2E failures in `editor-link` and `editor-toolbar` confirmed on `main` — not caused by this PR