### PR TITLE
feat: add role="alert" to auth form error messages (#946)

### DIFF
--- a/src/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/src/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -113,7 +113,7 @@ export function ForgotPasswordForm() {
               autoFocus
             />
           </div>
-          {error && <p className="text-xs text-destructive">{error}</p>}
+          {error && <p className="text-xs text-destructive" role="alert">{error}</p>}
           <Button type="submit" disabled={loading} className="mt-1">
             {loading ? "Sending…" : "Send reset link"}
           </Button>

--- a/src/app/(auth)/forgot-password/page.test.tsx
+++ b/src/app/(auth)/forgot-password/page.test.tsx
@@ -114,7 +114,9 @@ describe("ForgotPasswordPage", () => {
     form.requestSubmit();
 
     await waitFor(() => {
-      expect(screen.getByText("Rate limit exceeded")).toBeInTheDocument();
+      const errorEl = screen.getByText("Rate limit exceeded");
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveAttribute("role", "alert");
     });
   });
 

--- a/src/app/(auth)/reset-password/page.test.tsx
+++ b/src/app/(auth)/reset-password/page.test.tsx
@@ -81,9 +81,9 @@ describe("ResetPasswordPage", () => {
     form.requestSubmit();
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Passwords do not match."),
-      ).toBeInTheDocument();
+      const errorEl = screen.getByText("Passwords do not match.");
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveAttribute("role", "alert");
     });
 
     expect(mockUpdateUser).not.toHaveBeenCalled();
@@ -143,7 +143,9 @@ describe("ResetPasswordPage", () => {
     form.requestSubmit();
 
     await waitFor(() => {
-      expect(screen.getByText("Token expired")).toBeInTheDocument();
+      const errorEl = screen.getByText("Token expired");
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveAttribute("role", "alert");
     });
   });
 

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -125,7 +125,7 @@ export function ResetPasswordForm() {
               minLength={6}
             />
           </div>
-          {error && <p className="text-xs text-destructive">{error}</p>}
+          {error && <p className="text-xs text-destructive" role="alert">{error}</p>}
           <Button type="submit" disabled={loading} className="mt-1">
             {loading ? "Updating…" : "Reset password"}
           </Button>

--- a/src/app/(auth)/sign-in/page.test.tsx
+++ b/src/app/(auth)/sign-in/page.test.tsx
@@ -96,9 +96,9 @@ describe("SignInPage", () => {
     form.requestSubmit();
 
     await waitFor(() => {
-      expect(
-        screen.getByText("Invalid login credentials"),
-      ).toBeInTheDocument();
+      const errorEl = screen.getByText("Invalid login credentials");
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveAttribute("role", "alert");
     });
   });
 

--- a/src/app/(auth)/sign-in/sign-in-form.tsx
+++ b/src/app/(auth)/sign-in/sign-in-form.tsx
@@ -120,7 +120,7 @@ function SignInFormInner() {
               Email confirmed — you can now sign in.
             </p>
           )}
-          {error && <p className="text-xs text-destructive">{error}</p>}
+          {error && <p className="text-xs text-destructive" role="alert">{error}</p>}
           <Button type="submit" disabled={loading} className="mt-1">
             {loading ? "Signing in…" : "Sign in"}
           </Button>

--- a/src/app/(auth)/sign-up/page.test.tsx
+++ b/src/app/(auth)/sign-up/page.test.tsx
@@ -100,7 +100,9 @@ describe("SignUpPage", () => {
     form.requestSubmit();
 
     await waitFor(() => {
-      expect(screen.getByText("User already registered")).toBeInTheDocument();
+      const errorEl = screen.getByText("User already registered");
+      expect(errorEl).toBeInTheDocument();
+      expect(errorEl).toHaveAttribute("role", "alert");
     });
   });
 

--- a/src/app/(auth)/sign-up/sign-up-form.tsx
+++ b/src/app/(auth)/sign-up/sign-up-form.tsx
@@ -161,7 +161,7 @@ export function SignUpForm() {
               minLength={6}
             />
           </div>
-          {error && <p className="text-xs text-destructive">{error}</p>}
+          {error && <p className="text-xs text-destructive" role="alert">{error}</p>}
           <Button type="submit" disabled={loading} className="mt-1">
             {loading ? "Creating account…" : "Sign up"}
           </Button>


### PR DESCRIPTION
Closes #946

## What

Add `role="alert"` to error `<p>` elements in all four auth forms so screen readers announce validation errors when they appear. This matches the existing pattern in `oauth-buttons.tsx`.

## How

- Added `role="alert"` to the conditional error `<p>` in:
  - `sign-in-form.tsx`
  - `sign-up-form.tsx`
  - `reset-password-form.tsx`
  - `forgot-password-form.tsx`
- Updated existing unit tests in all four form test files to assert `role="alert"` on error elements.

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 133 files, 1818 tests passed
- No interactive UI changes, so E2E tests are not required.