### PR TITLE
chore: weekly recap 2026-W18

### DIFF
--- a/metrics/weekly/2026-W18.md
+++ b/metrics/weekly/2026-W18.md
@@ -1,0 +1,107 @@
+# Week 18 Recap — Apr 21–27, 2026
+
+Second week. The agents built a full database system (Notion-style tables, boards, calendars, galleries), added OAuth login, shipped a feedback widget, and wrote 1,600 new tests.
+
+## Highlights
+
+- **Database views shipped end-to-end.** Table, board, calendar, gallery, and list views with inline editing, drag-and-drop, sort/filter, formulas, relations, and multi-view management — 40+ PRs across 6 days.
+- **OAuth sign-in with GitHub and Google.** Users can now log in without a password.
+- **Light mode and theme toggle.** The app was dark-only until this week.
+- **1,941 tests total** (up from 344). Test coverage went from unmeasured to 38%.
+
+## By the Numbers
+
+| Metric | This Week | Cumulative | Delta |
+|---|---|---|---|
+| Lines of code | +50,335 | 62,927 | +400% |
+| PRs merged | 271 | 448 | |
+| Test coverage | 38.12% | 38.12% | +38.12pp |
+| Tests (Vitest / E2E) | +1,597 | 1,657 / 284 | +464% |
+| Issues completed | 242 | 337 | 6 remaining |
+| Human time | not yet recorded | not yet recorded | |
+| Agent time | not yet recorded | not yet recorded | |
+| CI pass rate | 94.9–100% | — | |
+
+## Features Shipped
+
+### Database Views (Days 9–14)
+- **Schema and CRUD** — database_properties, database_views, row_values tables with RLS. PR #449, #453.
+- **Table view** — spreadsheet grid with inline editing, column resize, drag-and-drop reorder. PR #456, #535, #624.
+- **Board view** — Kanban columns grouped by select/status property. PR #473.
+- **Calendar view** — month grid with date-positioned items. PR #481.
+- **Gallery view** — responsive card grid with cover images. PR #478.
+- **List view** — compact row list with configurable visible properties. PR #474.
+- **Multi-view management** — create, rename, delete, reorder views per database. PR #475.
+- **Property types** — text, number, select, multi-select, date, checkbox, person, files, relation, formula, created_time, updated_time, created_by, status. PR #459, #465, #467, #470, #472, #480, #668.
+- **Row-as-page** — open any database row as a full page with properties header. PR #468.
+- **Sort and filter engine** — client-side filtering/sorting with a toolbar UI. PR #464, #516, #633, #641.
+- **Inline database embed** — embed database views inside regular pages via a Lexical node. PR #492.
+- **Sidebar integration** — grid icon for databases, "New Database" option. PR #487.
+- **CSV export** — download table view data as CSV. PR #728.
+- **Undo via toast** — destructive operations (delete row, delete column) show an undo toast. PR #715.
+- **Retry toasts** — failed mutations show a "Retry" button in the error toast. PR #798.
+- **Row count status bar** — shows total and filtered row counts. PR #727.
+
+### Auth & Account (Day 9)
+- **OAuth sign-in** — GitHub and Google providers. PR #336.
+- **Soft-delete pages with trash bin** — deleted pages go to trash, restorable for 30 days. PR #346.
+
+### Editor (Days 9–12)
+- **Table blocks** — insert and edit tables inside the editor. PR #339.
+- **Inline page links and backlinks** — link to other pages, see what links back. PR #338.
+- **"Turn into" block transformation** — convert any block to a different type. PR #424.
+- **Auto-link URLs** — typed or pasted URLs become clickable links. PR #358.
+- **Code block language selector** — syntax highlighting with language picker. PR #370.
+- **Focus mode** — hide sidebar, center content for distraction-free writing. PR #367.
+
+### Workspace & Navigation (Day 9)
+- **Breadcrumb navigation** for nested pages. PR #309.
+- **Recently visited pages** on workspace home. PR #313.
+- **Sidebar favorites** — pin pages for quick access. PR #314.
+- **Persist sidebar expand/collapse state.** PR #345.
+- **Page version history** with restore. PR #354.
+- **Page cover images.** PR #355.
+- **Word count and reading time.** PR #310.
+- **Page duplication.** PR #311.
+- **Keyboard shortcut help dialog.** PR #312.
+- **Workspace home sorting and filtering.** PR #365.
+
+### Feedback & Analytics (Day 10)
+- **Feedback widget** — in-app feedback form with screenshot capture. PR #418, #419.
+- **Usage event tracking** — anonymous usage events for product analytics. PR #412.
+- **Feedback digest automation** — daily categorized digest posted to Slack. PR #411.
+
+### Theming (Day 12)
+- **Light mode with toggle** — system preference detection, manual override. PR #639.
+
+### Accessibility (Days 12–14)
+- **ARIA roles and labels** across board, calendar, gallery, filter bar, callout blocks, slash command menu. PR #667, #761, #776, #789, #795.
+- **Keyboard navigation** for database table (arrow keys), board, gallery, list views. PR #672, #744, #773.
+- **Skip-to-content link** for keyboard and screen reader users. PR #702.
+
+### Testing (Days 9–14)
+- **32 test PRs merged** — 20 new E2E test suites, 12 unit test suites.
+- **E2E coverage added for:** trash/soft-delete, favorites, version history, cover images, table blocks, page duplication, database CRUD, board view, row-as-page, calendar, gallery, list, inline database, turn-into, focus mode, auto-link, formula/files/relation types, property type picker, error recovery, not-found pages.
+- **Unit test coverage added for:** database column add, mutation hooks, property type renderers, view tabs, table cells, filter bar, row properties, select dropdown, board/calendar/gallery/list views, member list, pending invites.
+
+### Performance & Refactoring
+- **React.memo on database sub-components** — reduced re-renders in table view. PR #722.
+- **UI performance improvements** for database views and sidebar. PR #661.
+- **5 refactor PRs** — decomposed table-view, database-view-client, filter-bar, and page-tree into focused sub-components. PR #674, #688, #694, #695, #698.
+
+### Storybook
+- **Stories added for:** select-dropdown, extracted table sub-components, sidebar components, editor image dialogs, editor callout/collapsible nodes, editor floating toolbar, slash command menu, link editor. PR #679, #720, #749, #755, #807, #809.
+
+## What's Next
+
+- **Row virtualization** — large databases need virtual scrolling (#778).
+- **Bulk row selection and delete** — multi-select rows for batch operations (#779).
+- **Quick search filter** — filter database rows by typing (#732).
+- **Optimistic updates** — make database mutations feel instant (#804).
+- **Password reset flow** (#823).
+
+## Challenges & Learnings
+
+- **Database views were the largest feature area ever attempted in one week.** 40+ PRs touching 30+ new files, with 10 property types, 5 view types, and inline embedding. The agents handled it by decomposing the work into small, independently mergeable PRs — but the sheer volume (90 PRs on Day 10 alone) created merge conflicts that required 5 CI-fix cycles. Batching related changes into fewer, larger PRs would have reduced churn.
+- **Sentry noise from E2E tests polluted production error tracking.** The E2E error-recovery tests (#800) used Playwright route interception to simulate server errors, but those simulated errors triggered real Sentry captures in production. It took three separate bug issues (#806, #810, #811) to fully resolve: removing double-captures from the data layer, classifying PGRST500 errors, downgrading transient fetch errors, and finally disabling Sentry entirely during E2E sessions. The lesson: when adding error-path tests, verify they don't generate side effects in observability systems.
+- **Test coverage jumped from 0% to 38% but is still low.** The agents wrote 1,600 tests — but the codebase also grew 5x. Coverage percentage barely kept pace with new code. The 38% number reflects the challenge of testing a UI-heavy app where many components need browser-level E2E tests rather than unit tests.


### PR DESCRIPTION
Week 18 recap (Apr 21–27, 2026) for the build-in-public audience.

Key numbers:
- **+50,335 LOC** (62,927 cumulative, up 400% from W17)
- **271 PRs merged** (448 cumulative)
- **242 issues completed** (6 remaining)
- **1,941 tests** (up from 344, +464%)
- **38% test coverage** (from 0%)

Highlights: full database views (table, board, calendar, gallery, list), OAuth sign-in, light mode, feedback widget, accessibility improvements, and 32 test PRs.