### PR TITLE
chore: daily metrics snapshot 2026-04-30

### DIFF
--- a/metrics/daily/2026-04-30.json
+++ b/metrics/daily/2026-04-30.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-04-30",
+  "day_number": 18,
+  "loc": {
+    "total": 65528,
+    "delta": 982,
+    "by_language": {
+      "TypeScript": 63769,
+      "SQL": 1496,
+      "CSS": 263
+    }
+  },
+  "files": {
+    "total": 217,
+    "delta": 5
+  },
+  "prs": {
+    "total": 482,
+    "delta": 11,
+    "currently_open": 0
+  },
+  "commits": {
+    "total": 505,
+    "delta": 11
+  },
+  "issues": {
+    "backlog": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 348,
+    "opened_today": 0,
+    "closed_today": 0
+  },
+  "tests": {
+    "unit": 1730,
+    "e2e": 312
+  },
+  "ci": {
+    "runs_total": 0,
+    "runs_passed": 0,
+    "pass_rate_pct": null
+  },
+  "test_coverage_pct": 37.81,
+  "autonomous_pct": 84,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
Daily metrics snapshot for 2026-04-30 (Day 18).

| Metric | Value | Delta |
|---|---|---|
| LOC | 65,528 | +982 |
| Files | 217 | +5 |
| PRs merged | 482 | +11 |
| Commits | 505 | +11 |
| PRs open | 0 | — |
| Issues done | 348 | +5 |
| Unit tests | 1,730 | +8 |
| E2E tests | 312 | +17 |
| Test coverage | 37.81% | -0.54 |
| CI runs today | 0 | — |
| Autonomous % | 84% | — |
