### PR TITLE
perf: lazy-load sentry in auth forms to reduce first-load JS (#951)

### DIFF
--- a/src/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/src/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import Link from "next/link";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -36,7 +35,9 @@ export function ForgotPasswordForm() {
       });
 
     if (resetError) {
-      captureSupabaseError(resetError, "forgot-password:resetPasswordForEmail");
+      import("@/lib/sentry").then(({ captureSupabaseError }) =>
+        captureSupabaseError(resetError, "forgot-password:resetPasswordForEmail"),
+      );
       setError(resetError.message);
       setLoading(false);
       return;

--- a/src/app/(auth)/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/reset-password/reset-password-form.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -46,7 +45,9 @@ export function ResetPasswordForm() {
     });
 
     if (updateError) {
-      captureSupabaseError(updateError, "reset-password:updateUser");
+      import("@/lib/sentry").then(({ captureSupabaseError }) =>
+        captureSupabaseError(updateError, "reset-password:updateUser"),
+      );
       setError(updateError.message);
       setLoading(false);
       return;

--- a/src/components/auth/oauth-buttons.test.tsx
+++ b/src/components/auth/oauth-buttons.test.tsx
@@ -159,11 +159,11 @@ describe("OAuthButtons — OAuth enabled", () => {
       expect(screen.getByRole("alert")).toHaveTextContent(
         "Provider not enabled",
       );
+      expect(mockCaptureSupabaseError).toHaveBeenCalledWith(
+        oauthError,
+        "oauth.signIn.github",
+      );
     });
-    expect(mockCaptureSupabaseError).toHaveBeenCalledWith(
-      oauthError,
-      "oauth.signIn.github",
-    );
   });
 
   it("disables both buttons while a provider is loading", async () => {

--- a/src/components/auth/oauth-buttons.tsx
+++ b/src/components/auth/oauth-buttons.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { getClient } from "@/lib/supabase/lazy-client";
-import { captureSupabaseError } from "@/lib/sentry";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -61,7 +60,9 @@ export function OAuthButtons() {
     });
 
     if (oauthError) {
-      captureSupabaseError(oauthError as unknown as Error, `oauth.signIn.${provider}`);
+      import("@/lib/sentry").then(({ captureSupabaseError }) =>
+        captureSupabaseError(oauthError as unknown as Error, `oauth.signIn.${provider}`),
+      );
       setError(oauthError.message);
       setLoadingProvider(null);
     }


### PR DESCRIPTION
Closes #951

## What

Lazy-load `@/lib/sentry` in auth form components to keep the sentry error classification module (~22kB source) out of the initial page JS for auth routes.

## How

Replaced static `import { captureSupabaseError } from "@/lib/sentry"` with dynamic `import("@/lib/sentry").then(...)` in three files:

- `forgot-password-form.tsx` — only loads sentry when `resetPasswordForEmail` fails
- `reset-password-form.tsx` — only loads sentry when `updateUser` fails
- `oauth-buttons.tsx` — already dynamically imported itself, but its static sentry import was pulling the module into the dynamic chunk

This follows the same lazy-loading pattern used by `@/lib/capture.ts` and `@/lib/toast.ts`.

Updated `oauth-buttons.test.tsx` to wrap the `captureSupabaseError` assertion inside `waitFor` since the dynamic import makes the call asynchronous.

## Bundle sizes (gzipped first-load JS)

| Route | Before | After | Budget |
|---|---|---|---|
| `/sign-in` | 186.9 kB | 186.9 kB | 200 kB ✅ |
| `/sign-up` | 187.0 kB | 187.0 kB | 200 kB ✅ |
| `/forgot-password` | 188.1 kB | 186.6 kB | 200 kB ✅ |
| `/reset-password` | 188.0 kB | 186.6 kB | 200 kB ✅ |

The framework baseline (Next.js + React runtime shared by all routes) accounts for ~160 kB. The remaining ~27 kB is auth-specific UI components and form code.

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 133 files, 1818 tests passed
- Auth E2E (`auth.spec.ts`, `password-reset.spec.ts`, `public-routes.spec.ts`) — 36 tests passed
- `pnpm build` — all auth routes under 200 kB budget