### PR TITLE
fix(security): block storage enumeration and restrict RPC permissions

### DIFF
--- a/supabase/migrations/20260429171925_security_hardening.sql
+++ b/supabase/migrations/20260429171925_security_hardening.sql
@@ -1,0 +1,89 @@
+-- Security hardening: block anonymous storage enumeration and restrict
+-- RPC execute permissions to authenticated users only.
+--
+-- Fixes reported by security researcher (Lorenzo):
+--   1. Anonymous users can enumerate and download all objects in page-images
+--      and feedback-screenshots buckets via POST /storage/v1/object/list/.
+--   2. Feedback screenshots are publicly listable and downloadable.
+--   3. User account enumeration via /auth/v1/signup (dashboard fix — see below).
+--
+-- Additional findings from full RLS audit:
+--   4. Four security-definer RPCs callable by anon with no internal auth check:
+--      usage_event_counts_7d, purge_old_page_versions, prune_excess_page_versions,
+--      purge_old_trash.
+--
+-- MANUAL STEP REQUIRED AFTER DEPLOY:
+--   In the Supabase Dashboard, go to Authentication → Settings → Security
+--   and enable "Protect against email enumeration attacks". This prevents
+--   the /auth/v1/signup endpoint from revealing whether an email is registered.
+
+-- =============================================================================
+-- 1. Storage: replace public SELECT policies with authenticated-only
+-- =============================================================================
+-- Buckets remain public: true so direct-URL image rendering (/object/public/...)
+-- continues to work. Only the listing API (/object/list/...) is restricted.
+
+-- ---- page-images ----
+DROP POLICY IF EXISTS "Public read access for page images" ON storage.objects;
+
+DO $$ BEGIN
+  CREATE POLICY "Authenticated read access for page images"
+    ON storage.objects FOR SELECT
+    TO authenticated
+    USING (bucket_id = 'page-images');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ---- feedback-screenshots ----
+DROP POLICY IF EXISTS "Public read access for feedback screenshots" ON storage.objects;
+
+DO $$ BEGIN
+  CREATE POLICY "Authenticated read access for feedback screenshots"
+    ON storage.objects FOR SELECT
+    TO authenticated
+    USING (bucket_id = 'feedback-screenshots');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- =============================================================================
+-- 2. RPCs: revoke execute from public/anon, grant to authenticated only
+-- =============================================================================
+-- Service role key bypasses these restrictions, so cron jobs and automations
+-- that use createAdminClient() are unaffected.
+
+-- ---- Critical: no internal auth check, callable by anon today ----
+
+REVOKE EXECUTE ON FUNCTION usage_event_counts_7d(text[]) FROM public, anon;
+GRANT EXECUTE ON FUNCTION usage_event_counts_7d(text[]) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION purge_old_page_versions() FROM public, anon;
+GRANT EXECUTE ON FUNCTION purge_old_page_versions() TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION prune_excess_page_versions(uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION prune_excess_page_versions(uuid) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION purge_old_trash() FROM public, anon;
+GRANT EXECUTE ON FUNCTION purge_old_trash() TO authenticated;
+
+-- ---- Defense-in-depth: have internal auth checks but should still be restricted ----
+
+REVOKE EXECUTE ON FUNCTION search_pages(text, uuid, integer) FROM public, anon;
+GRANT EXECUTE ON FUNCTION search_pages(text, uuid, integer) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION create_workspace(text, text) FROM public, anon;
+GRANT EXECUTE ON FUNCTION create_workspace(text, text) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION delete_account() FROM public, anon;
+GRANT EXECUTE ON FUNCTION delete_account() TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION accept_invite(uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION accept_invite(uuid) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION soft_delete_page(uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION soft_delete_page(uuid) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION restore_page(uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION restore_page(uuid) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION empty_trash(uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION empty_trash(uuid) TO authenticated;


### PR DESCRIPTION
## What

Addresses security findings reported by Lorenzo (security researcher):

1. **Storage bucket enumeration** — anonymous users could list all objects in `page-images` and `feedback-screenshots` buckets via `POST /storage/v1/object/list/`.
2. **Feedback screenshot exposure** — same root cause as above.
3. **User account enumeration** — `/auth/v1/signup` reveals whether an email is registered (dashboard fix documented below).

Full RLS audit uncovered an additional finding:

4. **Unprotected security-definer RPCs** — `usage_event_counts_7d`, `purge_old_page_versions`, `prune_excess_page_versions`, and `purge_old_trash` were callable by the `anon` role with no internal auth check. The first leaks analytics data; the other three are destructive (delete page versions and trashed pages).

## Changes

Single migration file: `20260429171925_security_hardening.sql`

**Storage policies:**
- Replace `SELECT TO public` with `SELECT TO authenticated` on both `page-images` and `feedback-screenshots` buckets.
- Buckets remain `public: true` so direct-URL image rendering (`/object/public/...`) is unaffected. Only the listing API is restricted.

**RPC permissions:**
- `REVOKE EXECUTE FROM public, anon` + `GRANT TO authenticated` on 11 functions:
  - 4 critical (no internal auth check): `usage_event_counts_7d`, `purge_old_page_versions`, `prune_excess_page_versions`, `purge_old_trash`
  - 7 defense-in-depth (have internal auth checks): `search_pages`, `create_workspace`, `delete_account`, `accept_invite`, `soft_delete_page`, `restore_page`, `empty_trash`
- Exceptions kept public: `health_check` (intentionally public), `get_invite_by_token` (needed before auth).
- Service role key (used by cron jobs and automations) bypasses GRANT restrictions — no impact on existing functionality.

## Impact on existing app

**None.** Verified by tracing all callers:
- The app never calls `.list()` on either storage bucket. All image rendering uses `getPublicUrl()` (client-side URL construction) + direct public URLs.
- All RPC callers use authenticated sessions or the service role key.

## Manual step required after deploy

In the **Supabase Dashboard → Authentication → Settings → Security**, enable **"Protect against email enumeration attacks"**. This makes `/auth/v1/signup` responses identical regardless of whether the email exists.

## Testing

- `pnpm lint` — 0 errors ✅
- `pnpm typecheck` — clean ✅
- `pnpm test` — 1723 tests passed ✅ (including migration validation)