### PR TITLE
chore: daily metrics snapshot 2026-05-10

### DIFF
--- a/metrics/daily/2026-05-10.json
+++ b/metrics/daily/2026-05-10.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-05-10",
+  "day_number": 28,
+  "loc": {
+    "total": 72909,
+    "delta": 231,
+    "by_language": {
+      "TypeScript": 71084,
+      "SQL": 1544,
+      "CSS": 281
+    }
+  },
+  "files": {
+    "total": 242,
+    "delta": 6
+  },
+  "prs": {
+    "total": 570,
+    "delta": 9,
+    "currently_open": 1
+  },
+  "commits": {
+    "total": 593,
+    "delta": 9
+  },
+  "issues": {
+    "backlog": 4,
+    "in_progress": 0,
+    "in_review": 1,
+    "done": 398,
+    "opened_today": 9,
+    "closed_today": 3
+  },
+  "tests": {
+    "unit": 1844,
+    "e2e": 362
+  },
+  "ci": {
+    "runs_total": 18,
+    "runs_passed": 18,
+    "pass_rate_pct": 100.0
+  },
+  "test_coverage_pct": 36.64,
+  "autonomous_pct": 87,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
## Daily Metrics — 2026-05-10 (Day 28)

| Metric | Value | Delta |
|---|---|---|
| Lines of code | 72,909 | +231 |
| Files | 242 | +6 |
| PRs merged (cumulative) | 570 | +9 |
| PRs open | 1 | — |
| Commits | 593 | +9 |
| Unit tests | 1,844 | +22 |
| E2E tests | 362 | +9 |
| CI pass rate | 100.0% | 18/18 runs |
| Test coverage | 36.64% | -0.02 |
| Autonomous PR % | 87% | +1 |

### Issues
| Status | Count |
|---|---|
| Backlog | 4 |
| In Progress | 0 |
| In Review | 1 |
| Done | 398 |
| Opened today | 9 |
| Closed today | 3 |
