### PR TITLE
fix: guard client-side Supabase cookie values against null (#933)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 131 | 1795 |
+| Unit/Integration (Vitest) | 132 | 1802 |
 | E2E (Playwright) | 69 | 340 |
-| **Total** | **200** | **2135** |
+| **Total** | **201** | **2142** |
 
 ### Test files by domain
 
@@ -52,7 +52,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **API**: `health/route.test.ts` (7 tests), `search/route.test.ts` (11 tests), `account/route.test.ts` (6 tests), `cron/purge-trash/route.test.ts` (8 tests), `feedback/route.test.ts` (17 tests), `pages/[pageId]/versions/route.test.ts` (11 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (11 tests), `e2e/account-deletion.spec.ts` (4 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `design-spec-compliance.test.ts` (6 tests), `relative-time.test.ts` (7 tests), `e2e/visual-regression.spec.ts` (1 test)
 - **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (149 tests), `retry.test.ts` (6 tests), `track-event-server.test.ts` (6 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
-- **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests)
+- **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests)
 
 ## Known Gaps
 
@@ -108,5 +108,6 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-07 | Confirmation dialog for bulk row deletion (#921). Added AlertDialog confirmation to `bulk-action-bar.tsx`. Replaced 1 E2E test with 2 new tests (confirm + cancel) in `database-bulk-select.spec.ts` (6→7). Added 2 Storybook stories (DeleteConfirmation, DeleteConfirmationSingleRow). Test totals: 130 Vitest files (1766 tests), 68 E2E specs (333 tests). |
 | 2026-05-07 | Calendar keyboard navigation (#924). Added `calendar-keyboard.ts` hook and wired into `calendar-view.tsx`. Added 1 new Vitest file: `calendar-keyboard.test.ts` (25 tests). Added 1 new E2E spec: `e2e/database-calendar-keyboard.spec.ts` (7 tests). Test totals: 131 Vitest files (1791 tests), 69 E2E specs (340 tests). |
 | 2026-05-07 | E2E test request browser context fallback (#931). Updated `sentry.unit.test.ts` (108→149 tests): added 4 regression tests for browser context fallback in `isE2ETestRequest`. Test totals: 131 Vitest files (1795 tests), 69 E2E specs (340 tests). |
+| 2026-05-07 | Client-side Supabase cookie null-safety (#933). Added null guard to `createBrowserClient` cookie options in `client.ts`, matching server-side pattern. Added 1 new Vitest file: `supabase/client.test.ts` (7 tests). Test totals: 132 Vitest files (1802 tests), 69 E2E specs (340 tests). |
 
 

--- a/src/lib/supabase/client.test.ts
+++ b/src/lib/supabase/client.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+type CookieEntry = { name: string; value: string };
+type SetCookieEntry = {
+  name: string;
+  value: string;
+  options?: Record<string, unknown>;
+};
+type CookieOptions = {
+  getAll: () => CookieEntry[];
+  setAll: (cookies: SetCookieEntry[]) => void;
+};
+
+let capturedCookies: CookieOptions | null = null;
+
+vi.mock("@supabase/ssr", () => ({
+  createBrowserClient: (
+    _url: string,
+    _key: string,
+    opts?: { cookies?: CookieOptions },
+  ) => {
+    capturedCookies = opts?.cookies ?? null;
+    return {} as unknown;
+  },
+}));
+
+// Must import after mock setup
+import { createClient } from "./client";
+
+describe("createClient cookie handling", () => {
+  let originalCookie: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    capturedCookies = null;
+    originalCookie = Object.getOwnPropertyDescriptor(document, "cookie");
+  });
+
+  afterEach(() => {
+    if (originalCookie) {
+      Object.defineProperty(document, "cookie", originalCookie);
+    } else {
+      // Reset to default jsdom behavior
+      Object.defineProperty(document, "cookie", {
+        get() {
+          return "";
+        },
+        set() {},
+        configurable: true,
+      });
+    }
+  });
+
+  it("provides custom cookie options to createBrowserClient", () => {
+    createClient();
+    expect(capturedCookies).not.toBeNull();
+    expect(capturedCookies!.getAll).toBeInstanceOf(Function);
+    expect(capturedCookies!.setAll).toBeInstanceOf(Function);
+  });
+
+  it("getAll parses document.cookie into name/value pairs", () => {
+    Object.defineProperty(document, "cookie", {
+      get: () => "session=abc123; theme=dark",
+      set: vi.fn(),
+      configurable: true,
+    });
+
+    createClient();
+    const cookies = capturedCookies!.getAll();
+
+    expect(cookies).toEqual([
+      { name: "session", value: "abc123" },
+      { name: "theme", value: "dark" },
+    ]);
+  });
+
+  it("getAll returns empty array when document.cookie is empty", () => {
+    Object.defineProperty(document, "cookie", {
+      get: () => "",
+      set: vi.fn(),
+      configurable: true,
+    });
+
+    createClient();
+    const cookies = capturedCookies!.getAll();
+
+    expect(cookies).toEqual([]);
+  });
+
+  it("getAll returns string values that are safe for startsWith (null-safety regression)", () => {
+    // Simulate a cookie string where parsing could yield edge-case values.
+    // The ?? "" guard ensures every value is a string, preventing the
+    // TypeError: Cannot read properties of null (reading 'startsWith')
+    // that occurs in @supabase/ssr's combineChunks.
+    Object.defineProperty(document, "cookie", {
+      get: () => "sb-auth-token.0=chunk0; sb-auth-token.1=; sb-auth-token.2=chunk2",
+      set: vi.fn(),
+      configurable: true,
+    });
+
+    createClient();
+    const cookies = capturedCookies!.getAll();
+
+    // Every value must be a string (never null/undefined)
+    for (const cookie of cookies) {
+      expect(typeof cookie.value).toBe("string");
+      // This is the exact operation that crashes without the null guard
+      expect(() => cookie.value.startsWith("base64-")).not.toThrow();
+    }
+
+    expect(cookies).toEqual([
+      { name: "sb-auth-token.0", value: "chunk0" },
+      { name: "sb-auth-token.1", value: "" },
+      { name: "sb-auth-token.2", value: "chunk2" },
+    ]);
+  });
+
+  it("getAll handles cookies with = in the value", () => {
+    Object.defineProperty(document, "cookie", {
+      get: () => "token=abc=def=ghi",
+      set: vi.fn(),
+      configurable: true,
+    });
+
+    createClient();
+    const cookies = capturedCookies!.getAll();
+
+    expect(cookies).toEqual([{ name: "token", value: "abc=def=ghi" }]);
+  });
+
+  it("setAll writes cookies to document.cookie", () => {
+    const setCalls: string[] = [];
+    Object.defineProperty(document, "cookie", {
+      get: () => "",
+      set: (val: string) => setCalls.push(val),
+      configurable: true,
+    });
+
+    createClient();
+    capturedCookies!.setAll([
+      { name: "session", value: "xyz", options: { path: "/", secure: true } },
+    ]);
+
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0]).toContain("session=xyz");
+    expect(setCalls[0]).toContain("path=/");
+    expect(setCalls[0]).toContain("secure");
+  });
+
+  it("setAll omits false and null option values", () => {
+    const setCalls: string[] = [];
+    Object.defineProperty(document, "cookie", {
+      get: () => "",
+      set: (val: string) => setCalls.push(val),
+      configurable: true,
+    });
+
+    createClient();
+    capturedCookies!.setAll([
+      {
+        name: "test",
+        value: "val",
+        options: { path: "/", httpOnly: false, sameSite: null },
+      },
+    ]);
+
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0]).toContain("test=val");
+    expect(setCalls[0]).toContain("path=/");
+    expect(setCalls[0]).not.toContain("httpOnly");
+    expect(setCalls[0]).not.toContain("sameSite");
+  });
+});

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -3,6 +3,46 @@ import { createBrowserClient } from "@supabase/ssr";
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          if (typeof document === "undefined") return [];
+          const parsed = Object.fromEntries(
+            document.cookie
+              .split("; ")
+              .filter(Boolean)
+              .map((c) => {
+                const [name, ...rest] = c.split("=");
+                return [name, rest.join("=")];
+              })
+          );
+          return Object.keys(parsed).map((name) => ({
+            name,
+            // Guard against null/undefined values from partial cookie
+            // deletion during session teardown. @supabase/ssr's
+            // combineChunks passes values to startsWith() without a
+            // typeof guard, causing a TypeError. Matches the server-side
+            // guard in server.ts.
+            value: parsed[name] ?? "",
+          }));
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            const parts = [`${name}=${encodeURIComponent(value)}`];
+            if (options) {
+              for (const [key, val] of Object.entries(options)) {
+                if (val === true) {
+                  parts.push(key);
+                } else if (val !== false && val != null) {
+                  parts.push(`${key}=${val}`);
+                }
+              }
+            }
+            document.cookie = parts.join("; ");
+          });
+        },
+      },
+    }
   );
 }


### PR DESCRIPTION
Closes #933

## What

`TypeError: Cannot read properties of null (reading 'startsWith')` in `@supabase/ssr`'s `combineChunks` → `getItem` path during client-side session restoration. The error occurs when a cookie value is null during session teardown or in degraded auth states (e.g., HeadlessChrome bots). The server-side client (`server.ts`) already had a null guard, but the browser client (`client.ts`) relied on `@supabase/ssr`'s default `getAll` which doesn't fully protect against null values in the `combineChunks` code path.

## How

Added explicit `cookies` options to `createBrowserClient` with a custom `getAll` that parses `document.cookie` and applies `?? ""` to every value, matching the server-side pattern in `server.ts`. Also added a custom `setAll` that serializes cookies with proper option handling. This ensures `combineChunks` always receives string values, preventing the `startsWith` TypeError.

## Testing

Added `src/lib/supabase/client.test.ts` (7 tests) covering:
- Custom cookie options are passed to `createBrowserClient`
- `getAll` parses `document.cookie` correctly
- `getAll` returns empty array for empty cookies
- `getAll` guarantees all values are strings safe for `startsWith` (null-safety regression test)
- `getAll` handles cookies with `=` in the value
- `setAll` writes cookies to `document.cookie` with options
- `setAll` omits false/null option values

All CI checks pass: `pnpm lint && pnpm typecheck && pnpm test` (132 files, 1802 tests).