### PR TITLE
perf: lazy-load settings page content to reduce first-load JS (#952)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -541,6 +541,8 @@ src/
 │   ├── route-error.tsx          # Reusable error boundary UI (Sentry capture + retry button)
 │   ├── workspace-home.tsx       # Workspace home: page list or empty state with create CTA
 │   ├── workspace-home-client.tsx # Client wrapper: lazy-loads WorkspaceHome via next/dynamic
+│   ├── settings-page-client.tsx  # Client wrapper: lazy-loads SettingsPageContent via next/dynamic
+│   ├── settings-page-content.tsx # Settings page layout: form + change password + danger zone
 │   ├── workspace-settings-form.tsx # Edit workspace name/slug, lazy-loads delete workspace section
 │   ├── delete-workspace-section.tsx # Workspace deletion danger zone with AlertDialog confirmation
 │   ├── danger-zone-settings.tsx # Client wrapper: lazy-loads DeleteAccountSection via next/dynamic

--- a/src/app/(app)/[workspaceSlug]/settings/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/page.tsx
@@ -1,11 +1,7 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { WorkspaceSettingsForm } from "@/components/workspace-settings-form";
-import { ChangePasswordSection } from "@/components/change-password-section";
-import { DangerZoneSettings } from "@/components/danger-zone-settings";
-import { Separator } from "@/components/ui/separator";
+import { SettingsPageClient } from "@/components/settings-page-client";
 
 export async function generateMetadata({
   params,
@@ -56,34 +52,10 @@ export default async function WorkspaceSettingsPage({
   const userEmail = user.email ?? "";
 
   return (
-    <div className="mx-auto max-w-xl p-6">
-      <div className="flex items-center gap-4">
-        <h1 className="text-2xl font-semibold">Workspace settings</h1>
-        <Link
-          href={`/${workspaceSlug}/settings/members`}
-          className="text-sm text-accent underline-offset-4 hover:underline"
-        >
-          Members
-        </Link>
-      </div>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Manage your workspace name, URL, and other settings.
-      </p>
-      <div className="mt-6">
-        <WorkspaceSettingsForm workspace={workspace} userId={user.id} />
-      </div>
-      {workspace.is_personal && (
-        <>
-          <Separator className="mt-8 bg-overlay-border" />
-          <div className="mt-8">
-            <ChangePasswordSection />
-          </div>
-          <Separator className="mt-8 bg-overlay-border" />
-          <div className="mt-8">
-            <DangerZoneSettings userEmail={userEmail} />
-          </div>
-        </>
-      )}
-    </div>
+    <SettingsPageClient
+      workspace={workspace}
+      userId={user.id}
+      userEmail={userEmail}
+    />
   );
 }

--- a/src/components/settings-page-client.tsx
+++ b/src/components/settings-page-client.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { Workspace } from "@/lib/types";
+
+const SettingsPageContent = dynamic(
+  () =>
+    import("@/components/settings-page-content").then(
+      (mod) => mod.SettingsPageContent,
+    ),
+);
+
+interface SettingsPageClientProps {
+  workspace: Workspace;
+  userId: string;
+  userEmail: string;
+}
+
+export function SettingsPageClient(props: SettingsPageClientProps) {
+  return <SettingsPageContent {...props} />;
+}

--- a/src/components/settings-page-content.tsx
+++ b/src/components/settings-page-content.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { WorkspaceSettingsForm } from "@/components/workspace-settings-form";
+import { Separator } from "@/components/ui/separator";
+import type { Workspace } from "@/lib/types";
+
+const ChangePasswordSection = dynamic(
+  () =>
+    import("@/components/change-password-section").then(
+      (mod) => mod.ChangePasswordSection,
+    ),
+);
+
+const DangerZoneSettings = dynamic(
+  () =>
+    import("@/components/danger-zone-settings").then(
+      (mod) => mod.DangerZoneSettings,
+    ),
+);
+
+interface SettingsPageContentProps {
+  workspace: Workspace;
+  userId: string;
+  userEmail: string;
+}
+
+export function SettingsPageContent({
+  workspace,
+  userId,
+  userEmail,
+}: SettingsPageContentProps) {
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <div className="flex items-center gap-4">
+        <h1 className="text-2xl font-semibold">Workspace settings</h1>
+        <Link
+          href={`/${workspace.slug}/settings/members`}
+          className="text-sm text-accent underline-offset-4 hover:underline"
+        >
+          Members
+        </Link>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Manage your workspace name, URL, and other settings.
+      </p>
+      <div className="mt-6">
+        <WorkspaceSettingsForm workspace={workspace} userId={userId} />
+      </div>
+      {workspace.is_personal && (
+        <>
+          <Separator className="mt-8 bg-overlay-border" />
+          <div className="mt-8">
+            <ChangePasswordSection />
+          </div>
+          <Separator className="mt-8 bg-overlay-border" />
+          <div className="mt-8">
+            <DangerZoneSettings userEmail={userEmail} />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #952

## What

Applies the same "thin client wrapper + `next/dynamic`" pattern already used by the workspace home and members pages to the settings page. This moves `WorkspaceSettingsForm`, `ChangePasswordSection`, and `DangerZoneSettings` out of the settings route's first-load JS bundle.

## How

- **`settings-page-client.tsx`** — thin `"use client"` wrapper that dynamically imports `SettingsPageContent`.
- **`settings-page-content.tsx`** — contains the settings page layout (heading, form, change password, danger zone). Additionally lazy-loads `ChangePasswordSection` and `DangerZoneSettings` via `next/dynamic` since they're conditional (personal workspace only).
- **`settings/page.tsx`** — simplified server component that fetches data and renders `SettingsPageClient`.

## Bundle size results

| Route | Before (gz, level=6) | After (gz, level=6) | Change |
|---|---|---|---|
| `/[workspaceSlug]/settings` | 197kB | 181kB | **−16kB** |
| `/[workspaceSlug]/settings/members` | 183kB | 183kB | unchanged |
| `/[workspaceSlug]` | 181kB | 181kB | unchanged |

All three routes are now well under the 200kB gzipped budget.

## Testing

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — clean
- `pnpm test` — 1818 tests passed (133 files)
- `pnpm test:e2e` — workspace-settings E2E: 2/3 passed; 1 pre-existing flaky failure (`delete non-personal workspace with confirmation`) confirmed on main
- No new interactive UI → no new E2E tests needed
- No visual changes → no story updates needed