### PR TITLE
feat: replace direct sonner imports with lazy @/lib/toast wrapper (#949)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -111,5 +111,6 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-07 | Client-side Supabase cookie null-safety (#933). Added null guard to `createBrowserClient` cookie options in `client.ts`, matching server-side pattern. Added 1 new Vitest file: `supabase/client.test.ts` (7 tests). Test totals: 132 Vitest files (1802 tests), 69 E2E specs (340 tests). |
 | 2026-05-07 | Transient fetch retry on search RPC (#937). Extended `retryOnNetworkError` to handle thrown transient errors. Wrapped search route RPC call with retry. Updated 2 files with grown counts: `search/route.test.ts` (11→14), `retry.test.ts` (6→9). Test totals: 132 Vitest files (1808 tests), 69 E2E specs (340 tests). |
 | 2026-05-07 | Prefers-reduced-motion accessibility (#940). Added `@media (prefers-reduced-motion: reduce)` rule to `globals.css`. Added 1 new Vitest file: `reduced-motion.test.ts` (6 tests). Test totals: 133 Vitest files (1818 tests), 69 E2E specs (340 tests). |
+| 2026-05-08 | Replace direct sonner imports with lazy `@/lib/toast` wrapper (#949). Updated 5 source files and 5 test mocks. Added ESLint `no-restricted-imports` rule for `sonner` toast. Extended `ToastData` type with `action` property. No new tests. Test totals unchanged: 133 Vitest files (1818 tests), 69 E2E specs (340 tests). |
 
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,11 +23,14 @@ const eslintConfig = defineConfig([
   // Prevent raw lazyCaptureException imports — use captureSupabaseError or
   // captureApiError from @/lib/sentry instead. The classification wrappers
   // and React error boundaries are exempt.
+  // Prevent direct sonner toast imports — use @/lib/toast instead to keep
+  // sonner (~15 kB) out of the initial bundle via lazy loading.
   {
     files: ["src/**/*.ts", "src/**/*.tsx"],
     ignores: [
       "src/lib/sentry.ts",
       "src/lib/capture.ts",
+      "src/lib/toast.ts",
       "src/app/global-error.tsx",
       "src/components/route-error.tsx",
     ],
@@ -41,6 +44,12 @@ const eslintConfig = defineConfig([
               importNames: ["lazyCaptureException"],
               message:
                 "Use captureSupabaseError or captureApiError from @/lib/sentry instead. Raw lazyCaptureException bypasses error classification.",
+            },
+            {
+              name: "sonner",
+              importNames: ["toast"],
+              message:
+                "Use @/lib/toast instead. Direct sonner imports bypass lazy-loading and add ~15 kB to the initial bundle.",
             },
           ],
         },

--- a/src/components/database/hooks/use-database-filters.test.ts
+++ b/src/components/database/hooks/use-database-filters.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/lib/database-filters", () => ({
     filterRowsMock(rows, filters, props),
 }));
 
-vi.mock("sonner", () => ({
+vi.mock("@/lib/toast", () => ({
   toast: {
     error: (...args: unknown[]) => toastErrorMock(...args),
   },

--- a/src/components/database/hooks/use-database-filters.ts
+++ b/src/components/database/hooks/use-database-filters.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   sortRows,
   filterRows,

--- a/src/components/database/hooks/use-database-properties.test.ts
+++ b/src/components/database/hooks/use-database-properties.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/column-helpers", () => ({
       : {},
 }));
 
-vi.mock("sonner", () => ({
+vi.mock("@/lib/toast", () => ({
   toast: Object.assign(
     (...args: unknown[]) => toastMock(...args),
     { error: (...args: unknown[]) => toastErrorMock(...args) },

--- a/src/components/database/hooks/use-database-properties.ts
+++ b/src/components/database/hooks/use-database-properties.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   addProperty,
   deleteProperty,

--- a/src/components/database/hooks/use-database-rows.test.ts
+++ b/src/components/database/hooks/use-database-rows.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/sentry", () => ({
 
 const toastSuccessMock = vi.fn();
 
-vi.mock("sonner", () => ({
+vi.mock("@/lib/toast", () => ({
   toast: Object.assign(
     (...args: unknown[]) => toastMock(...args),
     {

--- a/src/components/database/hooks/use-database-rows.ts
+++ b/src/components/database/hooks/use-database-rows.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import {
   addRow,
   duplicateRow,

--- a/src/components/database/hooks/use-database-views.test.ts
+++ b/src/components/database/hooks/use-database-views.test.ts
@@ -26,7 +26,7 @@ vi.mock("@/lib/database", () => ({
   loadDatabase: (...args: unknown[]) => loadDatabaseMock(...args),
 }));
 
-vi.mock("sonner", () => ({
+vi.mock("@/lib/toast", () => ({
   toast: {
     error: (...args: unknown[]) => toastErrorMock(...args),
   },

--- a/src/components/database/hooks/use-database-views.ts
+++ b/src/components/database/hooks/use-database-views.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { VIEW_TYPE_LABELS } from "@/components/database/view-tabs";
 import {
   addView,

--- a/src/components/database/views/table-cell.test.tsx
+++ b/src/components/database/views/table-cell.test.tsx
@@ -69,8 +69,8 @@ vi.mock("@/lib/sentry", () => ({
   captureSupabaseError: vi.fn(),
 }));
 
-// Mock sonner toast
-vi.mock("sonner", () => ({
+// Mock lazy toast wrapper
+vi.mock("@/lib/toast", () => ({
   toast: {
     error: vi.fn(),
     success: vi.fn(),

--- a/src/components/database/views/table-cell.tsx
+++ b/src/components/database/views/table-cell.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { ErrorInfo, ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { toast } from "sonner";
+import { toast } from "@/lib/toast";
 import { computePosition, flip, shift, offset } from "@floating-ui/react";
 import { captureSupabaseError, lazyCaptureException } from "@/lib/sentry";
 import { cn } from "@/lib/utils";

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,6 +1,12 @@
+interface ToastAction {
+  label: React.ReactNode;
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}
+
 interface ToastData {
   description?: string;
   duration?: number;
+  action?: ToastAction;
 }
 
 type ToastFn = (message: string, data?: ToastData) => void;


### PR DESCRIPTION
Closes #949

## What

Replaces direct `import { toast } from "sonner"` with `import { toast } from "@/lib/toast"` in 5 database-domain files, and adds an ESLint rule to prevent future regressions.

The lazy wrapper (`src/lib/toast.ts`) dynamically imports sonner on first invocation, keeping ~15 kB gzipped out of the initial page JS. These 5 files were the only remaining production code bypassing the wrapper.

## Changes

- **5 source files** — swapped `sonner` → `@/lib/toast`:
  - `use-database-filters.ts`
  - `use-database-views.ts`
  - `use-database-rows.ts`
  - `use-database-properties.ts`
  - `views/table-cell.tsx`
- **5 test files** — updated `vi.mock("sonner", ...)` → `vi.mock("@/lib/toast", ...)` to match new import paths
- **`src/lib/toast.ts`** — extended `ToastData` type with `action` property (`{ label, onClick }`) used by database hooks for retry buttons
- **`eslint.config.mjs`** — added `sonner` to `no-restricted-imports` rule, banning `toast` imports from `sonner` with a message directing to `@/lib/toast`. Exempts `src/lib/toast.ts` (the wrapper itself).

## Testing

- `pnpm lint` — 0 errors (45 pre-existing warnings)
- `pnpm typecheck` — passes
- `pnpm test` — 133 files, 1818 tests passed
- No new E2E tests needed — this is a pure import-path change with no behavioral or UI changes