### PR TITLE
fix: timeseries aggregator crashes on missing distribution buckets (#877)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 126 | 1730 |
+| Unit/Integration (Vitest) | 127 | 1736 |
 | E2E (Playwright) | 64 | 318 |
-| **Total** | **190** | **2048** |
+| **Total** | **191** | **2054** |
 
 ### Test files by domain
 
@@ -52,7 +52,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **API**: `health/route.test.ts` (6 tests), `search/route.test.ts` (11 tests), `account/route.test.ts` (6 tests), `cron/purge-trash/route.test.ts` (8 tests), `feedback/route.test.ts` (17 tests), `pages/[pageId]/versions/route.test.ts` (11 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (11 tests), `e2e/account-deletion.spec.ts` (4 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `relative-time.test.ts` (7 tests), `e2e/visual-regression.spec.ts` (1 test)
 - **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (108 tests), `retry.test.ts` (6 tests), `track-event-server.test.ts` (6 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
-- **Infrastructure**: `migrations.test.ts` (33 tests)
+- **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests)
 
 ## Known Gaps
 
@@ -88,6 +88,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-04-25 | Test count drift fix (#786). Added 38 new Vitest files (mostly database component, hook, property type, and view tests): `csv-export.test.ts` (38), `table-cell.test.tsx` (40), `database-view-client.test.tsx` (6), `filter-bar.test.tsx` (20), `filter-value-editor.test.tsx` (34), `sort-menu.test.tsx` (19), `rename-property-dialog.test.tsx` (14), `row-properties-header.test.tsx` (17), `view-tabs.test.tsx` (24), `use-database-filters.test.ts` (18), `use-database-properties.test.ts` (18), `use-database-rows.test.ts` (19), `use-database-views.test.ts` (24), `checkbox.test.tsx` (8), `computed.test.tsx` (15), `date.test.tsx` (12), `email.test.tsx` (8), `files.test.tsx` (11), `formula.test.tsx` (6), `multi-select.test.tsx` (10), `number.test.tsx` (14), `person.test.tsx` (9), `phone.test.tsx` (10), `relation.test.tsx` (12), `select-dropdown.test.tsx` (32), `select.test.tsx` (11), `status.test.tsx` (14), `text.test.tsx` (10), `url.test.tsx` (10), `board-view-helpers.test.ts` (18), `board-view.test.tsx` (13), `calendar-view-helpers.test.ts` (35), `calendar-view.test.tsx` (15), `database-empty-state.test.tsx` (14), `gallery-view.test.tsx` (17), `list-keyboard.test.ts` (14), `list-view.test.tsx` (22), `row-count-announcer.test.tsx` (7), `row-count-status-bar.test.tsx` (5). Added 2 new loading test files: `[workspaceSlug]/settings/loading.test.ts` (5), `[workspaceSlug]/settings/members/loading.test.ts` (5). Added 10 new E2E specs: `database-add-property-types.spec.ts` (10), `database-board-keyboard.spec.ts` (6), `database-csv-export.spec.ts` (3), `database-files.spec.ts` (4), `database-filter-keyboard.spec.ts` (6), `database-formula.spec.ts` (3), `database-gallery-keyboard.spec.ts` (5), `database-list-keyboard.spec.ts` (6), `database-relation.spec.ts` (3), `public-routes.spec.ts` (11). Updated 3 files with grown counts: `gallery-view-design-spec.test.ts` (2→3), `migrations.test.ts` (29→33), `database-crud.spec.ts` (8→10). Test totals: 119 Vitest files (1618 tests), 59 E2E specs (274 tests). |
 | 2026-04-29 | Font family selector (#848). Added 1 new E2E spec: `editor-font-family.spec.ts` (5 tests). Test totals: 126 Vitest files (1722 tests), 62 E2E specs (289 tests). |
 | 2026-04-29 | Mobile sidebar close-on-navigate fix (#853). Updated `sidebar-context.test.tsx` (19→21 tests): added mobile close-on-navigate and desktop no-close-on-navigate tests. Updated `e2e/sidebar-responsive.spec.ts` (3→4 tests): added mobile Sheet auto-close after page navigation. Test totals: 126 Vitest files (1724 tests), 63 E2E specs (300 tests). |
+| 2026-05-01 | Timeseries aggregator fix (#877). Added 1 new Vitest file: `build-timeseries.test.mjs` (6 tests) — regression tests for missing distribution buckets and CI pass rate fallback. Test totals: 127 Vitest files (1736 tests), 64 E2E specs (318 tests). |
 | 2026-04-29 | API route transient error classification fix (#856). Updated 4 files with regression tests: `feedback/route.test.ts` (15→17), `account/route.test.ts` (5→6), `search/route.test.ts` (10→11), `cron/purge-trash/route.test.ts` (7→8). Test totals: 126 Vitest files (1730 tests), 63 E2E specs (300 tests). |
 | 2026-04-29 | Interactive demo editor on landing page (#860). Added 1 new E2E spec: `demo-editor.spec.ts` (11 tests). Corrected `public-routes.spec.ts` count (11→14 tests). Test totals: 126 Vitest files (1730 tests), 64 E2E specs (314 tests). |
 | 2026-04-30 | SEO routes auth middleware fix (#870). Updated `public-routes.spec.ts` (14→18 tests): added 4 regression tests for /robots.txt, /sitemap.xml, /opengraph-image, /twitter-image. Test totals: 126 Vitest files (1730 tests), 64 E2E specs (318 tests). |

--- a/metrics/daily/2026-04-30.json
+++ b/metrics/daily/2026-04-30.json
@@ -29,7 +29,9 @@
     "in_review": 0,
     "done": 348,
     "opened_today": 0,
-    "closed_today": 0
+    "closed_today": 0,
+    "delta_opened": 0,
+    "delta_done": 0
   },
   "tests": {
     "unit": 1730,
@@ -43,5 +45,20 @@
   "test_coverage_pct": 37.81,
   "autonomous_pct": 84,
   "human_minutes": null,
-  "agent_minutes": null
+  "agent_minutes": null,
+  "pr_merge_time_buckets": {
+    "lt_5m": 206,
+    "5_10m": 180,
+    "10_20m": 57,
+    "30_60m": 33,
+    "1_2h": 10
+  },
+  "issue_close_time_buckets": {
+    "lt_15m": 49,
+    "15_30m": 81,
+    "30_60m": 101,
+    "1_2h": 66,
+    "2_4h": 49,
+    "4_8h": 17
+  }
 }

--- a/metrics/daily/2026-05-01.json
+++ b/metrics/daily/2026-05-01.json
@@ -29,7 +29,9 @@
     "in_review": 0,
     "done": 351,
     "opened_today": 1,
-    "closed_today": 1
+    "closed_today": 1,
+    "delta_opened": 1,
+    "delta_done": 1
   },
   "tests": {
     "unit": 1730,
@@ -43,5 +45,20 @@
   "test_coverage_pct": 37.77,
   "autonomous_pct": 85,
   "human_minutes": null,
-  "agent_minutes": null
+  "agent_minutes": null,
+  "pr_merge_time_buckets": {
+    "lt_5m": 206,
+    "5_10m": 180,
+    "10_20m": 57,
+    "30_60m": 34,
+    "1_2h": 12
+  },
+  "issue_close_time_buckets": {
+    "lt_15m": 49,
+    "15_30m": 81,
+    "30_60m": 101,
+    "1_2h": 66,
+    "2_4h": 50,
+    "4_8h": 17
+  }
 }

--- a/metrics/timeseries.json
+++ b/metrics/timeseries.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-04-29T21:55:19Z",
+  "updatedAt": "2026-05-01T14:04:56Z",
   "startDate": "2026-04-14",
   "days": [
     {
@@ -449,37 +449,93 @@
       },
       "autonomousPct": 85,
       "ciGreenPct": 100
+    },
+    {
+      "date": "2026-04-30",
+      "dayNumber": 17,
+      "loc": {
+        "total": 65528,
+        "delta": 982
+      },
+      "prs": {
+        "total": 482,
+        "delta": 11
+      },
+      "commits": {
+        "total": 505,
+        "delta": 11
+      },
+      "issues": {
+        "done": 348,
+        "deltaDone": 0,
+        "deltaOpened": 0
+      },
+      "tests": {
+        "unit": 1730,
+        "e2e": 312,
+        "total": 2042
+      },
+      "autonomousPct": 84,
+      "ciGreenPct": 100
+    },
+    {
+      "date": "2026-05-01",
+      "dayNumber": 18,
+      "loc": {
+        "total": 65696,
+        "delta": 168
+      },
+      "prs": {
+        "total": 489,
+        "delta": 7
+      },
+      "commits": {
+        "total": 512,
+        "delta": 7
+      },
+      "issues": {
+        "done": 351,
+        "deltaDone": 1,
+        "deltaOpened": 1
+      },
+      "tests": {
+        "unit": 1730,
+        "e2e": 316,
+        "total": 2046
+      },
+      "autonomousPct": 85,
+      "ciGreenPct": 100
     }
   ],
   "latest": {
-    "date": "2026-04-29",
-    "dayNumber": 16,
+    "date": "2026-05-01",
+    "dayNumber": 18,
     "totals": {
-      "prs": 471,
-      "commits": 494,
-      "loc": 64546,
-      "issuesDone": 343,
-      "tests": 2017
+      "prs": 489,
+      "commits": 512,
+      "loc": 65696,
+      "issuesDone": 351,
+      "tests": 2046
     },
     "rates": {
       "autonomousPct": 85,
       "ciGreenPct": 100,
-      "testCoveragePct": 38.35
+      "testCoveragePct": 37.77
     },
     "distributions": {
       "prMergeTime": {
         "lt_5m": 206,
-        "5_10m": 179,
-        "10_20m": 56,
-        "30_60m": 29,
-        "1_2h": 10
+        "5_10m": 180,
+        "10_20m": 57,
+        "30_60m": 34,
+        "1_2h": 12
       },
       "issueCloseTime": {
         "lt_15m": 49,
         "15_30m": 81,
         "30_60m": 101,
         "1_2h": 66,
-        "2_4h": 47,
+        "2_4h": 50,
         "4_8h": 17
       }
     }

--- a/scripts/metrics/build-timeseries.mjs
+++ b/scripts/metrics/build-timeseries.mjs
@@ -62,6 +62,24 @@ function ciGreenPct(snap) {
   return 100;
 }
 
+const DEFAULT_PR_BUCKETS = { lt_5m: 0, '5_10m': 0, '10_20m': 0, '30_60m': 0, '1_2h': 0 };
+const DEFAULT_ISSUE_BUCKETS = { lt_15m: 0, '15_30m': 0, '30_60m': 0, '1_2h': 0, '2_4h': 0, '4_8h': 0 };
+
+/**
+ * Scan daily snapshot files (newest first) for a non-null object field.
+ * Used to find the most recent distribution buckets when the latest
+ * snapshot omits them.
+ */
+function findLatestField(files, field) {
+  for (let i = files.length - 1; i >= 0; i--) {
+    const snap = JSON.parse(readFileSync(join(DAILY_DIR, files[i]), 'utf8'));
+    if (snap[field] != null && typeof snap[field] === 'object') {
+      return snap[field];
+    }
+  }
+  return null;
+}
+
 // ── Main ──
 
 const dayFiles = readdirSync(DAILY_DIR)
@@ -115,6 +133,16 @@ const days = dayFiles.map(f => {
 
 const lastSnap = JSON.parse(readFileSync(join(DAILY_DIR, dayFiles[dayFiles.length - 1]), 'utf8'));
 
+// Distribution buckets may be missing from the latest snapshot if the daily
+// automation omitted them. Scan backward to find the most recent snapshot
+// that includes them, falling back to zero-filled defaults.
+const prMergeTime = lastSnap.pr_merge_time_buckets
+  ?? findLatestField(dayFiles, 'pr_merge_time_buckets')
+  ?? DEFAULT_PR_BUCKETS;
+const issueCloseTime = lastSnap.issue_close_time_buckets
+  ?? findLatestField(dayFiles, 'issue_close_time_buckets')
+  ?? DEFAULT_ISSUE_BUCKETS;
+
 const out = {
   updatedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
   startDate: START,
@@ -135,8 +163,8 @@ const out = {
       testCoveragePct: lastSnap.test_coverage_pct,
     },
     distributions: {
-      prMergeTime: lastSnap.pr_merge_time_buckets,
-      issueCloseTime: lastSnap.issue_close_time_buckets,
+      prMergeTime,
+      issueCloseTime,
     },
   },
 };

--- a/scripts/metrics/build-timeseries.test.mjs
+++ b/scripts/metrics/build-timeseries.test.mjs
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+
+/**
+ * Regression tests for build-timeseries.mjs (#877).
+ * Runs the actual script via a thin wrapper that overrides DAILY_DIR and OUT
+ * to point at temp fixtures.
+ */
+
+const SCRIPT_PATH = join(import.meta.dirname, 'build-timeseries.mjs');
+
+function makeSnapshot(overrides = {}) {
+  return {
+    date: '2026-04-14',
+    day_number: 1,
+    loc: { total: 100, delta: 100, by_language: { TypeScript: 100 } },
+    files: { total: 10, delta: 10 },
+    prs: { total: 5, delta: 5, currently_open: 0 },
+    commits: { total: 10, delta: 10 },
+    issues: {
+      backlog: 0, in_progress: 0, in_review: 0, done: 3,
+      opened_today: 1, closed_today: 1, delta_opened: 1, delta_done: 1,
+    },
+    tests: { unit: 10, e2e: 5 },
+    ci: { runs_total: 2, runs_passed: 2, pass_rate_pct: 100 },
+    test_coverage_pct: 50,
+    autonomous_pct: 90,
+    pr_merge_time_buckets: { lt_5m: 2, '5_10m': 1, '10_20m': 1, '30_60m': 1, '1_2h': 0 },
+    issue_close_time_buckets: { lt_15m: 1, '15_30m': 1, '30_60m': 0, '1_2h': 1, '2_4h': 0, '4_8h': 0 },
+    human_minutes: null,
+    agent_minutes: null,
+    ...overrides,
+  };
+}
+
+/** Run the real script with overridden DAILY_DIR and OUT paths. */
+function runAggregator(dailyDir, outFile) {
+  // Read the real script, patch the two path constants, write to a temp wrapper
+  let src = readFileSync(SCRIPT_PATH, 'utf8');
+  src = src.replace(
+    /const DAILY_DIR = .+;/,
+    `const DAILY_DIR = ${JSON.stringify(dailyDir)};`,
+  );
+  src = src.replace(
+    /const OUT = .+;/,
+    `const OUT = ${JSON.stringify(outFile)};`,
+  );
+  const wrapperPath = join(dailyDir, '..', '_test_wrapper.mjs');
+  writeFileSync(wrapperPath, src);
+  try {
+    return execSync(`node ${wrapperPath}`, { encoding: 'utf8', stdio: 'pipe' });
+  } finally {
+    rmSync(wrapperPath, { force: true });
+  }
+}
+
+describe('build-timeseries.mjs', () => {
+  let tmpDir;
+  let dailyDir;
+  let outFile;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'timeseries-test-'));
+    dailyDir = join(tmpDir, 'daily');
+    mkdirSync(dailyDir);
+    outFile = join(tmpDir, 'timeseries.json');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('succeeds when all snapshots have complete fields', () => {
+    const snap1 = makeSnapshot({ date: '2026-04-14' });
+    const snap2 = makeSnapshot({
+      date: '2026-04-15',
+      loc: { total: 120, delta: 20, by_language: { TypeScript: 120 } },
+      prs: { total: 7, delta: 2, currently_open: 0 },
+      commits: { total: 12, delta: 2 },
+    });
+    writeFileSync(join(dailyDir, '2026-04-14.json'), JSON.stringify(snap1));
+    writeFileSync(join(dailyDir, '2026-04-15.json'), JSON.stringify(snap2));
+
+    runAggregator(dailyDir, outFile);
+
+    const result = JSON.parse(readFileSync(outFile, 'utf8'));
+    expect(result.days).toHaveLength(2);
+    expect(result.latest.distributions.prMergeTime).toEqual(snap2.pr_merge_time_buckets);
+    expect(result.latest.distributions.issueCloseTime).toEqual(snap2.issue_close_time_buckets);
+  });
+
+  it('falls back to earlier snapshot when latest is missing distribution buckets', () => {
+    const snap1 = makeSnapshot({ date: '2026-04-14' });
+    const snap2 = makeSnapshot({ date: '2026-04-15' });
+    delete snap2.pr_merge_time_buckets;
+    delete snap2.issue_close_time_buckets;
+
+    writeFileSync(join(dailyDir, '2026-04-14.json'), JSON.stringify(snap1));
+    writeFileSync(join(dailyDir, '2026-04-15.json'), JSON.stringify(snap2));
+
+    runAggregator(dailyDir, outFile);
+
+    const result = JSON.parse(readFileSync(outFile, 'utf8'));
+    expect(result.days).toHaveLength(2);
+    expect(result.latest.distributions.prMergeTime).toEqual(snap1.pr_merge_time_buckets);
+    expect(result.latest.distributions.issueCloseTime).toEqual(snap1.issue_close_time_buckets);
+  });
+
+  it('uses zero-filled defaults when no snapshot has distribution buckets', () => {
+    const snap1 = makeSnapshot({ date: '2026-04-14' });
+    delete snap1.pr_merge_time_buckets;
+    delete snap1.issue_close_time_buckets;
+
+    writeFileSync(join(dailyDir, '2026-04-14.json'), JSON.stringify(snap1));
+
+    runAggregator(dailyDir, outFile);
+
+    const result = JSON.parse(readFileSync(outFile, 'utf8'));
+    expect(result.latest.distributions.prMergeTime).toEqual({
+      lt_5m: 0, '5_10m': 0, '10_20m': 0, '30_60m': 0, '1_2h': 0,
+    });
+    expect(result.latest.distributions.issueCloseTime).toEqual({
+      lt_15m: 0, '15_30m': 0, '30_60m': 0, '1_2h': 0, '2_4h': 0, '4_8h': 0,
+    });
+  });
+
+  it('reads ci.pass_rate_pct from nested ci object', () => {
+    const snap = makeSnapshot({
+      date: '2026-04-14',
+      ci: { runs_total: 6, runs_passed: 6, pass_rate_pct: 100 },
+    });
+    writeFileSync(join(dailyDir, '2026-04-14.json'), JSON.stringify(snap));
+
+    runAggregator(dailyDir, outFile);
+
+    const result = JSON.parse(readFileSync(outFile, 'utf8'));
+    expect(result.days[0].ciGreenPct).toBe(100);
+    expect(result.latest.rates.ciGreenPct).toBe(100);
+  });
+
+  it('defaults ciGreenPct to 100 when ci.pass_rate_pct is null', () => {
+    const snap = makeSnapshot({
+      date: '2026-04-14',
+      ci: { runs_total: 0, runs_passed: 0, pass_rate_pct: null },
+    });
+    writeFileSync(join(dailyDir, '2026-04-14.json'), JSON.stringify(snap));
+
+    runAggregator(dailyDir, outFile);
+
+    const result = JSON.parse(readFileSync(outFile, 'utf8'));
+    expect(result.days[0].ciGreenPct).toBe(100);
+  });
+
+  it('uses closed_today/opened_today when delta_done/delta_opened are missing', () => {
+    const snap = makeSnapshot({ date: '2026-04-14' });
+    delete snap.issues.delta_done;
+    delete snap.issues.delta_opened;
+    snap.issues.closed_today = 3;
+    snap.issues.opened_today = 5;
+
+    writeFileSync(join(dailyDir, '2026-04-14.json'), JSON.stringify(snap));
+
+    runAggregator(dailyDir, outFile);
+
+    const result = JSON.parse(readFileSync(outFile, 'utf8'));
+    expect(result.days[0].issues.deltaDone).toBe(3);
+    expect(result.days[0].issues.deltaOpened).toBe(5);
+  });
+});


### PR DESCRIPTION
Closes #877

## What

The `build-timeseries.mjs` aggregator crashed with `TypeError: Cannot convert undefined or null to object` when the latest daily snapshot was missing `pr_merge_time_buckets` or `issue_close_time_buckets`. This happened because the daily metrics automation on Apr 30 and May 1 omitted these fields, and the script accessed them unconditionally via `lastSnap.pr_merge_time_buckets`. The crash prevented `metrics/timeseries.json` from being regenerated since Apr 29.

A secondary issue: the `ci_pass_rate_pct` top-level field was removed from the daily snapshot schema in #863. The aggregator already handled this correctly via `ciGreenPct()` which checks both `ci.pass_rate_pct` and `ci_pass_rate_pct` — no code change needed for this part.

## How

- Added `findLatestField()` to `build-timeseries.mjs` that scans backward through daily snapshots to find the most recent one containing a given field. When the latest snapshot is missing distribution buckets, the aggregator falls back to the last known values instead of crashing. If no snapshot has the field, zero-filled defaults are used.
- Backfilled the Apr 30 and May 1 snapshots with the missing `delta_opened`, `delta_done`, `pr_merge_time_buckets`, and `issue_close_time_buckets` fields (computed from GitHub API data).
- Regenerated `metrics/timeseries.json` (now covers all 18 days through May 1).

## Testing

Added `scripts/metrics/build-timeseries.test.mjs` with 6 regression tests that run the actual aggregator script against temp fixtures:
- Complete snapshots produce correct output
- Missing distribution buckets in latest snapshot → falls back to earlier snapshot
- No snapshots have distribution buckets → uses zero-filled defaults
- `ci.pass_rate_pct` read from nested `ci` object
- `ci.pass_rate_pct: null` → defaults to 100
- Missing `delta_done`/`delta_opened` → falls back to `closed_today`/`opened_today`

All tests pass: `pnpm lint && pnpm typecheck && pnpm test` (127 files, 1736 tests).