### PR TITLE
chore: make bundle budget CI job a merge gate (#973)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - run: pnpm test:bundle
   e2e:
     runs-on: ubuntu-latest
-    needs: check
+    needs: [check, bundle]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5

--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -17,9 +17,18 @@ const BUDGET_KB = 200;
 const BUDGET_BYTES = BUDGET_KB * 1024;
 const STATS_PATH = resolve(".next/diagnostics/route-bundle-stats.json");
 
-// Routes that are allowed to exceed the budget. Add entries with a comment explaining why.
-// Example: { route: "/some-page", budgetKB: 250, reason: "includes large charting library" }
-const ALLOWLIST = [];
+// Routes that are allowed to exceed the default budget.
+// Each entry records the observed size (rounded up) so the check prevents further regression.
+// Tracked in #973 — these should be reduced to ≤200 kB over time.
+const ALLOWLIST = [
+  { route: "/sign-in", budgetKB: 290, reason: "Auth pages share a large Supabase auth bundle (#973)" },
+  { route: "/sign-up", budgetKB: 290, reason: "Auth pages share a large Supabase auth bundle (#973)" },
+  { route: "/forgot-password", budgetKB: 250, reason: "Auth pages share a large Supabase auth bundle (#973)" },
+  { route: "/reset-password", budgetKB: 250, reason: "Auth pages share a large Supabase auth bundle (#973)" },
+  { route: "/[workspaceSlug]", budgetKB: 250, reason: "Workspace root includes editor + sidebar bundles (#973)" },
+  { route: "/[workspaceSlug]/settings", budgetKB: 230, reason: "Settings page includes form + avatar components (#973)" },
+  { route: "/[workspaceSlug]/settings/members", budgetKB: 270, reason: "Members page includes invite dialog + member list (#973)" },
+];
 
 function run() {
   let raw;


### PR DESCRIPTION
Closes #973

## What

Makes the `bundle` CI job a merge gate so bundle size regressions cannot land on main. Adds an allowlist for the 7 routes currently over the 200kB budget so the check passes for the current state while preventing further regression.

## How

1. **`scripts/check-bundle.mjs`** — Added 7 over-budget routes to the `ALLOWLIST` with their current sizes rounded up to the nearest 10kB ceiling:
   - `/sign-in` (290kB), `/sign-up` (290kB) — auth bundle
   - `/forgot-password` (250kB), `/reset-password` (250kB) — auth bundle
   - `/[workspaceSlug]` (250kB) — editor + sidebar
   - `/[workspaceSlug]/settings` (230kB) — form + avatar
   - `/[workspaceSlug]/settings/members` (270kB) — invite dialog + member list

2. **`.github/workflows/ci.yml`** — Changed the `e2e` job from `needs: check` to `needs: [check, bundle]`. Since `e2e` is a downstream job, a `bundle` failure now prevents the pipeline from completing, effectively making it a merge gate.

## Testing

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (133 files, 1822 tests)
- No interactive UI changes — E2E tests not required