### PR TITLE
fix: disambiguate E2E gridcell input locators after bulk-select (#916)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -103,3 +103,4 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-06 | Fix database duplication (#908). Added `duplicateDatabase` and `remapViewConfig` to `src/lib/database.ts`. Updated both duplicate code paths (sidebar and page-menu) to handle database pages. Added 1 new Vitest file: `database-duplicate.test.ts` (11 tests). Added 1 new E2E spec: `e2e/database-duplicate.spec.ts` (2 tests). Test totals: 129 Vitest files (1753 tests), 66 E2E specs (322 tests). |
 | 2026-05-06 | Bulk row selection and delete (#779). Added `use-row-selection.ts` hook, `bulk-action-bar.tsx` component, checkbox column in table view, bulk delete in `use-database-rows.ts`. Added 1 new Vitest file: `use-row-selection.test.ts` (10 tests). Added 1 new E2E spec: `e2e/database-bulk-select.spec.ts` (6 tests). Test totals: 130 Vitest files (1763 tests), 67 E2E specs (328 tests). |
 
+

--- a/e2e/database-add-property-types.spec.ts
+++ b/e2e/database-add-property-types.spec.ts
@@ -325,8 +325,10 @@ test.describe("Database: add each property type", () => {
     await expect(header.first()).toBeVisible({ timeout: 5_000 });
 
     await clickLastPropertyCell(page);
-    // The URL cell uses a plain text input (same as text/number/email/phone)
-    const input = page.locator('[role="gridcell"] input');
+    // The URL cell uses a plain text input — use type="text" to avoid matching bulk-select checkboxes
+    const input = page.locator(
+      '[role="gridcell"] input[type="text"]',
+    );
     await expect(input).toBeVisible({ timeout: 5_000 });
     await input.fill("https://example.com");
     await input.blur();
@@ -351,7 +353,9 @@ test.describe("Database: add each property type", () => {
     await expect(header.first()).toBeVisible({ timeout: 5_000 });
 
     await clickLastPropertyCell(page);
-    const input = page.locator('[role="gridcell"] input');
+    const input = page.locator(
+      '[role="gridcell"] input[type="text"]',
+    );
     await expect(input).toBeVisible({ timeout: 5_000 });
     await input.fill("test@example.com");
     await input.blur();
@@ -376,7 +380,9 @@ test.describe("Database: add each property type", () => {
     await expect(header.first()).toBeVisible({ timeout: 5_000 });
 
     await clickLastPropertyCell(page);
-    const input = page.locator('[role="gridcell"] input');
+    const input = page.locator(
+      '[role="gridcell"] input[type="text"]',
+    );
     await expect(input).toBeVisible({ timeout: 5_000 });
     await input.fill("5551234567");
     await input.blur();


### PR DESCRIPTION
Closes #916

## What

Three E2E tests (URL, Email, Phone column types) in `database-add-property-types.spec.ts` fail with a Playwright strict mode violation. The locator `page.locator('[role="gridcell"] input')` resolves to 2 elements — a hidden checkbox from the bulk-select feature (PR #911) and the actual text input — causing the tests to fail.

## How

Updated the 3 ambiguous locators (lines 329, 354, 379) from `[role="gridcell"] input` to `[role="gridcell"] input[type="text"]`, matching the pattern already used by the Text and Number column tests in the same file (lines 143, 170). This excludes the `input[type="checkbox"]` elements added by bulk-select.

## Testing

- All 3 previously failing tests now pass: URL, Email, Phone column type tests
- `pnpm lint && pnpm typecheck && pnpm test` all pass
- Full E2E suite for the affected file passes (9/10 — the 1 failure is a pre-existing flaky Date column test unrelated to this change)
- Verified no other E2E files use the ambiguous bare `input` locator pattern