### PR TITLE
feat: show full page title on hover for truncated text (#928)

### DIFF
--- a/src/components/sidebar/page-tree-item.tsx
+++ b/src/components/sidebar/page-tree-item.tsx
@@ -156,6 +156,7 @@ export function PageTreeItem({
         <button
           className="flex-1 truncate text-left"
           onClick={() => onNavigate(page.id)}
+          title={page.title || "Untitled"}
         >
           {page.title || "Untitled"}
         </button>

--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -191,7 +191,7 @@ export function WorkspaceHome({
                     <FileText className="h-4 w-4 text-muted-foreground" />
                   )}
                 </span>
-                <span className="flex-1 truncate">
+                <span className="flex-1 truncate" title={visit.title || "Untitled"}>
                   {visit.title || "Untitled"}
                 </span>
                 <RelativeTime
@@ -272,7 +272,7 @@ export function WorkspaceHome({
                     <FileText className="h-4 w-4 text-muted-foreground" />
                   )}
                 </span>
-                <span className="flex-1 truncate">
+                <span className="flex-1 truncate" title={page.title || "Untitled"}>
                   {page.title || "Untitled"}
                 </span>
                 <RelativeTime


### PR DESCRIPTION
Closes #928

## What

Adds native `title` attributes to truncated page names so users can see the full title on hover. This addresses the usability issue where similarly-named pages (e.g., multiple "Untitled Database..." entries) are indistinguishable in the sidebar.

## How

Added `title={page.title || "Untitled"}` to three truncated text elements:

1. **`src/components/sidebar/page-tree-item.tsx`** — the sidebar page tree item button
2. **`src/components/workspace-home.tsx`** — "Recently Visited" list item spans
3. **`src/components/workspace-home.tsx`** — "All Pages" list item spans

This matches the existing pattern in `src/components/page-breadcrumb.tsx` which already uses `title={displayTitle}` on truncated segments.

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 132 files, 1802 tests passed
- `pnpm test:e2e` — sidebar E2E tests (sidebar-drag, sidebar-responsive) pass
- No new E2E tests needed: this adds HTML `title` attributes only (no new interactions, event handlers, or behavior changes)