### PR TITLE
fix: handle plain-object Supabase errors in Sentry reporting (#828)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -232,6 +232,28 @@ lazyCaptureException(error);
 Reserve `lazyCaptureException` for errors that have no structured classification
 (e.g. Lexical editor framework errors, unexpected runtime exceptions).
 
+### Supabase errors may be plain objects, not Error instances
+
+The Supabase PostgREST client (v2.103.0+) returns **plain objects**
+`{ message, details, hint, code }` — not `PostgrestError` class instances — when
+`fetch` throws a network error in the default (non-`throwOnError`) mode. The
+`PostgrestError` class is only instantiated when `shouldThrowOnError` is true.
+
+Do NOT use `instanceof Error` to check for Supabase errors. Use duck-type checks:
+
+```typescript
+// ✅ Correct — works for both PostgrestError instances and plain objects
+if (error && typeof error === "object" && "code" in error && "details" in error) { ... }
+
+// ❌ Wrong — fails for plain objects from network errors
+if (error instanceof Error && "code" in error) { ... }
+```
+
+`captureSupabaseError` handles this automatically — it wraps plain objects in a
+proper `Error` before sending to Sentry so they get proper stack traces and
+grouping. The `isPostgrestError` duck-type check in `src/lib/sentry.ts` also
+handles both shapes.
+
 ### Always use `captureApiError` for internal API fetch errors
 
 Non-Supabase fetch calls (e.g. `/api/pages/…/versions`) must use `captureApiError`

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -13,6 +13,7 @@ import("@sentry/nextjs").then(async (Sentry) => {
     isNextjsInternalNoise,
     isReactLexicalDomConflict,
     isSupabaseAuthLockContention,
+    isTransientSupabaseNetworkEvent,
   } = await import("@/lib/sentry");
 
   Sentry.init({
@@ -36,6 +37,7 @@ import("@sentry/nextjs").then(async (Sentry) => {
       if (isNextjsInternalNoise(event)) return null;
       if (isReactLexicalDomConflict(event)) return null;
       if (isSupabaseAuthLockContention(event)) return null;
+      if (isTransientSupabaseNetworkEvent(event)) return null;
       return event;
     },
   });

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -18,15 +18,22 @@ export function isE2ETestSession(): boolean {
 }
 
 /**
- * Duck-type check for Supabase PostgrestError. Avoids importing the class
- * from `@supabase/supabase-js` which would pull the entire SDK (~59 kB)
- * into every page bundle.
+ * Duck-type check for Supabase PostgrestError shape. Matches both:
+ * 1. `PostgrestError` class instances (from `throwOnError()` path) — extend `Error`
+ * 2. Plain objects `{ message, details, hint, code }` returned by the Supabase
+ *    PostgREST client in the default `{ data, error }` pattern when `fetch` throws
+ *    a network error (the client catches the fetch error and returns a plain object
+ *    literal, not a `PostgrestError` instance)
+ *
+ * Does NOT use `instanceof Error` — the Supabase client returns plain objects for
+ * network-level failures (see postgrest-js `executeWithRetry` catch handler).
  */
 function isPostgrestError(
   error: unknown,
 ): error is { message: string; code: string; details: string; hint: string } {
+  if (error == null || typeof error !== "object") return false;
   return (
-    error instanceof Error &&
+    "message" in error &&
     "code" in error &&
     "details" in error &&
     "hint" in error
@@ -295,6 +302,73 @@ export function isSupabaseAuthLockError(error: Error): boolean {
 }
 
 /**
+ * Returns true when the Sentry event is a transient network error from a
+ * Supabase operation. These are "TypeError: Failed to fetch" or "fetch failed"
+ * errors that occur when the browser loses connectivity or the Supabase
+ * endpoint is temporarily unreachable. They are not actionable and should
+ * be dropped from Sentry entirely to reduce noise.
+ *
+ * Matches two shapes:
+ * 1. Events where the exception value contains "Failed to fetch" or
+ *    "fetch failed" — the wrapped Error from `captureSupabaseError`
+ * 2. Events reported as "Object captured as exception with keys: code,
+ *    details, hint, message" where the extra data contains a transient
+ *    network error message — plain objects that bypassed `ensureError`
+ */
+export function isTransientSupabaseNetworkEvent(event: ErrorEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) return false;
+
+  const hasTransientException = values.some((ex) => {
+    const val = ex.value ?? "";
+    return (
+      val.includes("Failed to fetch") ||
+      val.includes("fetch failed") ||
+      val.includes("Load failed") ||
+      val.includes("NetworkError when attempting to fetch resource") ||
+      val.includes("The Internet connection appears to be offline") ||
+      val.includes("Network request failed")
+    );
+  });
+
+  if (hasTransientException) return true;
+
+  // Check for plain-object errors that Sentry serialized as
+  // "Object captured as exception with keys: code, details, hint, message"
+  const hasObjectException = values.some(
+    (ex) =>
+      typeof ex.value === "string" &&
+      ex.value.includes("Object captured as exception with keys:") &&
+      ex.value.includes("code") &&
+      ex.value.includes("details") &&
+      ex.value.includes("message"),
+  );
+
+  if (!hasObjectException) return false;
+
+  // Verify the extra data contains a transient network error message
+  const extra = event.extra;
+  if (!extra) return false;
+  const msg =
+    typeof extra.message === "string" ? extra.message : "";
+  const serialized = extra.__serialized__;
+  const serializedMsg =
+    serialized &&
+    typeof serialized === "object" &&
+    "message" in serialized &&
+    typeof (serialized as Record<string, unknown>).message === "string"
+      ? (serialized as Record<string, string>).message
+      : "";
+
+  return (
+    msg.includes("Failed to fetch") ||
+    msg.includes("fetch failed") ||
+    serializedMsg.includes("Failed to fetch") ||
+    serializedMsg.includes("fetch failed")
+  );
+}
+
+/**
  * Returns true when the Sentry event is a Supabase auth lock contention
  * error. These are unhandled promise rejections from the Supabase client's
  * internal `_acquireLock` when concurrent requests steal each other's
@@ -406,11 +480,33 @@ export function captureApiError(error: unknown, operation: string): void {
 }
 
 /**
+ * Ensure the value passed to `lazyCaptureException` is a proper `Error`
+ * instance. The Supabase PostgREST client returns plain objects
+ * `{ message, details, hint, code }` for network-level fetch failures
+ * (see postgrest-js `executeWithRetry` catch handler). Sentry cannot
+ * extract a stack trace from plain objects and reports them as
+ * "Object captured as exception with keys: …", creating ungrouped noise.
+ */
+function ensureError(error: Error | { message: string }): Error {
+  if (error instanceof Error) return error;
+  const wrapped = new Error(error.message);
+  wrapped.name = "SupabaseError";
+  // Preserve the original object so Sentry extra data still has access
+  wrapped.cause = error;
+  return wrapped;
+}
+
+/**
  * Report a Supabase error to Sentry with structured context.
  *
- * Accepts both PostgrestError (from query/mutation results) and generic Error
- * (from catch blocks). The `operation` tag makes it easy to filter in Sentry
- * by the database operation that failed.
+ * Accepts `PostgrestError` class instances (from `throwOnError()` path),
+ * plain objects `{ message, details, hint, code }` (from the default
+ * `{ data, error }` pattern when fetch fails), and generic `Error` objects
+ * (from catch blocks).
+ *
+ * Plain objects are wrapped in a proper `Error` before sending to Sentry
+ * so they get proper stack traces and grouping instead of appearing as
+ * "Object captured as exception with keys: code, details, hint, message".
  *
  * Transient network errors (e.g. `TypeError: Failed to fetch`) are captured at
  * `warning` level to reduce noise — they are not application bugs.
@@ -430,6 +526,9 @@ export function captureSupabaseError(
     extra.hint = error.hint;
   }
 
+  // Wrap plain objects in a proper Error for Sentry grouping
+  const reportable = ensureError(error);
+
   if (
     isTransientNetworkError(error) ||
     isTransientStorageError(error) ||
@@ -441,9 +540,9 @@ export function captureSupabaseError(
     isStatementTimeoutError(error) ||
     isEmptyResultError(error)
   ) {
-    lazyCaptureException(error, { extra, level: "warning" });
+    lazyCaptureException(reportable, { extra, level: "warning" });
     return;
   }
 
-  lazyCaptureException(error, { extra });
+  lazyCaptureException(reportable, { extra });
 }

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -20,6 +20,7 @@ import {
   isPostgrestServerError,
   isSupabaseAuthLockError,
   isSupabaseAuthLockContention,
+  isTransientSupabaseNetworkEvent,
   captureSupabaseError,
   captureApiError,
   isNextjsInternalNoise,
@@ -37,6 +38,25 @@ function makePostgrestError(
     code: overrides.code ?? "PGRST000",
   });
   return err;
+}
+
+/**
+ * Create a plain object matching the shape returned by the Supabase PostgREST
+ * client when `fetch` throws a network error in the default (non-throwOnError)
+ * mode. These are NOT `PostgrestError` instances — they are plain object
+ * literals `{ message, details, hint, code }`.
+ *
+ * See: postgrest-js `executeWithRetry` catch handler.
+ */
+function makePlainSupabaseError(
+  overrides: { message?: string; details?: string; hint?: string; code?: string } = {},
+): { message: string; code: string; details: string; hint: string } {
+  return {
+    message: overrides.message ?? "TypeError: Failed to fetch",
+    details: overrides.details ?? "",
+    hint: overrides.hint ?? "",
+    code: overrides.code ?? "",
+  };
 }
 
 describe("isTransientNetworkError", () => {
@@ -198,6 +218,29 @@ describe("isTransientNetworkError", () => {
   it("returns false for a generic application error", () => {
     const error = new Error("Something went wrong");
     expect(isTransientNetworkError(error)).toBe(false);
+  });
+
+  // --- Plain object regression tests (MEMO-E / MEMO-C / #828) ---
+  // The Supabase PostgREST client returns plain objects (not PostgrestError
+  // instances) when fetch throws a network error in the default mode.
+
+  it("detects 'TypeError: Failed to fetch' from plain Supabase error object (#828 MEMO-E)", () => {
+    const error = makePlainSupabaseError({
+      message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+      details:
+        "TypeError: Failed to fetch\n    at https://memo.software-factory.dev/_next/static/chunks/0vf8__som4qot.js:20:1653",
+    });
+    expect(isTransientNetworkError(error as unknown as Error)).toBe(true);
+  });
+
+  it("detects 'TypeError: Failed to fetch' from plain object with empty code (#828 MEMO-C)", () => {
+    const error = makePlainSupabaseError({
+      message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+      details:
+        "TypeError: Failed to fetch\n    at http://localhost:3000/_next/static/chunks/0.rz_@sentry_core.js:6673:34",
+      code: "",
+    });
+    expect(isTransientNetworkError(error as unknown as Error)).toBe(true);
   });
 });
 
@@ -775,6 +818,81 @@ describe("captureSupabaseError", () => {
     expect(opts.extra.code).toBe("23505");
     expect(opts.extra.details).toBe("Key (id)=(abc) already exists.");
   });
+
+  // --- Plain object regression tests (MEMO-E / MEMO-C / #828) ---
+  // The Supabase PostgREST client returns plain objects (not PostgrestError
+  // instances) when fetch throws a network error in the default mode.
+
+  it("wraps plain Supabase error objects in Error before sending to Sentry (#828 MEMO-E)", async () => {
+    const plainError = makePlainSupabaseError({
+      message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+      details:
+        "TypeError: Failed to fetch\n    at https://memo.software-factory.dev/_next/static/chunks/0vf8__som4qot.js:20:1653",
+    });
+    captureSupabaseError(plainError as unknown as Error, "editor:save");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [captured, opts] = captureExceptionMock.mock.calls[0];
+    // Must be a proper Error instance, not a plain object
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.name).toBe("SupabaseError");
+    expect(captured.message).toBe(
+      "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+    );
+    // Transient network error → warning level
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.operation).toBe("editor:save");
+  });
+
+  it("extracts code/details/hint from plain Supabase error objects (#828 MEMO-C)", async () => {
+    const plainError = makePlainSupabaseError({
+      message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+      details:
+        "TypeError: Failed to fetch\n    at http://localhost:3000/_next/static/chunks/0.rz_@sentry_core.js:6673:34",
+      code: "",
+      hint: "",
+    });
+    captureSupabaseError(plainError as unknown as Error, "database-properties:reorder");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [captured, opts] = captureExceptionMock.mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(opts.level).toBe("warning");
+    expect(opts.extra.code).toBe("");
+    expect(opts.extra.details).toContain("TypeError: Failed to fetch");
+    expect(opts.extra.operation).toBe("database-properties:reorder");
+  });
+
+  it("passes Error instances through without wrapping", async () => {
+    const error = new Error("Failed to fetch");
+    captureSupabaseError(error, "page-tree:fetch-pages");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [captured] = captureExceptionMock.mock.calls[0];
+    // Should be the original Error, not wrapped
+    expect(captured).toBe(error);
+  });
+
+  it("wraps plain non-network Supabase errors in Error at error level (#828)", async () => {
+    const plainError = makePlainSupabaseError({
+      message: "unexpected server error",
+      code: "PGRST500",
+      details: "internal error",
+    });
+    captureSupabaseError(plainError as unknown as Error, "database.addProperty");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [captured, opts] = captureExceptionMock.mock.calls[0];
+    expect(captured).toBeInstanceOf(Error);
+    expect(captured.name).toBe("SupabaseError");
+    // Non-transient → error level (no level override)
+    expect(opts.level).toBeUndefined();
+    expect(opts.extra.code).toBe("PGRST500");
+  });
 });
 
 function makeSentryEvent(
@@ -1075,6 +1193,148 @@ describe("isSupabaseAuthLockContention", () => {
   it("returns false when exception is missing", () => {
     const event = { type: undefined } as ErrorEvent;
     expect(isSupabaseAuthLockContention(event)).toBe(false);
+  });
+});
+
+describe("isTransientSupabaseNetworkEvent", () => {
+  it("detects 'Failed to fetch' in exception value (#828 MEMO-E)", () => {
+    const event = makeSentryEvent([
+      {
+        type: "SupabaseError",
+        value: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+      },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("detects 'fetch failed' in exception value (Node.js)", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "TypeError: fetch failed" },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("detects 'Load failed' (Safari) in exception value", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Load failed" },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("detects 'NetworkError when attempting to fetch resource' (Firefox)", () => {
+    const event = makeSentryEvent([
+      {
+        type: "Error",
+        value: "NetworkError when attempting to fetch resource.",
+      },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("detects 'The Internet connection appears to be offline'", () => {
+    const event = makeSentryEvent([
+      {
+        type: "Error",
+        value: "The Internet connection appears to be offline.",
+      },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("detects 'Network request failed'", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Network request failed" },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("detects plain-object Sentry error with transient network message in extra (#828)", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value:
+              "Object captured as exception with keys: code, details, hint, message",
+          },
+        ],
+      },
+      extra: {
+        message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+        operation: "editor:save",
+      },
+    } as unknown as ErrorEvent;
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("detects plain-object Sentry error with __serialized__ extra (#828)", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value:
+              "Object captured as exception with keys: code, details, hint, message",
+          },
+        ],
+      },
+      extra: {
+        __serialized__: {
+          message: "TypeError: Failed to fetch (yoipusltrtbvneuywzkj.supabase.co)",
+          code: "",
+          details: "TypeError: Failed to fetch",
+          hint: "",
+        },
+      },
+    } as unknown as ErrorEvent;
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
+  });
+
+  it("returns false for non-network errors", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Cannot read properties of undefined" },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(false);
+  });
+
+  it("returns false for plain-object error without transient network message", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value:
+              "Object captured as exception with keys: code, details, hint, message",
+          },
+        ],
+      },
+      extra: {
+        message: "new row violates row-level security policy",
+        operation: "page-tree:create-page",
+      },
+    } as unknown as ErrorEvent;
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(false);
+  });
+
+  it("returns false when exception values are empty", () => {
+    const event = makeSentryEvent([]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(false);
+  });
+
+  it("returns false when exception is missing", () => {
+    const event = { type: undefined } as ErrorEvent;
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(false);
+  });
+
+  it("detects transient error in chained exceptions", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Some wrapper error" },
+      { type: "TypeError", value: "Failed to fetch" },
+    ]);
+    expect(isTransientSupabaseNetworkEvent(event)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Closes #828

## What

Sentry error volume spiked from 42 to 2,753 errors/week. MEMO-E (1,883 events) and MEMO-C (495 events) were both `"Object captured as exception with keys: code, details, hint, message"` — Sentry couldn't extract stack traces or group them properly because the errors were plain objects, not `Error` instances.

The Supabase PostgREST client (v2.103.0) returns **plain objects** `{ message, details, hint, code }` when `fetch` throws a network error in the default (non-`throwOnError`) mode. The `PostgrestError` class is only instantiated when `shouldThrowOnError` is true. Our `isPostgrestError` duck-type check used `instanceof Error`, which failed for these plain objects, causing transient network error classification to miss them entirely.

## How

Three-layer fix:

1. **`isPostgrestError`**: Removed `instanceof Error` check, replaced with pure duck-typing (`"message" in error && "code" in error && "details" in error && "hint" in error`). This correctly identifies both `PostgrestError` class instances and plain objects.

2. **`captureSupabaseError`**: Added `ensureError()` that wraps plain objects in a proper `Error` (with `name: "SupabaseError"`) before passing to `lazyCaptureException`. Sentry can now extract stack traces and group these errors properly.

3. **`beforeSend` filter**: Added `isTransientSupabaseNetworkEvent` to drop transient network errors from Sentry entirely. These are not actionable — the user already sees a "Save failed" toast, and the editor retries automatically.

Also added a convention to `.agents/conventions.md` documenting that Supabase errors may be plain objects.

## Testing

- Added `makePlainSupabaseError` helper that creates plain objects matching the exact shape returned by the Supabase PostgREST client for network errors
- Added regression tests for `isTransientNetworkError` with plain objects (reproduces MEMO-E and MEMO-C)
- Added regression tests for `captureSupabaseError` verifying plain objects are wrapped in `Error` instances before Sentry capture
- Added tests for `isTransientSupabaseNetworkEvent` covering all transient network patterns, plain-object fallback detection, and negative cases
- `pnpm lint && pnpm typecheck && pnpm test` all pass (1697 tests)