### PR TITLE
fix: remove rounded corners from invite loading skeleton (#1003)

### DIFF
--- a/src/app/(auth)/invite/[token]/loading.tsx
+++ b/src/app/(auth)/invite/[token]/loading.tsx
@@ -9,13 +9,13 @@ export default function InviteLoading() {
     <Card>
       <CardHeader>
         {/* Title skeleton */}
-        <div className="h-7 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-7 w-48 animate-pulse bg-muted" />
         {/* Description skeleton */}
-        <div className="h-4 w-64 animate-pulse rounded bg-muted" />
+        <div className="h-4 w-64 animate-pulse bg-muted" />
       </CardHeader>
       <CardContent>
         {/* Action button skeleton */}
-        <div className="h-9 w-full animate-pulse rounded bg-muted" />
+        <div className="h-9 w-full animate-pulse bg-muted" />
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Closes #1003

## What
The invite page loading skeleton (`src/app/(auth)/invite/[token]/loading.tsx`) used the `rounded` Tailwind class on its three skeleton `<div>` elements. The design spec requires sharp corners by default — skeletons are not in the exception list for `rounded-sm`.

## How
Removed the `rounded` class from all three skeleton divs, matching the convention used by every other loading skeleton in the codebase (`account/loading.tsx`, `[pageId]/loading.tsx`, etc.).

## Testing
- Lint: passes (no new warnings)
- Typecheck: passes
- Vitest: all 1844 tests pass (138 files)
- No E2E tests reference this loading component
- No story file exists for this trivial layout-only loading skeleton