### PR TITLE
chore: performance report 2026-W20

### DIFF
--- a/metrics/weekly/2026-W20-perf.md
+++ b/metrics/weekly/2026-W20-perf.md
@@ -1,0 +1,52 @@
+# Performance Report — Week 20
+
+## Health Endpoint
+- Status: ok
+- DB latency: 658ms ⚠️ (threshold: 500ms)
+- DB connected: yes
+
+## Error Trend
+- This week: unavailable (Sentry MCP tools not accessible)
+- Last week (W19): 3 errors
+- Trend: unknown
+
+> Sentry error counts could not be queried — MCP integration was not available during this run. Manual check recommended via https://de.sentry.io for org `ona-2j`, project `memo`.
+
+## Build Size
+| Page | First Load JS (gzip) | Status |
+|---|---|---|
+| / | 250.1 kB | ⚠️ |
+| /sign-in | 271.6 kB | ⚠️ |
+| /sign-up | 284.9 kB | ⚠️ |
+| /forgot-password | 271.3 kB | ⚠️ |
+| /reset-password | 271.3 kB | ⚠️ |
+| /invite/[token] | 257.7 kB | ⚠️ |
+| /[workspaceSlug] | 259.0 kB | ⚠️ |
+| /[workspaceSlug]/[pageId] | 263.5 kB | ⚠️ |
+| /[workspaceSlug]/settings | 259.5 kB | ⚠️ |
+| /[workspaceSlug]/settings/members | 260.1 kB | ⚠️ |
+| /account | 271.0 kB | ⚠️ |
+| /_not-found | 252.0 kB | ⚠️ |
+
+Shared base JS (common across all pages): 252.0 kB gzip (19 chunks).
+
+### Build Size vs W19
+
+| Page | W19 | W20 | Delta |
+|---|---|---|---|
+| / | 163.3 kB | 250.1 kB | +86.8 kB ↑ |
+| /sign-in | 286.0 kB | 271.6 kB | −14.4 kB ↓ |
+| /sign-up | 286.1 kB | 284.9 kB | −1.2 kB ↓ |
+| /forgot-password | 246.0 kB | 271.3 kB | +25.3 kB ↑ |
+| /reset-password | 246.3 kB | 271.3 kB | +25.0 kB ↑ |
+| /[workspaceSlug] | 241.8 kB | 259.0 kB | +17.2 kB ↑ |
+| /[workspaceSlug]/[pageId] | 185.5 kB | 263.5 kB | +78.0 kB ↑ |
+| /[workspaceSlug]/settings | 223.0 kB | 259.5 kB | +36.5 kB ↑ |
+| /[workspaceSlug]/settings/members | 264.8 kB | 260.1 kB | −4.7 kB ↓ |
+
+Note: W19 used Next.js built-in size reporting. W20 uses gzip-compressed chunk analysis from Turbopack build output (Next.js 16.2.3). Methodology differences may account for some variance.
+
+## Action Items
+- DB latency (658ms) exceeds 500ms threshold for the second consecutive week (W19: 799ms) — improved but still above threshold. Investigate Supabase connection pool and regional latency.
+- All 12 pages exceed the 200 kB first-load JS budget. The shared base alone is 252 kB. Audit shared chunks for tree-shaking opportunities, lazy-load heavy dependencies (Sentry SDK, Supabase client), and consider dynamic imports for non-critical code paths.
+- Sentry error trend could not be checked — verify MCP integration is configured for the Performance Monitor automation.


### PR DESCRIPTION
Weekly performance monitoring report for Week 20 (2026-05-11).

## Summary

| Metric | Value | Status |
|---|---|---|
| Health status | ok | ✅ |
| DB latency | 658ms | ⚠️ (threshold: 500ms) |
| DB connected | yes | ✅ |
| Sentry errors | unavailable | — |
| Pages over 200kB budget | 12/12 | ⚠️ |

### Key findings

- **DB latency improved** from 799ms (W19) to 658ms but remains above the 500ms threshold for the second consecutive week.
- **All pages exceed the 200kB first-load JS budget.** The shared base alone is 252kB gzip (19 chunks). This is a structural issue — individual page optimizations won't help until the shared bundle is reduced.
- **Sentry MCP tools were not accessible** during this run. Error trend could not be checked.

### Compared to W19

- DB latency: 799ms → 658ms (↓ 18%)
- Build sizes: most pages increased due to shared chunk growth; /sign-in and /sign-up slightly decreased