### PR TITLE
feat: add automatic retry for transient network errors in database hooks (#984)

### DIFF
--- a/src/components/database/database-view-client.test.tsx
+++ b/src/components/database/database-view-client.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/lib/sentry", () => ({
   captureSupabaseError: (...args: unknown[]) => captureSupabaseErrorMock(...args),
   lazyCaptureException: vi.fn(),
   isInsufficientPrivilegeError: () => false,
+  isTransientNetworkError: () => false,
 }));
 
 vi.mock("@sentry/nextjs", () => ({

--- a/src/components/database/database-view-client.tsx
+++ b/src/components/database/database-view-client.tsx
@@ -27,6 +27,7 @@ import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
+import { retryOnNetworkError } from "@/lib/retry";
 import { useDatabaseViews } from "@/components/database/hooks/use-database-views";
 import { useDatabaseRows } from "@/components/database/hooks/use-database-rows";
 import { useDatabaseProperties } from "@/components/database/hooks/use-database-properties";
@@ -151,8 +152,8 @@ export function DatabaseViewClient(props: DatabaseViewClientProps) {
       setError(null);
 
       const [dbResult, membersResult] = await Promise.all([
-        loadDatabase(pageId),
-        loadWorkspaceMembers(workspaceId),
+        retryOnNetworkError(() => loadDatabase(pageId)),
+        retryOnNetworkError(() => loadWorkspaceMembers(workspaceId)),
       ]);
       if (cancelled) return;
 

--- a/src/components/database/hooks/use-database-filters.test.ts
+++ b/src/components/database/hooks/use-database-filters.test.ts
@@ -23,6 +23,12 @@ vi.mock("@/lib/database-filters", () => ({
     filterRowsMock(rows, filters, props),
 }));
 
+vi.mock("@/lib/sentry", () => ({
+  captureSupabaseError: vi.fn(),
+  isInsufficientPrivilegeError: () => false,
+  isTransientNetworkError: () => false,
+}));
+
 vi.mock("@/lib/toast", () => ({
   toast: {
     error: (...args: unknown[]) => toastErrorMock(...args),

--- a/src/components/database/hooks/use-database-filters.ts
+++ b/src/components/database/hooks/use-database-filters.ts
@@ -11,6 +11,7 @@ import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
+import { retryOnNetworkError } from "@/lib/retry";
 import type {
   DatabaseProperty,
   DatabaseRow,
@@ -81,7 +82,9 @@ export function useDatabaseFilters({
           v.id === activeView.id ? { ...v, config: newConfig } : v,
         ),
       );
-      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
+      const { error } = await retryOnNetworkError(() =>
+        updateView(activeView.id, { config: newConfig }, pageId),
+      );
       if (error) {
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-filters:update-sort");
@@ -102,7 +105,9 @@ export function useDatabaseFilters({
           v.id === activeView.id ? { ...v, config: newConfig } : v,
         ),
       );
-      const { error } = await updateView(activeView.id, { config: newConfig }, pageId);
+      const { error } = await retryOnNetworkError(() =>
+        updateView(activeView.id, { config: newConfig }, pageId),
+      );
       if (error) {
         if (!isInsufficientPrivilegeError(error)) {
           captureSupabaseError(error, "database-filters:update-filter");

--- a/src/components/database/hooks/use-database-properties.test.ts
+++ b/src/components/database/hooks/use-database-properties.test.ts
@@ -44,6 +44,7 @@ vi.mock("@/lib/toast", () => ({
 vi.mock("@/lib/sentry", () => ({
   captureSupabaseError: (error: unknown, operation: unknown) => captureSupabaseErrorMock(error, operation),
   isInsufficientPrivilegeError: (error: unknown) => isInsufficientPrivilegeErrorMock(error),
+  isTransientNetworkError: () => false,
 }));
 
 // ---------------------------------------------------------------------------

--- a/src/components/database/hooks/use-database-properties.ts
+++ b/src/components/database/hooks/use-database-properties.ts
@@ -12,6 +12,7 @@ import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
+import { retryOnNetworkError } from "@/lib/retry";
 import {
   generateColumnName,
   getDefaultColumnConfig,
@@ -266,7 +267,7 @@ export function useDatabaseProperties({
           // Revert all state
           setProperties(prevProperties);
           setViews(prevViews);
-          const { data } = await loadDatabase(pageId);
+          const { data } = await retryOnNetworkError(() => loadDatabase(pageId));
           if (data) setRows(data.rows);
           return;
         }

--- a/src/components/database/hooks/use-database-rows.test.ts
+++ b/src/components/database/hooks/use-database-rows.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/lib/sentry", () => ({
     captureSupabaseErrorMock(error, operation),
   isInsufficientPrivilegeError: (error: Error) =>
     isInsufficientPrivilegeErrorMock(error),
+  isTransientNetworkError: () => false,
 }));
 
 const toastSuccessMock = vi.fn();

--- a/src/components/database/hooks/use-database-rows.ts
+++ b/src/components/database/hooks/use-database-rows.ts
@@ -12,6 +12,7 @@ import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
+import { retryOnNetworkError } from "@/lib/retry";
 import type { DatabaseProperty, DatabaseRow } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -394,7 +395,7 @@ export function useDatabaseRows({
             },
           });
           // Reload to restore
-          const { data } = await loadDatabase(pageId);
+          const { data } = await retryOnNetworkError(() => loadDatabase(pageId));
           if (data) setRows(data.rows);
         }
       }, 5500);
@@ -464,7 +465,7 @@ export function useDatabaseRows({
             },
           });
           // Reload to restore failed rows
-          const { data } = await loadDatabase(pageId);
+          const { data } = await retryOnNetworkError(() => loadDatabase(pageId));
           if (data) setRows(data.rows);
         }
       }, 5500);

--- a/src/components/database/hooks/use-database-views.test.ts
+++ b/src/components/database/hooks/use-database-views.test.ts
@@ -35,6 +35,7 @@ vi.mock("@/lib/toast", () => ({
 vi.mock("@/lib/sentry", () => ({
   captureSupabaseError: (error: unknown, operation: unknown) => captureSupabaseErrorMock(error, operation),
   isInsufficientPrivilegeError: (error: unknown) => isInsufficientPrivilegeErrorMock(error),
+  isTransientNetworkError: () => false,
 }));
 
 vi.mock("@/components/database/view-tabs", () => ({

--- a/src/components/database/hooks/use-database-views.ts
+++ b/src/components/database/hooks/use-database-views.ts
@@ -13,6 +13,7 @@ import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
+import { retryOnNetworkError } from "@/lib/retry";
 import type {
   DatabaseProperty,
   DatabaseView,
@@ -281,7 +282,7 @@ export function useDatabaseViews({
           },
         });
         // Reload to restore correct order
-        const { data } = await loadDatabase(pageId);
+        const { data } = await retryOnNetworkError(() => loadDatabase(pageId));
         if (data) setViews(data.views);
       }
     },

--- a/src/lib/retry.test.ts
+++ b/src/lib/retry.test.ts
@@ -53,7 +53,7 @@ describe("retryOnNetworkError", () => {
     const result = await promise;
 
     expect(fn).toHaveBeenCalledOnce();
-    expect(result.error?.code).toBe("42501");
+    expect((result.error as PostgrestError | null)?.code).toBe("42501");
   });
 
   it("retries on transient network error and succeeds", async () => {

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,5 +1,4 @@
 import { isTransientNetworkError } from "@/lib/sentry";
-import { PostgrestError } from "@supabase/supabase-js";
 
 interface RetryOptions {
   /** Maximum number of retry attempts (default: 2). */
@@ -8,15 +7,19 @@ interface RetryOptions {
   baseDelayMs?: number;
 }
 
-/** Any Supabase query result shape — the only requirement is an `error` field. */
-type SupabaseResult = { error: PostgrestError | null };
+/**
+ * Any Supabase query result shape — the only requirement is an `error` field.
+ * Accepts both `PostgrestError` and plain `Error` so callers like `loadDatabase`
+ * (which widens the error type) can use `retryOnNetworkError` directly.
+ */
+type SupabaseResult = { error: Error | null };
 
 /**
  * Retry a Supabase query when it fails with a transient network error.
  *
  * Handles both failure modes:
- * - Result-level errors: `{ data: null, error: PostgrestError }` where the
- *   error is a transient network failure.
+ * - Result-level errors: `{ data: null, error: Error }` where the error is
+ *   a transient network failure (works with both `PostgrestError` and `Error`).
  * - Thrown errors: Node.js undici `TypeError: fetch failed` that bypasses
  *   the Supabase result pattern entirely.
  *


### PR DESCRIPTION
Closes #984

## What

Wraps database hook Supabase calls with `retryOnNetworkError` so transient network failures (e.g. `TypeError: fetch failed`) are retried automatically with exponential backoff before surfacing an error toast.

## How

- **`src/lib/retry.ts`** — Widened `SupabaseResult` type from `{ error: PostgrestError | null }` to `{ error: Error | null }` so functions like `loadDatabase` (which widen the error type) can use `retryOnNetworkError` directly. Backward-compatible since `PostgrestError extends Error`.
- **`database-view-client.tsx`** — Wrapped the initial `loadDatabase` and `loadWorkspaceMembers` calls with `retryOnNetworkError`.
- **`use-database-rows.ts`** — Wrapped both `loadDatabase` read-back calls (in `handleDeleteRow` and `handleBulkDeleteRows` error recovery paths).
- **`use-database-properties.ts`** — Wrapped the `loadDatabase` read-back call (in `handleDeleteColumn` error recovery).
- **`use-database-views.ts`** — Wrapped the `loadDatabase` read-back call (in `handleReorderViews` error recovery).
- **`use-database-filters.ts`** — Wrapped both `updateView` persistence calls (sort and filter config). These are idempotent UPDATEs, safe to retry.
- **Test files** — Added `isTransientNetworkError` to `@/lib/sentry` mocks in all affected test files so `retryOnNetworkError` resolves correctly in the test environment.

Write mutations (`addRow`, `duplicateRow`, `updateRowValue`, `deleteProperty`, `soft_delete_page`, etc.) are NOT retried — only reads and read-back-after-write queries.

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 138 files, 1858 tests pass
- No interactive UI changes, so no new E2E tests required. Existing manual "Retry" toast actions are preserved as fallback.