### PR TITLE
chore: performance report 2026-W18

### DIFF
--- a/metrics/weekly/2026-W18-perf.md
+++ b/metrics/weekly/2026-W18-perf.md
@@ -1,0 +1,55 @@
+# Performance Report — Week 18
+
+**Date:** 2026-04-27
+**Period:** 2026-04-20 → 2026-04-27
+
+## Health Endpoint
+
+- Status: **ok**
+- DB latency: **1159ms** ⚠️ (threshold: 500ms)
+- DB connected: **yes**
+
+The health endpoint returned `status: ok`, but database latency (1159ms) exceeds the 500ms threshold by 2.3×. This may indicate Supabase connection pool pressure or cold-start overhead on the serverless function.
+
+## Error Trend
+
+- This week (Apr 20–27): **2,753 errors**
+- Last week (Apr 13–20): **42 errors**
+- Trend: **↑ 6,455%** ❌
+
+The error count increased dramatically. Top contributors:
+
+| Issue | Title | Events | Status |
+|---|---|---|---|
+| [MEMO-E](https://ona-2j.sentry.io/issues/MEMO-E) | np (unknown client error) | 1,883 | ignored |
+| [MEMO-C](https://ona-2j.sentry.io/issues/MEMO-C) | \<unknown\> | 495 | ignored |
+| [MEMO-F](https://ona-2j.sentry.io/issues/MEMO-F) | np (unknown client error) | 43 | resolved |
+| [MEMO-22](https://ona-2j.sentry.io/issues/MEMO-22) | \<unknown\> | 33 | resolved |
+| [MEMO-11](https://ona-2j.sentry.io/issues/MEMO-11) | removeChild DOM error | 31 | resolved |
+
+MEMO-E alone accounts for 68% of all errors this week. Both MEMO-E and MEMO-C are currently ignored but represent the bulk of the spike. These appear to be minified client-side errors (`np`, `<unknown>`) on the `/:workspaceSlug/:pageId` route, suggesting missing source maps or unhandled promise rejections in the page editor.
+
+## Build Size
+
+Measured via Turbopack production build (gzipped). Threshold: 200kB first-load JS.
+
+| Page | First Load JS (gzip) | Status |
+|---|---|---|
+| `/` | 192.6kB | ✅ |
+| `/sign-in` | 192.6kB | ✅ |
+| `/sign-up` | 192.6kB | ✅ |
+| `/invite/[token]` | 192.6kB | ✅ |
+| `/[workspaceSlug]` | 323.5kB | ❌ |
+| `/[workspaceSlug]/[pageId]` | 560.6kB | ❌ |
+| `/[workspaceSlug]/settings` | 323.5kB | ❌ |
+| `/[workspaceSlug]/settings/members` | 323.5kB | ❌ |
+
+Shared framework JS: 131.6kB (gzipped, 6 chunks).
+
+The authenticated app routes exceed the 200kB threshold. The page editor route (`/[workspaceSlug]/[pageId]`) is the heaviest at 560.6kB — nearly 3× the threshold. The workspace routes share ~192kB of page-specific client components beyond the framework baseline.
+
+## Action Items
+
+- ❌ **DB latency exceeds 500ms** — investigate Supabase connection pooling, consider connection reuse or health check query optimization
+- ❌ **Error spike: 6,455% increase** — MEMO-E (1,883 events) and MEMO-C (495 events) need investigation; likely missing source maps or unhandled client errors on the page editor route
+- ❌ **Bundle size: 4 routes over 200kB** — the page editor route at 560.6kB needs code splitting; consider lazy-loading editor components, splitting heavy dependencies


### PR DESCRIPTION
Weekly performance monitoring report for 2026-W18 (Apr 20–27).

## Summary

| Metric | Value | Status |
|---|---|---|
| Health endpoint | ok | ✅ |
| DB latency | 1159ms | ⚠️ >500ms threshold |
| DB connected | yes | ✅ |
| Errors this week | 2,753 | ❌ ↑6,455% vs last week |
| Bundle (worst page) | 560.6kB gzip | ❌ >200kB threshold |

## Critical Findings

1. **Error spike**: 2,753 errors this week vs 42 last week. MEMO-E (1,883 events) and MEMO-C (495 events) are the top contributors — both are minified client errors on the page editor route.
2. **DB latency**: 1159ms exceeds the 500ms threshold.
3. **Bundle size**: 4 authenticated routes exceed 200kB. The page editor at 560.6kB is the heaviest.

GitHub issues created for critical metrics.