### PR TITLE
fix: scope mobile header E2E selector to header row (#1042)

### DIFF
--- a/e2e/workspace-home-mobile-header.spec.ts
+++ b/e2e/workspace-home-mobile-header.spec.ts
@@ -17,9 +17,11 @@ test.describe("Workspace home — mobile header layout", () => {
     const heading = main.locator("h1").first();
     await expect(heading).toBeVisible({ timeout: 15_000 });
 
-    // Both action buttons should be visible (mobile labels: "Database" and "Page")
-    const dbButton = main.getByRole("button", { name: /database/i });
-    const pageButton = main.getByRole("button", { name: /page/i });
+    // Scope to the header row (the container that holds the h1) to avoid
+    // matching sidebar page buttons like "Untitled Database just now".
+    const headerRow = heading.locator("..");
+    const dbButton = headerRow.getByRole("button", { name: /database/i });
+    const pageButton = headerRow.getByRole("button", { name: /page/i });
     await expect(dbButton).toBeVisible({ timeout: 5_000 });
     await expect(pageButton).toBeVisible({ timeout: 5_000 });
 


### PR DESCRIPTION
Closes #1042

## What

The E2E test `workspace-home-mobile-header.spec.ts` fails with a strict mode violation because `main.getByRole('button', { name: /database/i })` matches 500+ elements — both the header "Database" action button and all sidebar page buttons containing "Database" in their title (e.g., "Untitled Database just now").

## How

Scope the button locators to the header row by navigating from the `h1` heading to its parent container (`heading.locator("..")`). This parent `div` contains only the workspace title and the two action buttons, eliminating ambiguity with sidebar page tree items.

## Testing

- `pnpm lint` — passes (no new warnings)
- `pnpm typecheck` — passes
- `pnpm test` — 139 files, 1877 tests pass
- The selector change is minimal and targeted: `heading.locator("..")` returns the flex container that wraps `h1` + action buttons, which is the same DOM structure verified in the original PR #1040