### PR TITLE
fix: filter E2E test noise from server-side Sentry and guard Supabase SSR cookie null (#834)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -383,6 +383,22 @@ These files have intentional bare `catch {}` blocks with documented reasons:
 
 All other catch blocks must capture the error variable and report to Sentry.
 
+### E2E test noise filtering in Sentry
+
+E2E tests (Playwright with HeadlessChrome) can trigger server-side errors that
+are not application bugs. Both client-side and server-side Sentry configs must
+filter these out:
+
+- **Client-side** — Playwright's auth fixture sets `window.__SENTRY_DISABLED__`
+  via `addInitScript`. The `beforeSend` filter checks `isE2ETestSession()`.
+- **Server-side** — `sentry.server.config.ts` and `sentry.edge.config.ts` use
+  `isE2ETestRequest(event)` which checks the request user-agent for
+  `HeadlessChrome/`. This catches errors from API routes and server components
+  that the client-side flag cannot reach.
+
+When adding new Sentry config files or `beforeSend` filters, always include
+both `isNextjsInternalNoise` and `isE2ETestRequest` checks.
+
 ## Environment Variable Guards
 
 Route handlers and server utilities that use Supabase must guard against missing

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { isNextjsInternalNoise } from "@/lib/sentry";
+import { isE2ETestRequest, isNextjsInternalNoise } from "@/lib/sentry";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
@@ -11,6 +11,9 @@ Sentry.init({
 
   beforeSend(event) {
     if (isNextjsInternalNoise(event)) {
+      return null;
+    }
+    if (isE2ETestRequest(event)) {
       return null;
     }
     return event;

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { isNextjsInternalNoise } from "@/lib/sentry";
+import { isE2ETestRequest, isNextjsInternalNoise } from "@/lib/sentry";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
@@ -13,6 +13,9 @@ Sentry.init({
 
   beforeSend(event) {
     if (isNextjsInternalNoise(event)) {
+      return null;
+    }
+    if (isE2ETestRequest(event)) {
       return null;
     }
     return event;

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -18,6 +18,20 @@ export function isE2ETestSession(): boolean {
 }
 
 /**
+ * Returns true when the Sentry event originated from an E2E test session.
+ * On the server side, Playwright runs in HeadlessChrome — the user-agent
+ * in the request headers is the only reliable signal since the client-side
+ * `window.__SENTRY_DISABLED__` flag is not available server-side.
+ *
+ * This complements the client-side `isE2ETestSession()` which uses the
+ * window flag set by Playwright's `addInitScript`.
+ */
+export function isE2ETestRequest(event: ErrorEvent): boolean {
+  const ua = event.request?.headers?.["User-Agent"] ?? event.request?.headers?.["user-agent"] ?? "";
+  return ua.includes("HeadlessChrome/");
+}
+
+/**
  * Duck-type check for Supabase PostgrestError shape. Matches both:
  * 1. `PostgrestError` class instances (from `throwOnError()` path) — extend `Error`
  * 2. Plain objects `{ message, details, hint, code }` returned by the Supabase

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -26,6 +26,7 @@ import {
   isNextjsInternalNoise,
   isReactLexicalDomConflict,
   isE2ETestSession,
+  isE2ETestRequest,
 } from "./sentry";
 
 function makePostgrestError(
@@ -1437,5 +1438,49 @@ describe("isE2ETestSession", () => {
   it("returns false when __SENTRY_DISABLED__ is a non-true value", () => {
     win.__SENTRY_DISABLED__ = "true";
     expect(isE2ETestSession()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isE2ETestRequest — drops server-side Sentry events from E2E test sessions
+// ---------------------------------------------------------------------------
+
+describe("isE2ETestRequest", () => {
+  function makeRequestEvent(headers: Record<string, string>): ErrorEvent {
+    return { type: undefined, request: { headers } } as unknown as ErrorEvent;
+  }
+
+  it("returns true when User-Agent contains HeadlessChrome/", () => {
+    const event = makeRequestEvent({
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/147.0.0.0 Safari/537.36",
+    });
+    expect(isE2ETestRequest(event)).toBe(true);
+  });
+
+  it("returns true when user-agent header is lowercase", () => {
+    const event = makeRequestEvent({
+      "user-agent":
+        "Mozilla/5.0 HeadlessChrome/147.0.0.0 Safari/537.36",
+    });
+    expect(isE2ETestRequest(event)).toBe(true);
+  });
+
+  it("returns false for a normal Chrome user-agent", () => {
+    const event = makeRequestEvent({
+      "User-Agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/147.0.0.0 Safari/537.36",
+    });
+    expect(isE2ETestRequest(event)).toBe(false);
+  });
+
+  it("returns false when request has no headers", () => {
+    const event = { type: undefined, request: {} } as unknown as ErrorEvent;
+    expect(isE2ETestRequest(event)).toBe(false);
+  });
+
+  it("returns false when event has no request", () => {
+    const event = { type: undefined } as ErrorEvent;
+    expect(isE2ETestRequest(event)).toBe(false);
   });
 });

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -9,7 +9,17 @@ export async function createClient() {
     {
       cookies: {
         getAll() {
-          return cookieStore.getAll();
+          // Ensure every cookie value is a string. During session teardown
+          // (e.g. account deletion), the cookie store may return null values
+          // for auth chunks. @supabase/ssr's combineChunks passes these to
+          // startsWith() without a typeof guard, causing a TypeError.
+          // See: https://github.com/supabase/ssr/issues — client-side
+          // getItem (line ~146) lacks the typeof guard that the server-side
+          // path (line ~253) has.
+          return cookieStore.getAll().map(({ name, value }) => ({
+            name,
+            value: value ?? "",
+          }));
         },
         setAll(cookiesToSet) {
           try {


### PR DESCRIPTION
Closes #834

## What

`DELETE /api/account` throws `TypeError: Cannot read properties of null (reading 'startsWith')` during E2E test runs. The error originates in `@supabase/ssr`'s cookie chunking logic — the client-side `getItem` path (line ~146 of `cookies.js`) calls `chunkedCookie.startsWith()` without a `typeof` guard, unlike the server-side path (line ~253) which has one. During account deletion, the auth session is torn down while the RPC is in flight, causing `combineChunks` to return a non-string truthy value.

Additionally, the server-side Sentry configs (`sentry.server.config.ts`, `sentry.edge.config.ts`) lacked E2E test session filtering — the client-side `isE2ETestSession()` check (added in #813) only works in the browser via `window.__SENTRY_DISABLED__`.

## How

Two-pronged fix:

1. **Server-side E2E filtering** — Added `isE2ETestRequest(event)` to `src/lib/sentry.ts` which detects Playwright's HeadlessChrome user-agent in the Sentry event's request headers. Applied in `beforeSend` for both `sentry.server.config.ts` and `sentry.edge.config.ts`.

2. **Defensive cookie wrapper** — Updated `src/lib/supabase/server.ts` `getAll` callback to coerce null cookie values to empty strings (`value ?? ""`), preventing the upstream `@supabase/ssr` null-safety bug from throwing.

Updated `.agents/conventions.md` with a new section documenting the E2E noise filtering pattern for both client and server Sentry configs.

## Testing

- Added 5 unit tests for `isE2ETestRequest` covering: HeadlessChrome detection (both `User-Agent` and `user-agent` header casing), normal Chrome rejection, missing headers, and missing request.
- All 1704 existing tests pass. Lint and typecheck clean.