### PR TITLE
perf: remove auth page bundle allowlist entries (#979)

### DIFF
--- a/scripts/check-bundle.mjs
+++ b/scripts/check-bundle.mjs
@@ -21,10 +21,6 @@ const STATS_PATH = resolve(".next/diagnostics/route-bundle-stats.json");
 // Each entry records the observed size (rounded up) so the check prevents further regression.
 // Tracked in #973 — these should be reduced to ≤200 kB over time.
 const ALLOWLIST = [
-  { route: "/sign-in", budgetKB: 290, reason: "Auth pages share a large Supabase auth bundle (#973)" },
-  { route: "/sign-up", budgetKB: 290, reason: "Auth pages share a large Supabase auth bundle (#973)" },
-  { route: "/forgot-password", budgetKB: 250, reason: "Auth pages share a large Supabase auth bundle (#973)" },
-  { route: "/reset-password", budgetKB: 250, reason: "Auth pages share a large Supabase auth bundle (#973)" },
   { route: "/[workspaceSlug]", budgetKB: 250, reason: "Workspace root includes editor + sidebar bundles (#973)" },
   { route: "/[workspaceSlug]/settings", budgetKB: 230, reason: "Settings page includes form + avatar components (#973)" },
   { route: "/[workspaceSlug]/settings/members", budgetKB: 270, reason: "Members page includes invite dialog + member list (#973)" },


### PR DESCRIPTION
Closes #979

## What

Remove the 4 auth route entries (`/sign-in`, `/sign-up`, `/forgot-password`, `/reset-password`) from the bundle budget allowlist in `scripts/check-bundle.mjs`. These routes now pass the standard 200kB gzipped budget without overrides.

## Why

Auth pages were originally 243-286kB and needed allowlist entries to prevent CI failures. Prior optimizations — lazy Supabase client (`getClient` via dynamic import), dynamic OAuth buttons (`next/dynamic`), and lazy Sentry imports — brought them down to 186-187kB, well under the 200kB budget. The allowlist entries were never cleaned up.

## Current auth page sizes

| Route | Size (gzip) | Budget |
|---|---|---|
| `/sign-in` | 187.1 kB | 200 kB ✅ |
| `/sign-up` | 187.2 kB | 200 kB ✅ |
| `/forgot-password` | 186.8 kB | 200 kB ✅ |
| `/reset-password` | 186.8 kB | 200 kB ✅ |

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 133 files, 1822 tests passed
- `pnpm build && pnpm test:bundle` — all 12 routes pass without allowlist entries
- E2E: `e2e/auth.spec.ts` (8 tests), `e2e/password-reset.spec.ts` (10 tests), `e2e/public-routes.spec.ts` (18 tests) — all pass
- No UI or functional changes — only the bundle check script was modified