### PR TITLE
chore(automations): add PR merge webhook trigger to Feature Builder

### DIFF
--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -12,6 +12,7 @@ triggers:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       pullRequest:
+        webhookId: 019d8d97-eb6e-70c4-a97d-25952abbc5a7
         events:
             - PULL_REQUEST_EVENT_MERGED
     - context:

--- a/.ona/automations/feature-builder.yaml
+++ b/.ona/automations/feature-builder.yaml
@@ -11,6 +11,13 @@ triggers:
         projects:
             projectIds:
                 - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
+      pullRequest:
+        events:
+            - PULL_REQUEST_EVENT_MERGED
+    - context:
+        projects:
+            projectIds:
+                - 019d8bf4-1ded-7317-be2f-555e8fb55ff9
       manual: {}
 action:
     limits:


### PR DESCRIPTION
## What

Adds a `PULL_REQUEST_EVENT_MERGED` webhook trigger to the Feature Builder so it picks up the next backlog item immediately when a PR merges and a slot opens, rather than waiting up to 2h for the cron.

## Why

When a PR merges, a backlog slot opens (the pre-flight caps open PRs at 3). Without this, the next issue waits up to 2h. With the webhook, pickup is immediate.

## Safety

- `maxParallel: 1` prevents duplicate runs if cron and webhook fire simultaneously
- The prompt's pre-flight checks (open PR count, existing PR for same issue) provide defense-in-depth