### PR TITLE
feat: add focus-visible styles to workspace home page list items (#1027)

### DIFF
--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -205,7 +205,7 @@ export function WorkspaceHome({
             {recentVisits.map((visit) => (
               <button
                 key={visit.page_id}
-                className="flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-overlay-hover"
+                className="flex items-center gap-2 px-3 py-2 text-left text-sm transition-none hover:bg-overlay-hover focus-visible:bg-overlay-active focus-visible:outline-none"
                 onClick={() =>
                   router.push(`/${workspace.slug}/${visit.page_id}`)
                 }
@@ -286,7 +286,7 @@ export function WorkspaceHome({
             {filteredAndSorted.map((page) => (
               <button
                 key={page.id}
-                className="flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-overlay-hover"
+                className="flex items-center gap-2 px-3 py-2 text-left text-sm transition-none hover:bg-overlay-hover focus-visible:bg-overlay-active focus-visible:outline-none"
                 onClick={() =>
                   router.push(`/${workspace.slug}/${page.id}`)
                 }


### PR DESCRIPTION
Closes #1027

## What

Adds keyboard focus indicators to the page list buttons in the workspace home "Recently Visited" and "All Pages" sections. Previously, these buttons had hover styles but no visible focus state, making them inaccessible to keyboard users.

## How

Added `focus-visible:bg-overlay-active focus-visible:outline-none transition-none` to both button `className` strings in `src/components/workspace-home.tsx`:

- `recentVisits.map()` button (line 208)
- `filteredAndSorted.map()` button (line 289)

This matches the established pattern used in sidebar page tree items (`page-tree-item.tsx`) and search results (`page-search.tsx`) where `bg-overlay-active` indicates the selected/focused state.

- `focus-visible` ensures the ring only appears on keyboard navigation, not mouse clicks
- `transition-none` prevents flash on focus (matching the search result pattern)
- No `rounded-md` — design spec requires sharp corners

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 139 files, 1877 tests passed (including design-spec-compliance)
- `workspace-home-new-database.spec.ts` E2E test passes
- The "Clear filter" button already has focus styles via the `Button` component — no change needed