### PR TITLE
refactor: add typed helpers for Supabase join queries (#1047)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -620,11 +620,12 @@ src/
 │   ├── word-count.ts       # Word count and reading time calculation utilities
 │   ├── workspace.ts        # Workspace utilities: slug generation, validation, limits
 │   └── supabase/
-│       ├── admin.ts        # Service-role client for server-only operations (cron jobs)
-│       ├── client.ts       # Browser client (createBrowserClient)
-│       ├── lazy-client.ts  # Lazy-loaded browser client (defers SDK import to reduce initial bundle)
-│       ├── server.ts       # Server component client (createServerClient + cookies)
-│       └── proxy.ts        # Session refresh + auth redirect logic (updateSession)
+│       ├── admin.ts         # Service-role client for server-only operations (cron jobs)
+│       ├── client.ts        # Browser client (createBrowserClient)
+│       ├── lazy-client.ts   # Lazy-loaded browser client (defers SDK import to reduce initial bundle)
+│       ├── server.ts        # Server component client (createServerClient + cookies)
+│       ├── proxy.ts         # Session refresh + auth redirect logic (updateSession)
+│       └── typed-queries.ts # Typed helpers for Supabase join queries (centralizes select strings + casts)
 ├── proxy.ts                # Root proxy — calls updateSession, skips static/health routes
 └── instrumentation.ts      # Sentry server/edge init (register + onRequestError)
 

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -99,6 +99,40 @@ const supabase = createAdminClient();
 const { data, error } = await supabase.rpc("purge_old_trash");
 ```
 
+### Typed join queries
+
+Supabase without generated types returns joined relations as `unknown`. Use the
+helpers in `src/lib/supabase/typed-queries.ts` instead of inline `as unknown as`
+casts. Each helper pairs a query builder (encapsulating the select string) with a
+result caster (centralizing the type assertion).
+
+```typescript
+import {
+  membersWithProfiles,
+  asMemberProfileRows,
+} from "@/lib/supabase/typed-queries";
+
+// Query builder — chain filters as usual
+const { data, error } = await membersWithProfiles(supabase).eq(
+  "workspace_id",
+  workspaceId,
+);
+
+// Result caster — returns typed rows
+const members = asMemberProfileRows(data).map((m) => ({
+  id: m.user_id,
+  display_name: m.profiles.display_name,
+  email: m.profiles.email,
+  avatar_url: m.profiles.avatar_url,
+}));
+```
+
+Available helpers: `membersWithProfiles`, `membersWithProfileEmail`,
+`membersWithWorkspace`, `membersWithWorkspaceSlug`,
+`membersWithWorkspaceSlugPersonal`, `pageVisitsWithPages`. When adding a new
+join pattern, define the select string, row type, query builder, and result
+caster together in `typed-queries.ts`.
+
 ### Proxy (session refresh)
 
 Next.js 16 uses `src/proxy.ts` instead of `src/middleware.ts`. The proxy refreshes

--- a/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/[pageId]/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
+import {
+  membersWithProfiles,
+  asMemberProfileRows,
+} from "@/lib/supabase/typed-queries";
 import { captureSupabaseError } from "@/lib/sentry";
 import { trackEvent } from "@/lib/track-event-server";
 import type { SerializedEditorState } from "lexical";
@@ -265,27 +269,17 @@ export default async function PageView({
       }));
 
       // Enrich person/created_by properties with workspace members
-      const { data: membersData } = await supabase
-        .from("members")
-        .select(
-          "user_id, profiles!members_user_id_fkey(id, display_name, email, avatar_url)",
-        )
-        .eq("workspace_id", workspace.id);
+      const { data: membersData } = await membersWithProfiles(supabase).eq(
+        "workspace_id",
+        workspace.id,
+      );
 
-      const members = (membersData ?? []).map((m) => {
-        const profile = m.profiles as unknown as {
-          id: string;
-          display_name: string;
-          email: string;
-          avatar_url: string | null;
-        };
-        return {
-          id: m.user_id,
-          display_name: profile.display_name,
-          email: profile.email,
-          avatar_url: profile.avatar_url,
-        };
-      });
+      const members = asMemberProfileRows(membersData).map((m) => ({
+        id: m.user_id,
+        display_name: m.profiles.display_name,
+        email: m.profiles.email,
+        avatar_url: m.profiles.avatar_url,
+      }));
 
       const enrichedProperties = properties.map((prop) => {
         if (prop.type === "person" || prop.type === "created_by") {

--- a/src/app/(app)/[workspaceSlug]/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import {
+  pageVisitsWithPages,
+  asPageVisitRows,
+} from "@/lib/supabase/typed-queries";
 import { WorkspaceHomeClient } from "@/components/workspace-home-client";
 
 export async function generateMetadata({
@@ -58,9 +62,7 @@ export default async function WorkspacePage({
       .is("parent_id", null)
       .is("deleted_at", null)
       .order("position", { ascending: true }),
-    supabase
-      .from("page_visits")
-      .select("page_id, visited_at, pages!inner(title, icon, is_database, deleted_at)")
+    pageVisitsWithPages(supabase)
       .eq("workspace_id", workspace.id)
       .eq("user_id", userId)
       .is("pages.deleted_at", null)
@@ -69,16 +71,13 @@ export default async function WorkspacePage({
   ]);
 
   // Normalize the joined rows into a flat shape
-  const recentVisits = (recentVisitRows ?? []).map((row) => {
-    const page = row.pages as unknown as { title: string; icon: string | null; is_database: boolean };
-    return {
-      page_id: row.page_id as string,
-      visited_at: row.visited_at as string,
-      title: page.title,
-      icon: page.icon,
-      is_database: page.is_database ?? false,
-    };
-  });
+  const recentVisits = asPageVisitRows(recentVisitRows).map((row) => ({
+    page_id: row.page_id,
+    visited_at: row.visited_at,
+    title: row.pages.title,
+    icon: row.pages.icon,
+    is_database: row.pages.is_database ?? false,
+  }));
 
   return (
     <WorkspaceHomeClient

--- a/src/app/(auth)/sign-in/sign-in-form.tsx
+++ b/src/app/(auth)/sign-in/sign-in-form.tsx
@@ -4,6 +4,10 @@ import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { getClient } from "@/lib/supabase/lazy-client";
+import {
+  membersWithWorkspaceSlug,
+  asMemberWorkspaceSlugRow,
+} from "@/lib/supabase/typed-queries";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -53,16 +57,14 @@ function SignInFormInner() {
       data: { user },
     } = await supabase.auth.getUser();
     if (user) {
-      const { data: membership } = await supabase
-        .from("members")
-        .select("workspace_id, workspaces(slug)")
+      const { data: membership } = await membersWithWorkspaceSlug(supabase)
         .eq("user_id", user.id)
         .limit(1)
         .maybeSingle();
 
-      if (membership?.workspaces) {
-        const ws = membership.workspaces as unknown as { slug: string };
-        router.push(`/${ws.slug}`);
+      const typed = asMemberWorkspaceSlugRow(membership);
+      if (typed?.workspaces) {
+        router.push(`/${typed.workspaces.slug}`);
         return;
       }
     }

--- a/src/app/(auth)/sign-up/sign-up-form.tsx
+++ b/src/app/(auth)/sign-up/sign-up-form.tsx
@@ -4,6 +4,10 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { getClient } from "@/lib/supabase/lazy-client";
+import {
+  membersWithWorkspaceSlug,
+  asMemberWorkspaceSlugRow,
+} from "@/lib/supabase/typed-queries";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -67,16 +71,14 @@ export function SignUpForm() {
     // If email confirmation is disabled, the user is immediately active.
     // Fetch their workspace and redirect.
     if (data.user) {
-      const { data: membership } = await supabase
-        .from("members")
-        .select("workspace_id, workspaces(slug)")
+      const { data: membership } = await membersWithWorkspaceSlug(supabase)
         .eq("user_id", data.user.id)
         .limit(1)
         .maybeSingle();
 
-      if (membership?.workspaces) {
-        const ws = membership.workspaces as unknown as { slug: string };
-        router.push(`/${ws.slug}`);
+      const typed = asMemberWorkspaceSlugRow(membership);
+      if (typed?.workspaces) {
+        router.push(`/${typed.workspaces.slug}`);
         return;
       }
     }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import {
+  membersWithWorkspaceSlug,
+  asMemberWorkspaceSlugRow,
+} from "@/lib/supabase/typed-queries";
 
 /**
  * Handles auth redirects from Supabase: email confirmation, OAuth callbacks,
@@ -47,14 +51,13 @@ export async function GET(request: NextRequest) {
 
   if (isOAuth) {
     // OAuth sign-in: session is active, redirect to the user's workspace
-    const { data: membership } = await supabase
-      .from("members")
-      .select("workspaces(slug)")
+    const { data: membership } = await membersWithWorkspaceSlug(supabase)
       .eq("user_id", data.user.id)
       .limit(1)
       .maybeSingle();
 
-    const slug = (membership?.workspaces as unknown as { slug: string } | null)?.slug;
+    const typed = asMemberWorkspaceSlugRow(membership);
+    const slug = typed?.workspaces?.slug;
     return NextResponse.redirect(`${origin}/${slug ?? ""}`);
   }
 

--- a/src/components/database/property-types/person.tsx
+++ b/src/components/database/property-types/person.tsx
@@ -5,6 +5,10 @@ import { Check, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getClient } from "@/lib/supabase/lazy-client";
 import {
+  membersWithProfiles,
+  asMemberProfileRows,
+} from "@/lib/supabase/typed-queries";
+import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
@@ -173,12 +177,11 @@ export function PersonEditor({
         return;
       }
 
-      const { data: membersData, error: membersError } = await supabase
-        .from("members")
-        .select(
-          "user_id, profiles!members_user_id_fkey(id, display_name, email, avatar_url)",
-        )
-        .eq("workspace_id", dbPage.workspace_id);
+      const { data: membersData, error: membersError } =
+        await membersWithProfiles(supabase).eq(
+          "workspace_id",
+          dbPage.workspace_id,
+        );
 
       if (membersError) {
         if (!isInsufficientPrivilegeError(membersError)) {
@@ -189,21 +192,14 @@ export function PersonEditor({
       }
 
       if (!cancelled && membersData) {
-        const resolved: PersonInfo[] = membersData.map((m) => {
-          // Supabase join returns the relation as an opaque type
-          const profile = m.profiles as unknown as {
-            id: string;
-            display_name: string;
-            email: string;
-            avatar_url: string | null;
-          };
-          return {
+        const resolved: PersonInfo[] = asMemberProfileRows(membersData).map(
+          (m) => ({
             id: m.user_id,
-            display_name: profile.display_name,
-            email: profile.email,
-            avatar_url: profile.avatar_url,
-          };
-        });
+            display_name: m.profiles.display_name,
+            email: m.profiles.email,
+            avatar_url: m.profiles.avatar_url,
+          }),
+        );
         setMembers(resolved);
         setLoading(false);
       }

--- a/src/components/delete-workspace-section.tsx
+++ b/src/components/delete-workspace-section.tsx
@@ -5,6 +5,10 @@ import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
 import {
+  membersWithWorkspaceSlugPersonal,
+  asMemberWorkspaceSlugPersonalRows,
+} from "@/lib/supabase/typed-queries";
+import {
   captureSupabaseError,
   isInsufficientPrivilegeError,
 } from "@/lib/sentry";
@@ -54,24 +58,17 @@ export function DeleteWorkspaceSection({
       return;
     }
 
-    const { data: membership } = await supabase
-      .from("members")
-      .select("workspace_id, workspaces(slug, is_personal)")
+    const { data: membership } = await membersWithWorkspaceSlugPersonal(
+      supabase,
+    )
       .eq("user_id", userId)
       .limit(10);
 
-    // Supabase join returns the relation as an opaque type; casts are unavoidable
-    const personal = membership?.find((m) => {
-      const ws = m.workspaces as unknown as {
-        slug: string;
-        is_personal: boolean;
-      };
-      return ws?.is_personal;
-    });
+    const typedRows = asMemberWorkspaceSlugPersonalRows(membership);
+    const personal = typedRows.find((m) => m.workspaces?.is_personal);
 
     if (personal) {
-      const ws = personal.workspaces as unknown as { slug: string };
-      router.push(`/${ws.slug}`);
+      router.push(`/${personal.workspaces.slug}`);
     } else {
       router.push("/");
     }

--- a/src/components/members/invite-form.tsx
+++ b/src/components/members/invite-form.tsx
@@ -3,6 +3,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Check, Copy, Send } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
+import {
+  membersWithProfileEmail,
+  asMemberProfileEmailRows,
+} from "@/lib/supabase/typed-queries";
 import { captureSupabaseError } from "@/lib/sentry";
 import { trackEventClient } from "@/lib/track-event";
 import { Button } from "@/components/ui/button";
@@ -74,15 +78,14 @@ export function InviteForm({
 
     // Check if user is already a member.
     // Disambiguate: members has two FKs to profiles (user_id, invited_by).
-    const { data: existingMember } = await supabase
-      .from("members")
-      .select("id, profiles!members_user_id_fkey(email)")
-      .eq("workspace_id", workspaceId);
+    const { data: existingMember } = await membersWithProfileEmail(supabase).eq(
+      "workspace_id",
+      workspaceId,
+    );
 
-    const alreadyMember = existingMember?.some((m) => {
-      const profile = m.profiles as unknown as { email: string } | null;
-      return profile?.email?.toLowerCase() === trimmedEmail;
-    });
+    const alreadyMember = asMemberProfileEmailRows(existingMember).some(
+      (m) => m.profiles?.email?.toLowerCase() === trimmedEmail,
+    );
 
     if (alreadyMember) {
       onError("This user is already a member of this workspace.");

--- a/src/components/sidebar/workspace-switcher.tsx
+++ b/src/components/sidebar/workspace-switcher.tsx
@@ -4,6 +4,10 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ChevronsUpDown, Plus, Check } from "lucide-react";
 import { getClient } from "@/lib/supabase/lazy-client";
+import {
+  membersWithWorkspace,
+  asMemberWorkspaceFullRows,
+} from "@/lib/supabase/typed-queries";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -30,15 +34,14 @@ export function WorkspaceSwitcher({ userId }: WorkspaceSwitcherProps) {
   useEffect(() => {
     async function fetchWorkspaces() {
       const supabase = await getClient();
-      const { data: memberships } = await supabase
-        .from("members")
-        .select("workspace_id, workspaces(*)")
-        .eq("user_id", userId);
+      const { data: memberships } = await membersWithWorkspace(supabase).eq(
+        "user_id",
+        userId,
+      );
 
       if (memberships) {
-        // Supabase join returns the relation as an opaque type; cast is unavoidable
-        const ws = memberships
-          .map((m) => m.workspaces as unknown as Workspace)
+        const ws = asMemberWorkspaceFullRows(memberships)
+          .map((m) => m.workspaces)
           .filter(Boolean);
 
         // Personal first, then alphabetically by name

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -3,6 +3,10 @@
 
 import { createClient } from "@/lib/supabase/client";
 import {
+  membersWithProfiles,
+  asMemberProfileRows,
+} from "@/lib/supabase/typed-queries";
+import {
   getDatabaseCache,
   setDatabaseCache,
   invalidateDatabase,
@@ -878,31 +882,21 @@ export async function loadWorkspaceMembers(
   }
 
   const supabase = getClient();
-  const { data, error } = await supabase
-    .from("members")
-    .select(
-      "user_id, profiles!members_user_id_fkey(id, display_name, email, avatar_url)",
-    )
-    .eq("workspace_id", workspaceId);
+  const { data, error } = await membersWithProfiles(supabase).eq(
+    "workspace_id",
+    workspaceId,
+  );
 
   if (error) {
     return { data: null, error };
   }
 
-  const members: WorkspaceMember[] = (data ?? []).map((m) => {
-    const profile = m.profiles as unknown as {
-      id: string;
-      display_name: string;
-      email: string;
-      avatar_url: string | null;
-    };
-    return {
-      id: m.user_id,
-      display_name: profile.display_name,
-      email: profile.email,
-      avatar_url: profile.avatar_url,
-    };
-  });
+  const members: WorkspaceMember[] = asMemberProfileRows(data).map((m) => ({
+    id: m.user_id,
+    display_name: m.profiles.display_name,
+    email: m.profiles.email,
+    avatar_url: m.profiles.avatar_url,
+  }));
 
   setMembersCache(workspaceId, members);
 

--- a/src/lib/supabase/typed-queries.ts
+++ b/src/lib/supabase/typed-queries.ts
@@ -1,0 +1,169 @@
+// Typed query helpers for Supabase join queries.
+//
+// Without generated database types, Supabase returns joined relations as
+// `unknown`. These helpers centralize the select strings and type assertions
+// so call sites get properly typed results without `as unknown as` casts.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Workspace } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Result row types for each join pattern
+// ---------------------------------------------------------------------------
+
+/** Row from `members` with joined `profiles` via user_id FK. */
+export interface MemberProfileRow {
+  user_id: string;
+  profiles: {
+    id: string;
+    display_name: string;
+    email: string;
+    avatar_url: string | null;
+  };
+}
+
+/** Row from `members` with joined `profiles(email)` only. */
+export interface MemberProfileEmailRow {
+  id: string;
+  profiles: { email: string } | null;
+}
+
+/** Row from `members` with joined full `workspaces(*)`. */
+export interface MemberWorkspaceFullRow {
+  workspace_id: string;
+  workspaces: Workspace;
+}
+
+/** Row from `members` with joined `workspaces(slug)`. */
+export interface MemberWorkspaceSlugRow {
+  workspace_id: string;
+  workspaces: { slug: string } | null;
+}
+
+/** Row from `members` with joined `workspaces(slug, is_personal)`. */
+export interface MemberWorkspaceSlugPersonalRow {
+  workspace_id: string;
+  workspaces: { slug: string; is_personal: boolean };
+}
+
+/** Row from `page_visits` with joined `pages`. */
+export interface PageVisitRow {
+  page_id: string;
+  visited_at: string;
+  pages: {
+    title: string;
+    icon: string | null;
+    is_database: boolean;
+    deleted_at: string | null;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Select strings (single source of truth)
+// ---------------------------------------------------------------------------
+
+const SELECT_MEMBERS_PROFILES =
+  "user_id, profiles!members_user_id_fkey(id, display_name, email, avatar_url)";
+
+const SELECT_MEMBERS_PROFILES_EMAIL =
+  "id, profiles!members_user_id_fkey(email)";
+
+const SELECT_MEMBERS_WORKSPACES_ALL = "workspace_id, workspaces(*)";
+
+const SELECT_MEMBERS_WORKSPACES_SLUG = "workspace_id, workspaces(slug)";
+
+const SELECT_MEMBERS_WORKSPACES_SLUG_PERSONAL =
+  "workspace_id, workspaces(slug, is_personal)";
+
+const SELECT_PAGE_VISITS_PAGES =
+  "page_id, visited_at, pages!inner(title, icon, is_database, deleted_at)";
+
+// ---------------------------------------------------------------------------
+// Query builders
+//
+// Each returns a Supabase query builder with the select string baked in.
+// Callers chain `.eq()`, `.limit()`, etc. then cast the result using the
+// corresponding row type. The cast is safe because the select string and
+// row type are defined together above.
+// ---------------------------------------------------------------------------
+
+/** Members with profile info (id, display_name, email, avatar_url). */
+export function membersWithProfiles(client: SupabaseClient) {
+  return client.from("members").select(SELECT_MEMBERS_PROFILES);
+}
+
+/** Members with profile email only (for duplicate-member checks). */
+export function membersWithProfileEmail(client: SupabaseClient) {
+  return client.from("members").select(SELECT_MEMBERS_PROFILES_EMAIL);
+}
+
+/** Members with full workspace data. */
+export function membersWithWorkspace(client: SupabaseClient) {
+  return client.from("members").select(SELECT_MEMBERS_WORKSPACES_ALL);
+}
+
+/** Members with workspace slug only. */
+export function membersWithWorkspaceSlug(client: SupabaseClient) {
+  return client.from("members").select(SELECT_MEMBERS_WORKSPACES_SLUG);
+}
+
+/** Members with workspace slug and is_personal flag. */
+export function membersWithWorkspaceSlugPersonal(client: SupabaseClient) {
+  return client
+    .from("members")
+    .select(SELECT_MEMBERS_WORKSPACES_SLUG_PERSONAL);
+}
+
+/** Page visits with joined page data (title, icon, is_database). */
+export function pageVisitsWithPages(client: SupabaseClient) {
+  return client.from("page_visits").select(SELECT_PAGE_VISITS_PAGES);
+}
+
+// ---------------------------------------------------------------------------
+// Result casting helpers
+//
+// Supabase without generated types returns join fields as `unknown`.
+// These one-liner helpers centralize the cast so call sites stay clean.
+// ---------------------------------------------------------------------------
+
+/** Cast a raw members→profiles row array to typed rows. */
+export function asMemberProfileRows(
+  data: Record<string, unknown>[] | null,
+): MemberProfileRow[] {
+  return (data ?? []) as unknown as MemberProfileRow[];
+}
+
+/** Cast a raw members→profiles(email) row array to typed rows. */
+export function asMemberProfileEmailRows(
+  data: Record<string, unknown>[] | null,
+): MemberProfileEmailRow[] {
+  return (data ?? []) as unknown as MemberProfileEmailRow[];
+}
+
+/** Cast a raw members→workspaces(*) row array to typed rows. */
+export function asMemberWorkspaceFullRows(
+  data: Record<string, unknown>[] | null,
+): MemberWorkspaceFullRow[] {
+  return (data ?? []) as unknown as MemberWorkspaceFullRow[];
+}
+
+/** Cast a single raw members→workspaces(slug) row. */
+export function asMemberWorkspaceSlugRow(
+  data: Record<string, unknown> | null,
+): MemberWorkspaceSlugRow | null {
+  return data as unknown as MemberWorkspaceSlugRow | null;
+}
+
+/** Cast a raw members→workspaces(slug, is_personal) row array. */
+export function asMemberWorkspaceSlugPersonalRows(
+  data: Record<string, unknown>[] | null,
+): MemberWorkspaceSlugPersonalRow[] {
+  return (data ?? []) as unknown as MemberWorkspaceSlugPersonalRow[];
+}
+
+/** Cast a raw page_visits→pages row array to typed rows. */
+export function asPageVisitRows(
+  data: Record<string, unknown>[] | null,
+): PageVisitRow[] {
+  return (data ?? []) as unknown as PageVisitRow[];
+}


### PR DESCRIPTION
Closes #1047

## What

Adds `src/lib/supabase/typed-queries.ts` with typed query builders and result casters for the 3 recurring Supabase join patterns. Replaces all 11 inline `as unknown as` casts across 10 files with calls to these centralized helpers.

## How

Each join pattern is defined once with four co-located pieces:
- **Row type** — TypeScript interface for the join result shape
- **Select string** — the `.select()` argument as a constant
- **Query builder** — function that calls `.from().select()` and returns the chainable query
- **Result caster** — function that applies the `as unknown as` cast in one place

Call sites import the query builder (chain `.eq()`, `.limit()`, etc.) and the result caster (get typed rows back). The cast is centralized so a schema change only needs updating in one file.

### Helpers added

| Query builder | Result caster | Join pattern |
|---|---|---|
| `membersWithProfiles` | `asMemberProfileRows` | members → profiles (id, display_name, email, avatar_url) |
| `membersWithProfileEmail` | `asMemberProfileEmailRows` | members → profiles (email only) |
| `membersWithWorkspace` | `asMemberWorkspaceFullRows` | members → workspaces (*) |
| `membersWithWorkspaceSlug` | `asMemberWorkspaceSlugRow` | members → workspaces (slug) |
| `membersWithWorkspaceSlugPersonal` | `asMemberWorkspaceSlugPersonalRows` | members → workspaces (slug, is_personal) |
| `pageVisitsWithPages` | `asPageVisitRows` | page_visits → pages (title, icon, is_database) |

### Files changed (11 cast sites across 10 files)

- `src/lib/database.ts` — 1 cast
- `src/app/(app)/[workspaceSlug]/[pageId]/page.tsx` — 1 cast
- `src/app/(app)/[workspaceSlug]/page.tsx` — 1 cast
- `src/app/(auth)/sign-in/sign-in-form.tsx` — 1 cast
- `src/app/(auth)/sign-up/sign-up-form.tsx` — 1 cast
- `src/app/auth/callback/route.ts` — 1 cast
- `src/components/delete-workspace-section.tsx` — 2 casts
- `src/components/members/invite-form.tsx` — 1 cast
- `src/components/sidebar/workspace-switcher.tsx` — 1 cast
- `src/components/database/property-types/person.tsx` — 1 cast

### Knowledge base updates

- `.agents/architecture.md` — added `typed-queries.ts` to the Component Map
- `.agents/conventions.md` — added "Typed join queries" pattern with usage example

## Testing

- `pnpm lint` — 0 errors ✅
- `pnpm typecheck` — passes ✅
- `pnpm test` — 139 files, 1877 tests pass ✅
- No behavior changes — pure type-safety refactor, no new UI or interactions

## Notes

Three additional Supabase join casts exist outside the issue's scope (`settings/members/page.tsx` × 2, `page-backlinks.tsx` × 1). These use different join patterns (members with `*` + profiles, workspace_invites with profiles, page_links with pages) and could be addressed in a follow-up.