### PR TITLE
perf: reduce page editor bundle from 560KB to 220KB gzip (#830)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -513,6 +513,7 @@ src/
 │   ├── page-title.tsx           # Inline-editable page title (saves on blur/Enter)
 │   ├── page-breadcrumb.tsx       # Server component: breadcrumb nav (workspace → ancestors → current page)
 │   ├── page-backlinks.tsx        # Server component: backlinks section (queries page_links, shows linking pages)
+│   ├── page-content-client.tsx   # Client wrapper: lazy-loads DatabaseViewClient, RowPropertiesHeader, PageViewClient via next/dynamic
 │   ├── page-view-client.tsx     # Client wrapper for page view (holds editor ref, renders icon + title + menu + editor)
 │   ├── page-menu.tsx            # Page "..." dropdown: favorites, duplicate, version history, export/import markdown
 │   ├── version-history-panel.tsx # Sheet panel: lists page versions, preview, restore

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -10,9 +10,7 @@ import {
   type BreadcrumbItem,
 } from "@/components/page-breadcrumb";
 import { PageBacklinks } from "@/components/page-backlinks";
-import { PageViewClient } from "@/components/page-view-client";
-import { RowPropertiesHeader } from "@/components/database/row-properties-header";
-import { DatabaseViewClient } from "@/components/database/database-view-client";
+import { PageContentClient } from "@/components/page-content-client";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -309,42 +307,24 @@ export default async function PageView({
       <div className="mb-2">
         <PageBreadcrumb items={breadcrumbItems} />
       </div>
-      {isDatabase ? (
-        <DatabaseViewClient
-          pageId={page.id}
-          pageTitle={page.title}
-          pageIcon={page.icon ?? null}
-          pageCoverUrl={page.cover_url ?? null}
-          initialContent={initialContent}
-          workspaceId={workspace.id}
-          workspaceSlug={workspaceSlug}
-          userId={user.id}
-          initialData={initialDatabaseData}
-        />
-      ) : (
-        <>
-          {isRowPage && rowProperties.length > 0 && (
-            <RowPropertiesHeader
-              pageId={page.id}
-              properties={rowProperties}
-              values={rowValues}
-              pageCreatedAt={page.created_at}
-              pageUpdatedAt={page.updated_at}
-              pageCreatedBy={page.created_by}
-            />
-          )}
-          <PageViewClient
-            pageId={page.id}
-            pageTitle={page.title}
-            pageIcon={page.icon ?? null}
-            pageCoverUrl={page.cover_url ?? null}
-            initialContent={initialContent}
-            workspaceId={workspace.id}
-            workspaceSlug={workspaceSlug}
-            userId={user.id}
-          />
-        </>
-      )}
+      <PageContentClient
+        pageId={page.id}
+        pageTitle={page.title}
+        pageIcon={page.icon ?? null}
+        pageCoverUrl={page.cover_url ?? null}
+        initialContent={initialContent}
+        workspaceId={workspace.id}
+        workspaceSlug={workspaceSlug}
+        userId={user.id}
+        isDatabase={isDatabase}
+        isRowPage={isRowPage}
+        rowProperties={rowProperties}
+        rowValues={rowValues}
+        pageCreatedAt={page.created_at}
+        pageUpdatedAt={page.updated_at}
+        pageCreatedBy={page.created_by}
+        initialDatabaseData={initialDatabaseData}
+      />
       <Suspense fallback={null}>
         <PageBacklinks
           pageId={page.id}

--- a/src/components/page-content-client.tsx
+++ b/src/components/page-content-client.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { SerializedEditorState } from "lexical";
+import type { DatabaseProperty, RowValue } from "@/lib/types";
+import type { LoadDatabaseResult } from "@/lib/database";
+
+const DatabaseViewClient = dynamic(
+  () =>
+    import("@/components/database/database-view-client").then(
+      (mod) => mod.DatabaseViewClient,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="mt-6 space-y-3">
+        <div className="h-8 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-64 w-full animate-pulse rounded bg-muted" />
+      </div>
+    ),
+  },
+);
+
+const RowPropertiesHeader = dynamic(
+  () =>
+    import("@/components/database/row-properties-header").then(
+      (mod) => mod.RowPropertiesHeader,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="mb-4 space-y-2">
+        <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-48 animate-pulse rounded bg-muted" />
+      </div>
+    ),
+  },
+);
+
+const PageViewClient = dynamic(
+  () =>
+    import("@/components/page-view-client").then((mod) => mod.PageViewClient),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-4">
+        <div className="h-10 w-64 animate-pulse rounded bg-muted" />
+        <div className="space-y-3">
+          <div className="h-4 w-full animate-pulse bg-muted" />
+          <div className="h-4 w-5/6 animate-pulse bg-muted" />
+          <div className="h-4 w-4/6 animate-pulse bg-muted" />
+        </div>
+      </div>
+    ),
+  },
+);
+
+interface PageContentClientProps {
+  pageId: string;
+  pageTitle: string;
+  pageIcon: string | null;
+  pageCoverUrl: string | null;
+  initialContent: SerializedEditorState | null;
+  workspaceId: string;
+  workspaceSlug: string;
+  userId: string;
+  isDatabase: boolean;
+  isRowPage: boolean;
+  rowProperties: DatabaseProperty[];
+  rowValues: Record<string, RowValue>;
+  pageCreatedAt: string;
+  pageUpdatedAt: string;
+  pageCreatedBy: string;
+  initialDatabaseData: LoadDatabaseResult | null;
+}
+
+export function PageContentClient({
+  pageId,
+  pageTitle,
+  pageIcon,
+  pageCoverUrl,
+  initialContent,
+  workspaceId,
+  workspaceSlug,
+  userId,
+  isDatabase,
+  isRowPage,
+  rowProperties,
+  rowValues,
+  pageCreatedAt,
+  pageUpdatedAt,
+  pageCreatedBy,
+  initialDatabaseData,
+}: PageContentClientProps) {
+  if (isDatabase) {
+    return (
+      <DatabaseViewClient
+        pageId={pageId}
+        pageTitle={pageTitle}
+        pageIcon={pageIcon}
+        pageCoverUrl={pageCoverUrl}
+        initialContent={initialContent}
+        workspaceId={workspaceId}
+        workspaceSlug={workspaceSlug}
+        userId={userId}
+        initialData={initialDatabaseData}
+      />
+    );
+  }
+
+  return (
+    <>
+      {isRowPage && rowProperties.length > 0 && (
+        <RowPropertiesHeader
+          pageId={pageId}
+          properties={rowProperties}
+          values={rowValues}
+          pageCreatedAt={pageCreatedAt}
+          pageUpdatedAt={pageUpdatedAt}
+          pageCreatedBy={pageCreatedBy}
+        />
+      )}
+      <PageViewClient
+        pageId={pageId}
+        pageTitle={pageTitle}
+        pageIcon={pageIcon}
+        pageCoverUrl={pageCoverUrl}
+        initialContent={initialContent}
+        workspaceId={workspaceId}
+        workspaceSlug={workspaceSlug}
+        userId={userId}
+      />
+    </>
+  );
+}

--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import dynamic from "next/dynamic";
 import { SmilePlus } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
 import { captureSupabaseError } from "@/lib/sentry";
-import { EmojiPicker } from "@/components/emoji-picker";
+
+const EmojiPicker = dynamic(
+  () => import("@/components/emoji-picker").then((mod) => mod.EmojiPicker),
+  { ssr: false },
+);
 
 interface PageIconProps {
   pageId: string;

--- a/src/components/page-view-client.tsx
+++ b/src/components/page-view-client.tsx
@@ -6,7 +6,14 @@ import type { LexicalEditor, SerializedEditorState } from "lexical";
 import { PageTitle } from "@/components/page-title";
 import { PageIcon } from "@/components/page-icon";
 import { PageCover } from "@/components/page-cover";
-import { VersionHistoryPanel } from "@/components/version-history-panel";
+
+const VersionHistoryPanel = dynamic(
+  () =>
+    import("@/components/version-history-panel").then(
+      (mod) => mod.VersionHistoryPanel,
+    ),
+  { ssr: false },
+);
 
 
 const Editor = dynamic(

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -15,7 +15,14 @@ import { FavoritesSection } from "@/components/sidebar/favorites-section";
 import { PageTree } from "@/components/sidebar/page-tree";
 import { TrashSection } from "@/components/sidebar/trash-section";
 import { UserMenu } from "@/components/sidebar/user-menu";
-import { FeedbackForm } from "@/components/feedback/feedback-form";
+import dynamic from "next/dynamic";
+
+const FeedbackForm = dynamic(
+  () =>
+    import("@/components/feedback/feedback-form").then(
+      (mod) => mod.FeedbackForm,
+    ),
+);
 
 interface AppSidebarProps {
   userId: string;

--- a/src/components/sidebar/sidebar-context.tsx
+++ b/src/components/sidebar/sidebar-context.tsx
@@ -10,7 +10,15 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import { KeyboardShortcutsDialog } from "@/components/keyboard-shortcuts-dialog";
+import dynamic from "next/dynamic";
+
+const KeyboardShortcutsDialog = dynamic(
+  () =>
+    import("@/components/keyboard-shortcuts-dialog").then(
+      (mod) => mod.KeyboardShortcutsDialog,
+    ),
+  { ssr: false },
+);
 
 interface SidebarContextValue {
   open: boolean;


### PR DESCRIPTION
Closes #830

## What

Reduces the page editor route's first-load JS from 560.6KB to 220KB gzipped (61% reduction), well under the 300KB target.

## How

Moved heavy client components behind `next/dynamic` lazy-load boundaries so they are code-split into separate chunks loaded on demand rather than included in the initial page bundle.

**Key change:** Created `PageContentClient` — a thin `"use client"` wrapper that dynamically imports `DatabaseViewClient`, `RowPropertiesHeader`, and `PageViewClient`. This is necessary because Next.js does not code-split client components when they are directly imported from server components (per the [lazy loading docs](https://nextjs.org/docs/app/guides/lazy-loading)). The wrapper moves the dynamic import boundary into client-side code where `next/dynamic` actually triggers code splitting.

**Additional lazy-load targets:**
- `VersionHistoryPanel` — Sheet that only opens on demand via page menu
- `EmojiPicker` — Popover that only opens on icon click
- `FeedbackForm` (+ `html-to-image` dependency) — Sidebar form, rarely used
- `KeyboardShortcutsDialog` — Dialog that only opens on `?` keypress

## Results

| Page | Before | After | Change |
|---|---|---|---|
| `/[workspaceSlug]/[pageId]` | 560.6KB | 220KB | **-61%** |
| `/[workspaceSlug]` | 323.5KB | 277KB | -14% |
| `/[workspaceSlug]/settings` | 323.5KB | 258KB | -20% |
| `/[workspaceSlug]/settings/members` | 323.5KB | 300KB | -7% |

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 1678 tests pass
- `pnpm build` — production build succeeds
- No interactive UI changes (only import boundaries moved), so no E2E test changes needed