### PR TITLE
fix: prevent FK violation on page_versions from leaking to Sentry (#1013)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 138 | 1845 |
+| Unit/Integration (Vitest) | 138 | 1858 |
 | E2E (Playwright) | 74 | 369 |
-| **Total** | **212** | **2214** |
+| **Total** | **212** | **2227** |
 
 ### Test files by domain
 
@@ -49,9 +49,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **App Shell**: `sidebar-context.test.tsx` (21 tests), `(app)/loading.test.ts` (4 tests), `[workspaceSlug]/loading.test.ts` (5 tests), `[workspaceSlug]/[pageId]/loading.test.ts` (6 tests), `[workspaceSlug]/settings/loading.test.ts` (5 tests), `[workspaceSlug]/settings/members/loading.test.ts` (5 tests), `route-error.test.ts` (6 tests), `[workspaceSlug]/error.test.ts` (4 tests), `[workspaceSlug]/[pageId]/error.test.ts` (4 tests), `[workspaceSlug]/settings/error.test.ts` (4 tests), `[workspaceSlug]/settings/members/error.test.ts` (4 tests), `focus-mode-hint-design-spec.test.ts` (3 tests), `workspace-home-design-spec.test.ts` (5 tests), `e2e/sidebar-responsive.spec.ts` (4 tests), `e2e/mobile-responsive.spec.ts` (5 tests), `e2e/theme-toggle.spec.ts` (4 tests), `e2e/skip-to-content.spec.ts` (2 tests), `e2e/not-found.spec.ts` (3 tests), `e2e/public-routes.spec.ts` (18 tests), `e2e/demo-editor.spec.ts` (11 tests), `e2e/accessibility.spec.ts` (8 tests), `e2e/keyboard-shortcuts.spec.ts` (5 tests)
 - **Members**: `invite-form.test.ts` (4 tests), `member-list.test.tsx` (14 tests), `pending-invite-list.test.tsx` (8 tests), `role-select.test.tsx` (8 tests), `e2e/members.spec.ts` (7 tests)
 - **Feedback**: `feedback/route.test.ts` (17 tests), `feedback-form-design-spec.test.ts` (5 tests), `use-screenshot.test.ts` (2 tests), `e2e/feedback.spec.ts` (6 tests)
-- **API**: `health/route.test.ts` (7 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (6 tests), `cron/purge-trash/route.test.ts` (8 tests), `feedback/route.test.ts` (17 tests), `pages/[pageId]/versions/route.test.ts` (12 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (11 tests), `e2e/account-deletion.spec.ts` (4 tests), `e2e/account-settings.spec.ts` (5 tests)
+- **API**: `health/route.test.ts` (7 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (6 tests), `cron/purge-trash/route.test.ts` (8 tests), `feedback/route.test.ts` (17 tests), `pages/[pageId]/versions/route.test.ts` (15 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (11 tests), `e2e/account-deletion.spec.ts` (4 tests), `e2e/account-settings.spec.ts` (5 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `design-spec-compliance.test.ts` (9 tests), `relative-time.test.ts` (7 tests), `reduced-motion.test.ts` (6 tests), `e2e/visual-regression.spec.ts` (1 test)
-- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (149 tests), `retry.test.ts` (9 tests), `track-event-server.test.ts` (6 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
+- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (163 tests), `retry.test.ts` (9 tests), `track-event-server.test.ts` (6 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
 - **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests)
 
 ## Known Gaps
@@ -131,5 +131,6 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-10 | Add Storybook stories for sign-in and sign-up forms (#996). Added `sign-in-form.stories.tsx` (6 stories: Default, PreFilledEmail, EmailConfirmed, OAuthError, Loading, ValidationError) and `sign-up-form.stories.tsx` (4 stories: Default, Loading, ValidationError, ConfirmationPending). Generated 10 visual regression baselines. Test totals unchanged: 138 Vitest files (1844 tests), 73 E2E specs (364 tests). |
 | 2026-05-10 | Bundle size reduction (#1000). Replaced client component imports in `not-found.tsx` with inline SVG and plain `<a>` to eliminate lucide/base-ui from every page's RSC fallback. Added `lazy-route-error.tsx` wrapper and migrated all 10 error boundaries to use it, deferring RouteError + lucide + Button loading until an error occurs. Auth pages: 194→179 kB, settings pages: 182→173 kB. No test changes. Test totals unchanged: 138 Vitest files (1845 tests), 73 E2E specs (364 tests). |
 | 2026-05-10 | Add E2E tests for keyboard shortcuts dialog (#1001). Added `e2e/keyboard-shortcuts.spec.ts` (5 tests): open via ? key with category verification, shortcut display from each category, close on Escape, open via user menu, input-focus guard. Test totals: 138 Vitest files (1845 tests), 74 E2E specs (369 tests). |
+| 2026-05-10 | Fix FK violation Sentry leak on page-versions (#1013). Updated `sentry.unit.test.ts` (149→163 tests): added 2 tests for message-based FK detection fallback, 4 tests for `isE2ETestRequest` extra.userAgent fallback, 4 tests for userAgent propagation in captureSupabaseError/captureApiError. Updated `pages/[pageId]/versions/route.test.ts` (12→15 tests): added 3 tests for catch-block FK handling and User-Agent propagation. Test totals: 138 Vitest files (1858 tests), 74 E2E specs (369 tests). |
 
 

--- a/src/app/api/pages/[pageId]/versions/route.test.ts
+++ b/src/app/api/pages/[pageId]/versions/route.test.ts
@@ -68,8 +68,9 @@ vi.mock("@/lib/sentry", () => ({
   isInsufficientPrivilegeError: (err: Error & { code?: string }) =>
     err.code === "42501" ||
     err.message?.includes("violates row-level security policy"),
-  isForeignKeyViolationError: (err: Error & { code?: string }) =>
-    err.code === "23503",
+  isForeignKeyViolationError: (err: Error & { code?: string; message?: string }) =>
+    err.code === "23503" ||
+    (err.message?.includes("violates foreign key constraint") ?? false),
 }));
 
 const { GET, POST } = await import("./route");
@@ -265,6 +266,73 @@ describe("POST /api/pages/[pageId]/versions", () => {
     // Must NOT report to Sentry — FK violations on deleted parents are expected race conditions
     expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
     expect(captureApiErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when FK violation is thrown as exception in catch block (MEMO-2F factor 1)", async () => {
+    // Simulate Supabase throwing a FK violation as an exception (catch path)
+    // instead of returning it in { data, error }
+    const fkError = Object.assign(
+      new Error('insert or update on table "page_versions" violates foreign key constraint "page_versions_page_id_fkey"'),
+      { code: "23503" },
+    );
+    throwOnInsert = fkError;
+    listResult = { data: null, error: null };
+
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions", {
+        method: "POST",
+        body: JSON.stringify({ content: { root: { children: [] } } }),
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Page not found");
+    expect(captureApiErrorMock).not.toHaveBeenCalled();
+    expect(captureSupabaseErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates User-Agent to captureSupabaseError for E2E detection (MEMO-2F factor 2)", async () => {
+    // Simulate a generic Supabase error (not FK, not RLS) so it reaches captureSupabaseError
+    const genericError = Object.assign(
+      new Error("some unexpected error"),
+      { code: "XXXXX", details: "", hint: "" },
+    );
+    insertResult = { data: null, error: genericError };
+    listResult = { data: null, error: null };
+
+    const req = new NextRequest(new URL("/api/pages/page-123/versions", "http://localhost:3000"), {
+      method: "POST",
+      body: JSON.stringify({ content: { root: { children: [] } } }),
+      headers: { "user-agent": "Mozilla/5.0 HeadlessChrome/147.0.0.0" },
+    });
+
+    await POST(req, { params: mockParams });
+    expect(captureSupabaseErrorMock).toHaveBeenCalledWith(
+      genericError,
+      "page-versions:create",
+      "Mozilla/5.0 HeadlessChrome/147.0.0.0",
+    );
+  });
+
+  it("propagates User-Agent to captureApiError for E2E detection (MEMO-2F factor 2)", async () => {
+    // Simulate an unexpected throw that reaches the catch block
+    const unexpectedError = new Error("unexpected runtime error");
+    throwOnInsert = unexpectedError;
+    listResult = { data: null, error: null };
+
+    const req = new NextRequest(new URL("/api/pages/page-123/versions", "http://localhost:3000"), {
+      method: "POST",
+      body: JSON.stringify({ content: { root: { children: [] } } }),
+      headers: { "user-agent": "Mozilla/5.0 HeadlessChrome/147.0.0.0" },
+    });
+
+    await POST(req, { params: mockParams });
+    expect(captureApiErrorMock).toHaveBeenCalledWith(
+      unexpectedError,
+      "page-versions:create",
+      "Mozilla/5.0 HeadlessChrome/147.0.0.0",
+    );
   });
 
   it("returns 403 when RLS violation is thrown without PostgrestError shape (MEMO-W regression)", async () => {

--- a/src/app/api/pages/[pageId]/versions/route.ts
+++ b/src/app/api/pages/[pageId]/versions/route.ts
@@ -7,10 +7,11 @@ import { captureApiError, captureSupabaseError, isForeignKeyViolationError, isIn
  * Lists versions for a page, newest first. Requires workspace membership.
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ pageId: string }> },
 ) {
   const { pageId } = await params;
+  const userAgent = request.headers.get("user-agent") ?? undefined;
 
   try {
     const supabase = await createClient();
@@ -31,7 +32,7 @@ export async function GET(
       if (isInsufficientPrivilegeError(error)) {
         return NextResponse.json({ error: "Forbidden" }, { status: 403 });
       }
-      captureSupabaseError(error, "page-versions:list");
+      captureSupabaseError(error, "page-versions:list", userAgent);
       return NextResponse.json({ error: "Failed to list versions" }, { status: 500 });
     }
 
@@ -40,7 +41,7 @@ export async function GET(
     if (error instanceof Error && isInsufficientPrivilegeError(error)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    captureApiError(error, "page-versions:list");
+    captureApiError(error, "page-versions:list", userAgent);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
@@ -55,6 +56,7 @@ export async function POST(
   { params }: { params: Promise<{ pageId: string }> },
 ) {
   const { pageId } = await params;
+  const userAgent = request.headers.get("user-agent") ?? undefined;
 
   try {
     const supabase = await createClient();
@@ -112,7 +114,7 @@ export async function POST(
       if (isForeignKeyViolationError(error)) {
         return NextResponse.json({ error: "Page not found" }, { status: 404 });
       }
-      captureSupabaseError(error, "page-versions:create");
+      captureSupabaseError(error, "page-versions:create", userAgent);
       return NextResponse.json({ error: "Failed to create version" }, { status: 500 });
     }
 
@@ -121,7 +123,10 @@ export async function POST(
     if (error instanceof Error && isInsufficientPrivilegeError(error)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
-    captureApiError(error, "page-versions:create");
+    if (error instanceof Error && isForeignKeyViolationError(error)) {
+      return NextResponse.json({ error: "Page not found" }, { status: 404 });
+    }
+    captureApiError(error, "page-versions:create", userAgent);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -40,6 +40,14 @@ export function isE2ETestRequest(event: ErrorEvent): boolean {
   const browserName = (event.contexts?.browser as Record<string, unknown> | undefined)?.name;
   if (typeof browserName === "string" && browserName.includes("HeadlessChrome")) return true;
 
+  // Fallback: check extra.userAgent propagated by captureSupabaseError /
+  // captureApiError from the incoming request's User-Agent header. For
+  // server-side manually captured exceptions, event.request is empty and
+  // event.contexts.browser is not populated by the SDK — the User-Agent
+  // must be explicitly forwarded.
+  const extraUa = event.extra?.userAgent;
+  if (typeof extraUa === "string" && extraUa.includes("HeadlessChrome/")) return true;
+
   return false;
 }
 
@@ -188,18 +196,22 @@ export function isInsufficientPrivilegeError(error: Error): boolean {
  * This is an expected race condition during E2E test teardown and concurrent
  * user sessions, not an application bug.
  *
- * Matches two shapes:
+ * Matches three shapes:
  * 1. PostgrestError objects with `code: "23503"` (from `{ data, error }` path)
  * 2. Generic Error with a `code` property set to `"23503"` (thrown path)
+ * 3. Error whose message contains the FK violation pattern — fallback for
+ *    edge cases where the Supabase client returns an error object that
+ *    doesn't pass the `isPostgrestError` duck-type check (e.g. missing
+ *    `details` or `hint` properties from `.insert().select().single()`)
  */
 export function isForeignKeyViolationError(error: Error): boolean {
   if (isPostgrestError(error)) {
     return error.code === "23503";
   }
-  return (
-    "code" in error &&
-    (error as Record<string, unknown>).code === "23503"
-  );
+  if ("code" in error && (error as Record<string, unknown>).code === "23503") {
+    return true;
+  }
+  return error.message.includes("violates foreign key constraint");
 }
 
 /**
@@ -491,9 +503,15 @@ export function isTransientNetworkError(error: Error): boolean {
  * Use this for non-Supabase fetch calls (e.g. `/api/pages/…/versions`).
  * Transient network errors are captured at `warning` level to reduce noise.
  * All other errors are captured at `error` level.
+ *
+ * @param userAgent - Optional User-Agent from the incoming request. Propagated
+ *   into `extra.userAgent` so the server-side `beforeSend` filter can detect
+ *   E2E test sessions (HeadlessChrome) for manually captured exceptions where
+ *   `event.request` is empty.
  */
-export function captureApiError(error: unknown, operation: string): void {
+export function captureApiError(error: unknown, operation: string, userAgent?: string): void {
   const extra: Record<string, string> = { operation };
+  if (userAgent) extra.userAgent = userAgent;
 
   if (error instanceof Error) {
     extra.message = error.message;
@@ -538,15 +556,22 @@ function ensureError(error: Error | { message: string }): Error {
  *
  * Transient network errors (e.g. `TypeError: Failed to fetch`) are captured at
  * `warning` level to reduce noise — they are not application bugs.
+ *
+ * @param userAgent - Optional User-Agent from the incoming request. Propagated
+ *   into `extra.userAgent` so the server-side `beforeSend` filter can detect
+ *   E2E test sessions (HeadlessChrome) for manually captured exceptions where
+ *   `event.request` is empty.
  */
 export function captureSupabaseError(
   error: Error,
   operation: string,
+  userAgent?: string,
 ): void {
   const extra: Record<string, string> = {
     operation,
     message: error.message,
   };
+  if (userAgent) extra.userAgent = userAgent;
 
   if (isPostgrestError(error)) {
     extra.code = error.code;

--- a/src/lib/sentry.unit.test.ts
+++ b/src/lib/sentry.unit.test.ts
@@ -398,6 +398,18 @@ describe("isForeignKeyViolationError", () => {
     );
     expect(isForeignKeyViolationError(error)).toBe(false);
   });
+
+  it("detects FK violation by message when error lacks code property (MEMO-2F fallback)", () => {
+    const error = new Error(
+      'insert or update on table "page_versions" violates foreign key constraint "page_versions_page_id_fkey"',
+    );
+    expect(isForeignKeyViolationError(error)).toBe(true);
+  });
+
+  it("returns false for message without FK violation pattern and no code", () => {
+    const error = new Error("some other database error");
+    expect(isForeignKeyViolationError(error)).toBe(false);
+  });
 });
 
 describe("isDuplicateKeyError", () => {
@@ -931,6 +943,27 @@ describe("captureSupabaseError", () => {
     expect(opts.extra.hint).toBe("");
     expect(opts.extra.code).toBe("XX000");
   });
+
+  it("includes userAgent in extra when provided (MEMO-2F E2E detection)", async () => {
+    const error = new Error("some error");
+    captureSupabaseError(error, "page-versions:create", "Mozilla/5.0 HeadlessChrome/147.0.0.0");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.extra.userAgent).toBe("Mozilla/5.0 HeadlessChrome/147.0.0.0");
+    expect(opts.extra.operation).toBe("page-versions:create");
+  });
+
+  it("omits userAgent from extra when not provided", async () => {
+    const error = new Error("some error");
+    captureSupabaseError(error, "page-versions:create");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.extra.userAgent).toBeUndefined();
+  });
 });
 
 function makeSentryEvent(
@@ -1449,6 +1482,27 @@ describe("captureApiError", () => {
     const [, opts] = captureExceptionMock.mock.calls[0];
     expect(opts.extra.operation).toBe("versions:select");
   });
+
+  it("includes userAgent in extra when provided (MEMO-2F E2E detection)", async () => {
+    const error = new Error("some error");
+    captureApiError(error, "page-versions:create", "Mozilla/5.0 HeadlessChrome/147.0.0.0");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.extra.userAgent).toBe("Mozilla/5.0 HeadlessChrome/147.0.0.0");
+    expect(opts.extra.operation).toBe("page-versions:create");
+  });
+
+  it("omits userAgent from extra when not provided", async () => {
+    const error = new Error("some error");
+    captureApiError(error, "page-versions:create");
+    await flush();
+
+    expect(captureExceptionMock).toHaveBeenCalledOnce();
+    const [, opts] = captureExceptionMock.mock.calls[0];
+    expect(opts.extra.userAgent).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1551,6 +1605,38 @@ describe("isE2ETestRequest", () => {
     const event = {
       type: undefined,
       contexts: { browser: { name: 42 } },
+    } as unknown as ErrorEvent;
+    expect(isE2ETestRequest(event)).toBe(false);
+  });
+
+  it("returns true when extra.userAgent contains HeadlessChrome/ (MEMO-2F server-side fallback)", () => {
+    const event = {
+      type: undefined,
+      extra: { userAgent: "Mozilla/5.0 HeadlessChrome/147.0.0.0 Safari/537.36" },
+    } as unknown as ErrorEvent;
+    expect(isE2ETestRequest(event)).toBe(true);
+  });
+
+  it("returns false when extra.userAgent is a normal Chrome UA", () => {
+    const event = {
+      type: undefined,
+      extra: { userAgent: "Mozilla/5.0 Chrome/147.0.0.0 Safari/537.36" },
+    } as unknown as ErrorEvent;
+    expect(isE2ETestRequest(event)).toBe(false);
+  });
+
+  it("returns false when extra.userAgent is not a string", () => {
+    const event = {
+      type: undefined,
+      extra: { userAgent: 42 },
+    } as unknown as ErrorEvent;
+    expect(isE2ETestRequest(event)).toBe(false);
+  });
+
+  it("returns false when extra exists but has no userAgent", () => {
+    const event = {
+      type: undefined,
+      extra: { operation: "page-versions:create" },
     } as unknown as ErrorEvent;
     expect(isE2ETestRequest(event)).toBe(false);
   });


### PR DESCRIPTION
Closes #1013

## What

`POST /api/pages/{pageId}/versions` was still generating Sentry events at warning level for FK violations (PostgreSQL 23503) when the referenced page was deleted between the user action and the insert. PR #1008 added FK detection in the route handler, but two gaps remained: (1) `isForeignKeyViolationError` could miss errors with non-standard object shapes lacking the full PostgREST duck-type signature, and (2) the server-side `beforeSend` filter couldn't detect E2E test sessions for manually captured exceptions because `event.request` is empty and `event.contexts.browser` is not populated by the SDK.

## How

**Factor 1 — FK detection fallback:** Added a message-based fallback to `isForeignKeyViolationError` that matches `"violates foreign key constraint"` in the error message, catching edge cases where the error object lacks `details` or `hint` properties. Also added FK violation handling in the POST handler's `catch` block (thrown exception path), which was previously unguarded.

**Factor 2 — E2E detection for server-side captures:** Added an optional `userAgent` parameter to `captureSupabaseError` and `captureApiError`. The route handler now extracts the User-Agent from the incoming request and passes it through. The value is included in `extra.userAgent` on the Sentry event. Updated `isE2ETestRequest` to check `event.extra.userAgent` as a fallback when `event.request` headers and `event.contexts.browser` are both empty.

## Testing

- Added 14 regression tests for `isForeignKeyViolationError` message fallback (2), `isE2ETestRequest` extra.userAgent fallback (4), `captureSupabaseError`/`captureApiError` userAgent propagation (4), and route handler catch-block FK handling + User-Agent forwarding (3 + 1 existing updated).
- `pnpm lint && pnpm typecheck && pnpm test` all pass (138 files, 1858 tests).