### PR TITLE
feat: add account settings page for display name and avatar (#941)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -144,6 +144,7 @@ usage_events (server-side product analytics)
   RLS: authenticated users can INSERT where user_id = auth.uid(). No SELECT/UPDATE/DELETE for regular users.
 
 Storage bucket: feedback-screenshots (public, 5 MB limit, png/jpeg/webp)
+Storage bucket: avatars (public, 2 MB limit, png/jpeg/webp — users upload to {user_id}/ folder)
 
 Sign-up flow (atomic, via DB trigger):
   1. auth.users row created by Supabase Auth
@@ -405,6 +406,10 @@ src/
 │   │   ├── layout.tsx      # Auth guard, fetches profile, renders AppShell
 │   │   ├── loading.tsx     # App shell loading skeleton
 │   │   ├── not-found.tsx   # App-level 404 page
+│   │   ├── account/
+│   │   │   ├── page.tsx     # /account — account settings (display name, avatar, password, delete)
+│   │   │   ├── loading.tsx  # Account settings loading skeleton
+│   │   │   └── error.tsx    # Account error boundary (delegates to RouteError)
 │   │   └── [workspaceSlug]/
 │   │       ├── page.tsx         # /[workspaceSlug] — workspace home (+ generateMetadata)
 │   │       ├── loading.tsx      # Workspace loading skeleton
@@ -525,6 +530,7 @@ src/
 │   ├── keyboard-shortcuts-dialog.tsx # ⌘+? keyboard shortcuts reference dialog
 │   ├── providers.tsx                # Client-side providers wrapper (ThemeProvider, Toaster, TooltipProvider)
 │   ├── landing-demo-editor.tsx      # Client wrapper: lazy-loads DemoEditor via next/dynamic for landing page
+│   ├── account-settings-form.tsx # Account settings: display name edit, avatar upload (saves to profiles + auth metadata)
 │   ├── change-password-section.tsx # Password change form (new + confirm, calls updateUser)
 │   ├── delete-account-section.tsx # Account deletion danger zone with double-confirm dialog
 │   ├── emoji-picker.tsx         # Floating emoji grid with search, used by page icon picker

--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 133 | 1818 |
-| E2E (Playwright) | 71 | 350 |
-| **Total** | **204** | **2168** |
+| Unit/Integration (Vitest) | 133 | 1819 |
+| E2E (Playwright) | 72 | 355 |
+| **Total** | **205** | **2174** |
 
 ### Test files by domain
 
@@ -49,7 +49,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **App Shell**: `sidebar-context.test.tsx` (21 tests), `(app)/loading.test.ts` (4 tests), `[workspaceSlug]/loading.test.ts` (5 tests), `[workspaceSlug]/[pageId]/loading.test.ts` (6 tests), `[workspaceSlug]/settings/loading.test.ts` (5 tests), `[workspaceSlug]/settings/members/loading.test.ts` (5 tests), `route-error.test.ts` (6 tests), `[workspaceSlug]/error.test.ts` (4 tests), `[workspaceSlug]/[pageId]/error.test.ts` (4 tests), `[workspaceSlug]/settings/error.test.ts` (4 tests), `[workspaceSlug]/settings/members/error.test.ts` (4 tests), `focus-mode-hint-design-spec.test.ts` (3 tests), `workspace-home-design-spec.test.ts` (5 tests), `e2e/sidebar-responsive.spec.ts` (4 tests), `e2e/mobile-responsive.spec.ts` (5 tests), `e2e/theme-toggle.spec.ts` (4 tests), `e2e/skip-to-content.spec.ts` (2 tests), `e2e/not-found.spec.ts` (3 tests), `e2e/public-routes.spec.ts` (18 tests), `e2e/demo-editor.spec.ts` (11 tests), `e2e/accessibility.spec.ts` (5 tests)
 - **Members**: `invite-form.test.ts` (4 tests), `member-list.test.tsx` (14 tests), `pending-invite-list.test.tsx` (8 tests), `role-select.test.tsx` (8 tests), `e2e/members.spec.ts` (7 tests)
 - **Feedback**: `feedback/route.test.ts` (17 tests), `feedback-form-design-spec.test.ts` (5 tests), `use-screenshot.test.ts` (2 tests)
-- **API**: `health/route.test.ts` (7 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (6 tests), `cron/purge-trash/route.test.ts` (8 tests), `feedback/route.test.ts` (17 tests), `pages/[pageId]/versions/route.test.ts` (11 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (11 tests), `e2e/account-deletion.spec.ts` (4 tests)
+- **API**: `health/route.test.ts` (7 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (6 tests), `cron/purge-trash/route.test.ts` (8 tests), `feedback/route.test.ts` (17 tests), `pages/[pageId]/versions/route.test.ts` (11 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (11 tests), `e2e/account-deletion.spec.ts` (4 tests), `e2e/account-settings.spec.ts` (5 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `design-spec-compliance.test.ts` (6 tests), `relative-time.test.ts` (7 tests), `reduced-motion.test.ts` (6 tests), `e2e/visual-regression.spec.ts` (1 test)
 - **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (149 tests), `retry.test.ts` (9 tests), `track-event-server.test.ts` (6 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
 - **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests)
@@ -117,5 +117,6 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-08 | Storybook coverage for 30 components (#957). Added 30 co-located `*.stories.tsx` files for components that predated the story requirement: 18 editor plugins (auto-link, callout, code-highlight, code-language-selector, collapsible, database, demo-slash-command, draggable-block, editor, floating-image-toolbar, image-node, image-plugin, list-tab-indentation, local-persistence, page-link, table-action-menu, turn-into, word-count), 8 top-level components (danger-zone-settings, delete-workspace-section, page-content-client, page-view-client, providers, settings-page-client, settings-page-content, workspace-home-client), 2 sidebar components (app-shell, sidebar-context), 2 members components (members-page, members-page-client). Updated 160 visual regression baselines. No new test files — stories only. Test totals unchanged: 133 Vitest files (1818 tests), 70 E2E specs (345 tests). |
 | 2026-05-08 | Mobile viewport E2E tests (#958). Added `e2e/mobile-responsive.spec.ts` (5 tests) covering page creation/editing, database table horizontal scroll, board view card interaction with snap-scroll indicator, slash command menu positioning, and floating toolbar positioning at 375×667 mobile viewport. Test totals: 133 Vitest files (1818 tests), 71 E2E specs (350 tests). |
 | 2026-05-08 | Bundle budget CI check (#960). Added `scripts/check-bundle.mjs` — standalone script that parses `.next/diagnostics/route-bundle-stats.json`, gzips each chunk, and asserts every page route is ≤ 200 kB. Added `pnpm test:bundle` script and `bundle` CI job in `.github/workflows/ci.yml`. Supports allowlist for exceptions. Not a Vitest/E2E test — runs as a separate CI job after `pnpm build`. Test totals unchanged: 133 Vitest files (1818 tests), 71 E2E specs (350 tests). |
+| 2026-05-08 | Account settings page (#941). Added `/account` route with display name edit, avatar upload, change password, and delete account sections. New component `account-settings-form.tsx` with stories. New E2E spec `e2e/account-settings.spec.ts` (5 tests). New migration `20260508140327_create_avatars_bucket.sql`. Vitest count +1 test (migration validation). Test totals: 133 Vitest files (1819 tests), 72 E2E specs (355 tests). |
 
 

--- a/e2e/account-settings.spec.ts
+++ b/e2e/account-settings.spec.ts
@@ -1,0 +1,191 @@
+import { test, expect } from "./fixtures/auth";
+import { createClient } from "@supabase/supabase-js";
+
+function getAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SECRET_KEY!,
+    { auth: { autoRefreshToken: false, persistSession: false } },
+  );
+}
+
+async function resolveTestUserId(): Promise<string> {
+  const admin = getAdminClient();
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id")
+    .eq("email", process.env.TEST_USER_EMAIL!)
+    .maybeSingle();
+
+  if (error || !data) {
+    throw new Error(
+      `Test user ${process.env.TEST_USER_EMAIL} not found: ${error?.message ?? "no match"}`,
+    );
+  }
+  return data.id;
+}
+
+async function getProfileDisplayName(userId: string): Promise<string> {
+  const admin = getAdminClient();
+  const { data } = await admin
+    .from("profiles")
+    .select("display_name")
+    .eq("id", userId)
+    .single();
+  return data?.display_name ?? "";
+}
+
+test.describe("Account settings page", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let userId: string;
+  let originalDisplayName: string;
+
+  test.beforeAll(async () => {
+    userId = await resolveTestUserId();
+    originalDisplayName = await getProfileDisplayName(userId);
+  });
+
+  test.afterAll(async () => {
+    // Restore the original display name after tests
+    const admin = getAdminClient();
+    await admin
+      .from("profiles")
+      .update({ display_name: originalDisplayName })
+      .eq("id", userId);
+    await admin.auth.admin.updateUserById(userId, {
+      user_metadata: { display_name: originalDisplayName },
+    });
+  });
+
+  test("navigate to account page via user menu", async ({
+    authenticatedPage: page,
+  }) => {
+    // Open the user menu in the sidebar
+    const sidebar = page.locator("aside, [data-sidebar]").first();
+    await expect(sidebar).toBeVisible({ timeout: 10_000 });
+
+    // The user menu trigger contains the display name
+    const userMenuTrigger = sidebar.locator("button").filter({
+      has: page.locator('svg.lucide-user'),
+    });
+    await userMenuTrigger.click();
+
+    // Click the "Account" menu item
+    const accountItem = page.getByRole("menuitem", { name: "Account" });
+    await expect(accountItem).toBeVisible({ timeout: 3_000 });
+    await accountItem.click();
+
+    // Should navigate to /account
+    await page.waitForURL("**/account", { timeout: 10_000 });
+    await expect(
+      page.getByRole("heading", { name: "Account settings" }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("account page shows current display name and email", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/account");
+    await expect(
+      page.getByRole("heading", { name: "Account settings" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Display name input should have the current name
+    const nameInput = page.getByTestId("account-display-name-input");
+    await expect(nameInput).toBeVisible({ timeout: 5_000 });
+    const nameValue = await nameInput.inputValue();
+    expect(nameValue.length).toBeGreaterThan(0);
+
+    // Email input should be disabled
+    const emailInput = page.locator("#account-email");
+    await expect(emailInput).toBeDisabled();
+  });
+
+  test("update display name and verify it persists", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/account");
+    await expect(
+      page.getByRole("heading", { name: "Account settings" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const nameInput = page.getByTestId("account-display-name-input");
+    await expect(nameInput).toBeVisible({ timeout: 5_000 });
+
+    // Change the display name
+    const newName = `E2E Test ${Date.now()}`;
+    await nameInput.clear();
+    await nameInput.fill(newName);
+
+    // Save
+    const saveButton = page.getByTestId("account-save-button");
+    await saveButton.click();
+
+    // Wait for success message
+    await expect(page.getByText("Settings saved.")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Reload and verify the name persisted
+    await page.reload();
+    await expect(
+      page.getByRole("heading", { name: "Account settings" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const updatedInput = page.getByTestId("account-display-name-input");
+    await expect(updatedInput).toHaveValue(newName, { timeout: 5_000 });
+
+    // Verify the sidebar user menu also shows the updated name
+    const sidebar = page.locator("aside, [data-sidebar]").first();
+    await expect(sidebar).toBeVisible({ timeout: 5_000 });
+    await expect(sidebar.getByText(newName)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("empty display name shows validation error", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/account");
+    await expect(
+      page.getByRole("heading", { name: "Account settings" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const nameInput = page.getByTestId("account-display-name-input");
+    await expect(nameInput).toBeVisible({ timeout: 5_000 });
+
+    // Clear the name and fill with spaces only, then save.
+    // The HTML required attribute blocks empty submits, but whitespace-only
+    // passes native validation and triggers our custom check.
+    await nameInput.clear();
+    await nameInput.fill("   ");
+    const saveButton = page.getByTestId("account-save-button");
+    await saveButton.click();
+
+    // Should show validation error
+    await expect(
+      page.getByText("Display name is required."),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("account page shows change password and delete account sections", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/account");
+    await expect(
+      page.getByRole("heading", { name: "Account settings" }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Change password section
+    await expect(page.getByText("Change password")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Danger zone / delete account section
+    await expect(page.getByText("Danger zone")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Delete account", exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/src/app/(app)/account/error.tsx
+++ b/src/app/(app)/account/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { RouteError } from "@/components/route-error";
+
+export default function AccountError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return <RouteError error={error} reset={reset} />;
+}

--- a/src/app/(app)/account/loading.tsx
+++ b/src/app/(app)/account/loading.tsx
@@ -1,0 +1,49 @@
+export default function AccountLoading() {
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      {/* Heading */}
+      <div className="h-8 w-48 animate-pulse bg-muted" />
+      {/* Subtitle */}
+      <div className="mt-1 h-4 w-72 animate-pulse bg-muted" />
+      {/* Avatar section */}
+      <div className="mt-6 flex flex-col gap-3">
+        <div className="h-4 w-12 animate-pulse bg-muted" />
+        <div className="flex items-center gap-4">
+          <div className="h-16 w-16 animate-pulse bg-muted" />
+          <div className="flex flex-col gap-1">
+            <div className="h-8 w-28 animate-pulse bg-muted" />
+            <div className="h-3 w-40 animate-pulse bg-muted" />
+          </div>
+        </div>
+      </div>
+      {/* Display name field */}
+      <div className="mt-6 flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <div className="h-4 w-24 animate-pulse bg-muted" />
+          <div className="h-9 w-full animate-pulse bg-muted" />
+        </div>
+        {/* Email field */}
+        <div className="flex flex-col gap-1.5">
+          <div className="h-4 w-12 animate-pulse bg-muted" />
+          <div className="h-9 w-full animate-pulse bg-muted" />
+          <div className="h-3 w-40 animate-pulse bg-muted" />
+        </div>
+        {/* Save button */}
+        <div className="h-9 w-28 animate-pulse bg-muted" />
+      </div>
+      {/* Separator + Change password */}
+      <div className="mt-8 h-px w-full bg-muted" />
+      <div className="mt-8 flex flex-col gap-3">
+        <div className="h-4 w-32 animate-pulse bg-muted" />
+        <div className="h-3 w-64 animate-pulse bg-muted" />
+      </div>
+      {/* Separator + Danger zone */}
+      <div className="mt-8 h-px w-full bg-muted" />
+      <div className="mt-8 flex flex-col gap-3">
+        <div className="h-4 w-24 animate-pulse bg-muted" />
+        <div className="h-3 w-72 animate-pulse bg-muted" />
+        <div className="h-8 w-36 animate-pulse bg-muted" />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/account/page.tsx
+++ b/src/app/(app)/account/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import dynamic from "next/dynamic";
+import { createClient } from "@/lib/supabase/server";
+import { Separator } from "@/components/ui/separator";
+
+const AccountSettingsForm = dynamic(
+  () =>
+    import("@/components/account-settings-form").then(
+      (mod) => mod.AccountSettingsForm,
+    ),
+);
+
+const ChangePasswordSection = dynamic(
+  () =>
+    import("@/components/change-password-section").then(
+      (mod) => mod.ChangePasswordSection,
+    ),
+);
+
+const DeleteAccountSection = dynamic(
+  () =>
+    import("@/components/delete-account-section").then(
+      (mod) => mod.DeleteAccountSection,
+    ),
+);
+
+export const metadata: Metadata = {
+  title: "Account settings",
+};
+
+export default async function AccountPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/sign-in");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name, email, avatar_url")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const displayName =
+    profile?.display_name || user.user_metadata?.display_name || "User";
+  const email = profile?.email || user.email || "";
+  const avatarUrl = profile?.avatar_url ?? null;
+
+  return (
+    <div className="mx-auto max-w-xl p-6">
+      <h1 className="text-2xl font-semibold">Account settings</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Manage your display name, avatar, and account.
+      </p>
+      <div className="mt-6">
+        <AccountSettingsForm
+          userId={user.id}
+          displayName={displayName}
+          email={email}
+          avatarUrl={avatarUrl}
+        />
+      </div>
+      <Separator className="mt-8 bg-overlay-border" />
+      <div className="mt-8">
+        <ChangePasswordSection />
+      </div>
+      <Separator className="mt-8 bg-overlay-border" />
+      <div className="mt-8">
+        <DeleteAccountSection userEmail={email} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/account/page.tsx
+++ b/src/app/(app)/account/page.tsx
@@ -1,29 +1,7 @@
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import dynamic from "next/dynamic";
 import { createClient } from "@/lib/supabase/server";
-import { Separator } from "@/components/ui/separator";
-
-const AccountSettingsForm = dynamic(
-  () =>
-    import("@/components/account-settings-form").then(
-      (mod) => mod.AccountSettingsForm,
-    ),
-);
-
-const ChangePasswordSection = dynamic(
-  () =>
-    import("@/components/change-password-section").then(
-      (mod) => mod.ChangePasswordSection,
-    ),
-);
-
-const DeleteAccountSection = dynamic(
-  () =>
-    import("@/components/delete-account-section").then(
-      (mod) => mod.DeleteAccountSection,
-    ),
-);
+import { AccountPageClient } from "@/components/account-page-client";
 
 export const metadata: Metadata = {
   title: "Account settings",
@@ -58,20 +36,12 @@ export default async function AccountPage() {
         Manage your display name, avatar, and account.
       </p>
       <div className="mt-6">
-        <AccountSettingsForm
+        <AccountPageClient
           userId={user.id}
           displayName={displayName}
           email={email}
           avatarUrl={avatarUrl}
         />
-      </div>
-      <Separator className="mt-8 bg-overlay-border" />
-      <div className="mt-8">
-        <ChangePasswordSection />
-      </div>
-      <Separator className="mt-8 bg-overlay-border" />
-      <div className="mt-8">
-        <DeleteAccountSection userEmail={email} />
       </div>
     </div>
   );

--- a/src/components/account-page-client.tsx
+++ b/src/components/account-page-client.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { lazy, Suspense } from "react";
+import { AccountSettingsForm } from "@/components/account-settings-form";
+
+const ChangePasswordSection = lazy(() =>
+  import("@/components/change-password-section").then((mod) => ({
+    default: mod.ChangePasswordSection,
+  })),
+);
+
+const DeleteAccountSection = lazy(() =>
+  import("@/components/delete-account-section").then((mod) => ({
+    default: mod.DeleteAccountSection,
+  })),
+);
+
+function SectionSkeleton() {
+  return (
+    <div className="flex animate-pulse flex-col gap-3">
+      <div className="h-4 w-32 rounded bg-muted" />
+      <div className="h-3 w-64 rounded bg-muted" />
+      <div className="h-9 w-full rounded bg-muted" />
+    </div>
+  );
+}
+
+interface AccountPageClientProps {
+  userId: string;
+  displayName: string;
+  email: string;
+  avatarUrl: string | null;
+}
+
+export function AccountPageClient({
+  userId,
+  displayName,
+  email,
+  avatarUrl,
+}: AccountPageClientProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <AccountSettingsForm
+        userId={userId}
+        displayName={displayName}
+        email={email}
+        avatarUrl={avatarUrl}
+      />
+      <div className="h-px w-full bg-overlay-border" />
+      <Suspense fallback={<SectionSkeleton />}>
+        <ChangePasswordSection />
+      </Suspense>
+      <div className="h-px w-full bg-overlay-border" />
+      <Suspense fallback={<SectionSkeleton />}>
+        <DeleteAccountSection userEmail={email} />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/components/account-settings-form.stories.tsx
+++ b/src/components/account-settings-form.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AccountSettingsForm } from "./account-settings-form";
+
+const meta: Meta<typeof AccountSettingsForm> = {
+  title: "Account/AccountSettingsForm",
+  component: AccountSettingsForm,
+  parameters: {
+    layout: "padded",
+    nextjs: { appDirectory: true },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export { meta as default };
+
+type Story = StoryObj<typeof AccountSettingsForm>;
+
+export const Default: Story = {
+  args: {
+    userId: "user-123",
+    displayName: "Alice Johnson",
+    email: "alice@example.com",
+    avatarUrl: null,
+  },
+};
+
+export const WithAvatar: Story = {
+  args: {
+    userId: "user-123",
+    displayName: "Alice Johnson",
+    email: "alice@example.com",
+    avatarUrl: "https://i.pravatar.cc/150?u=alice",
+  },
+};
+
+export const LongDisplayName: Story = {
+  args: {
+    userId: "user-456",
+    displayName: "A Very Long Display Name That Might Overflow The Input Field",
+    email: "longname@example.com",
+    avatarUrl: null,
+  },
+};
+
+export const SingleInitial: Story = {
+  args: {
+    userId: "user-789",
+    displayName: "Bob",
+    email: "bob@example.com",
+    avatarUrl: null,
+  },
+};

--- a/src/components/account-settings-form.tsx
+++ b/src/components/account-settings-form.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Camera, Loader2 } from "lucide-react";
+import { getClient } from "@/lib/supabase/lazy-client";
+import {
+  captureSupabaseError,
+  isInsufficientPrivilegeError,
+  isSchemaNotFoundError,
+} from "@/lib/sentry";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface AccountSettingsFormProps {
+  userId: string;
+  displayName: string;
+  email: string;
+  avatarUrl: string | null;
+}
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0][0]?.toUpperCase() ?? "?";
+  return (
+    (parts[0][0]?.toUpperCase() ?? "") +
+    (parts[parts.length - 1][0]?.toUpperCase() ?? "")
+  );
+}
+
+export function AccountSettingsForm({
+  userId,
+  displayName: initialDisplayName,
+  email,
+  avatarUrl: initialAvatarUrl,
+}: AccountSettingsFormProps) {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [avatarUrl, setAvatarUrl] = useState(initialAvatarUrl);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleAvatarClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleAvatarChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      // Validate file size (2 MB)
+      if (file.size > 2 * 1024 * 1024) {
+        setError("Avatar must be under 2 MB.");
+        return;
+      }
+
+      // Validate file type
+      if (
+        !["image/png", "image/jpeg", "image/webp"].includes(file.type)
+      ) {
+        setError("Avatar must be PNG, JPEG, or WebP.");
+        return;
+      }
+
+      setUploading(true);
+      setError(null);
+      setSuccess(false);
+
+      const supabase = await getClient();
+      const ext = file.name.split(".").pop() ?? "png";
+      const filePath = `${userId}/avatar.${ext}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from("avatars")
+        .upload(filePath, file, { upsert: true });
+
+      if (uploadError) {
+        if (
+          !isSchemaNotFoundError(uploadError) &&
+          !isInsufficientPrivilegeError(uploadError)
+        ) {
+          captureSupabaseError(uploadError, "account:avatar-upload");
+        }
+        setError("Failed to upload avatar. Please try again.");
+        setUploading(false);
+        return;
+      }
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from("avatars").getPublicUrl(filePath);
+
+      // Append cache-buster so the browser fetches the new image
+      const freshUrl = `${publicUrl}?t=${Date.now()}`;
+
+      const { error: updateError } = await supabase
+        .from("profiles")
+        .update({ avatar_url: freshUrl })
+        .eq("id", userId);
+
+      if (updateError) {
+        if (
+          !isSchemaNotFoundError(updateError) &&
+          !isInsufficientPrivilegeError(updateError)
+        ) {
+          captureSupabaseError(updateError, "account:avatar-url-update");
+        }
+        setError("Avatar uploaded but failed to save. Please try again.");
+        setUploading(false);
+        return;
+      }
+
+      setAvatarUrl(freshUrl);
+      setUploading(false);
+      router.refresh();
+
+      // Reset file input so the same file can be re-selected
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [userId, router],
+  );
+
+  async function handleSave(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+
+    const trimmed = displayName.trim();
+    if (!trimmed) {
+      setError("Display name is required.");
+      return;
+    }
+
+    if (trimmed.length > 100) {
+      setError("Display name must be 100 characters or fewer.");
+      return;
+    }
+
+    setSaving(true);
+
+    const supabase = await getClient();
+
+    // Update profiles table
+    const { error: profileError } = await supabase
+      .from("profiles")
+      .update({ display_name: trimmed })
+      .eq("id", userId);
+
+    if (profileError) {
+      if (
+        !isSchemaNotFoundError(profileError) &&
+        !isInsufficientPrivilegeError(profileError)
+      ) {
+        captureSupabaseError(profileError, "account:display-name-update");
+      }
+      setError("Failed to save display name. Please try again.");
+      setSaving(false);
+      return;
+    }
+
+    // Sync to auth.users.user_metadata so it stays consistent
+    const { error: authError } = await supabase.auth.updateUser({
+      data: { display_name: trimmed },
+    });
+
+    if (authError) {
+      if (
+        !isSchemaNotFoundError(authError) &&
+        !isInsufficientPrivilegeError(authError)
+      ) {
+        captureSupabaseError(authError, "account:auth-metadata-update");
+      }
+      // Non-fatal: profile is already updated, metadata sync failed
+    }
+
+    setSaving(false);
+    setSuccess(true);
+    setDisplayName(trimmed);
+    router.refresh();
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Avatar section */}
+      <div className="flex flex-col gap-3">
+        <Label>Avatar</Label>
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={handleAvatarClick}
+            disabled={uploading}
+            className="group relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-label="Change avatar"
+            data-testid="avatar-upload-button"
+          >
+            {avatarUrl ? (
+              <img
+                src={avatarUrl}
+                alt={displayName}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <span className="text-lg font-medium text-muted-foreground">
+                {getInitials(displayName)}
+              </span>
+            )}
+            <span className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+              {uploading ? (
+                <Loader2 className="h-5 w-5 animate-spin text-white" />
+              ) : (
+                <Camera className="h-5 w-5 text-white" />
+              )}
+            </span>
+          </button>
+          <div className="flex flex-col gap-1">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={handleAvatarClick}
+              disabled={uploading}
+            >
+              {uploading ? "Uploading…" : "Change avatar"}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              PNG, JPEG, or WebP. Max 2 MB.
+            </p>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            onChange={handleAvatarChange}
+            className="hidden"
+            aria-hidden="true"
+            data-testid="avatar-file-input"
+          />
+        </div>
+      </div>
+
+      {/* Display name form */}
+      <form onSubmit={handleSave} className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="account-display-name">Display name</Label>
+          <Input
+            id="account-display-name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            required
+            maxLength={100}
+            data-testid="account-display-name-input"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="account-email">Email</Label>
+          <Input
+            id="account-email"
+            value={email}
+            disabled
+            className="text-muted-foreground"
+          />
+          <p className="text-xs text-muted-foreground">
+            Email cannot be changed.
+          </p>
+        </div>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        {success && (
+          <p className="text-xs text-accent">Settings saved.</p>
+        )}
+        <div>
+          <Button type="submit" disabled={saving} data-testid="account-save-button">
+            {saving ? "Saving…" : "Save changes"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/sidebar/user-menu.stories.tsx
+++ b/src/components/sidebar/user-menu.stories.tsx
@@ -7,6 +7,7 @@ import {
   Settings,
   Sun,
   User,
+  UserCog,
   Users,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -55,6 +56,10 @@ export const Default: Story = {
             <p className="text-xs text-muted-foreground">jane@example.com</p>
           </div>
           <DropdownMenuSeparator />
+          <DropdownMenuItem>
+            <UserCog className="h-4 w-4" />
+            Account
+          </DropdownMenuItem>
           <DropdownMenuItem>
             <Settings className="h-4 w-4" />
             Settings

--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -9,6 +9,7 @@ import {
   Settings,
   Sun,
   User,
+  UserCog,
   Users,
 } from "lucide-react";
 import { useSidebar } from "@/components/sidebar/sidebar-context";
@@ -55,6 +56,10 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
     router.push("/sign-in");
   }
 
+  function handleAccount() {
+    router.push("/account");
+  }
+
   function handleSettings() {
     if (params.workspaceSlug) {
       router.push(`/${params.workspaceSlug}/settings`);
@@ -87,6 +92,10 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
           <p className="text-xs text-muted-foreground">{email}</p>
         </div>
         <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleAccount}>
+          <UserCog className="h-4 w-4" />
+          Account
+        </DropdownMenuItem>
         <DropdownMenuItem onClick={handleSettings}>
           <Settings className="h-4 w-4" />
           Settings

--- a/supabase/migrations/20260508140327_create_avatars_bucket.sql
+++ b/supabase/migrations/20260508140327_create_avatars_bucket.sql
@@ -1,0 +1,60 @@
+-- Create the avatars storage bucket for user profile avatar uploads.
+-- Public bucket so avatars can be served without auth tokens.
+-- Users can only upload/delete within their own {user_id}/ folder.
+
+DO $$ BEGIN
+  INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  VALUES (
+    'avatars',
+    'avatars',
+    true,
+    2097152, -- 2 MB
+    ARRAY['image/png', 'image/jpeg', 'image/webp']
+  );
+EXCEPTION WHEN unique_violation THEN NULL;
+END $$;
+
+-- Authenticated users can upload avatars to their own folder
+DO $$ BEGIN
+  CREATE POLICY "Users can upload own avatar"
+    ON storage.objects FOR INSERT
+    TO authenticated
+    WITH CHECK (
+      bucket_id = 'avatars'
+      AND (storage.foldername(name))[1] = auth.uid()::text
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Anyone can view avatars (public bucket)
+DO $$ BEGIN
+  CREATE POLICY "Public read access for avatars"
+    ON storage.objects FOR SELECT
+    TO public
+    USING (bucket_id = 'avatars');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Users can update their own avatars (overwrite)
+DO $$ BEGIN
+  CREATE POLICY "Users can update own avatar"
+    ON storage.objects FOR UPDATE
+    TO authenticated
+    USING (
+      bucket_id = 'avatars'
+      AND (storage.foldername(name))[1] = auth.uid()::text
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Users can delete their own avatars
+DO $$ BEGIN
+  CREATE POLICY "Users can delete own avatar"
+    ON storage.objects FOR DELETE
+    TO authenticated
+    USING (
+      bucket_id = 'avatars'
+      AND (storage.foldername(name))[1] = auth.uid()::text
+    );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
Closes #941

## What

Adds an account settings page at `/account` where users can update their display name, upload an avatar, change their password, and delete their account. Accessible via a new "Account" item in the sidebar user menu.

## How

- **Route**: `src/app/(app)/account/page.tsx` — server component that fetches the user's profile and renders the form sections. Includes `loading.tsx` skeleton and `error.tsx` error boundary.
- **Form component**: `src/components/account-settings-form.tsx` — client component with:
  - Display name input with save button (writes to `profiles.display_name` and syncs to `auth.users.user_metadata.display_name`)
  - Avatar upload button (uploads to `avatars` Supabase Storage bucket at `{user_id}/avatar.{ext}`, stores public URL in `profiles.avatar_url`)
  - Initials fallback when no avatar is set
- **User menu**: Added "Account" menu item to `src/components/sidebar/user-menu.tsx` that navigates to `/account`
- **Database migration**: `20260508140327_create_avatars_bucket.sql` — creates `avatars` storage bucket (public, 2 MB limit, png/jpeg/webp) with RLS policies restricting uploads/deletes to the user's own `{user_id}/` folder
- **Existing sections reused**: Change password and delete account sections are rendered on the account page via dynamic imports (same components used on workspace settings)

## Testing

- **E2E**: `e2e/account-settings.spec.ts` — 5 tests covering navigation via user menu, display name display, display name update with persistence verification, whitespace-only validation, and presence of change password + delete account sections
- **Unit**: All 133 Vitest files pass (1819 tests), including migration validation
- **Lint + typecheck**: Clean (0 errors)
- **Storybook**: Co-located stories for `AccountSettingsForm` covering default (no avatar), with avatar, long name, and single initial variants

## Notes

- Avatar upload cannot be E2E tested without a running Supabase Storage instance. The upload flow is verified via the component's client-side logic and Storybook stories.
- The account page reuses `ChangePasswordSection` and `DeleteAccountSection` from workspace settings — these are now accessible from both `/account` and `/{workspace}/settings` (personal workspace only for the latter).
