### PR TITLE
fix: align performance monitor bundle measurement with CI script (#1050)

### DIFF
--- a/.ona/automations/performance-monitor.yaml
+++ b/.ona/automations/performance-monitor.yaml
@@ -30,8 +30,14 @@ action:
                      search_events(organizationSlug, naturalLanguageQuery="count of errors last week")
                    Flag if error count increased >50%.
 
-                3. Build size: run `pnpm build` and check the output for page sizes.
-                   Flag any page over 200KB (first load JS).
+                3. Build size: run `pnpm build`, then run `pnpm test:bundle` to measure
+                   gzipped first-load JS per route. This script reads
+                   `.next/diagnostics/route-bundle-stats.json`, gzips each chunk file,
+                   and sums per route — the same method CI uses.
+                   Parse the table from its stdout (columns: Route, Size (gzip), Budget, Status).
+                   Flag any route marked ❌ (over 200kB gzipped budget).
+                   Do NOT estimate sizes from `pnpm build` console output — those numbers
+                   use a different methodology and will not match CI.
 
                 ## Output
 
@@ -51,11 +57,11 @@ action:
                 - Last week: Y errors
                 - Trend: ↑/↓/→
 
-                ## Build Size
-                | Page | First Load JS | Status |
-                |---|---|---|
-                | / | XkB | ✅/⚠️/❌ |
-                | /login | XkB | ✅/⚠️/❌ |
+                ## Build Size (via `pnpm test:bundle`)
+                | Route | First Load JS (gzip) | Budget | Status |
+                |---|---|---|---|
+                Copy the table rows directly from `pnpm test:bundle` output.
+                Do NOT re-measure or estimate sizes from build console output.
 
                 ## Action Items
                 - [list any issues that need fixing, or "No action needed"]


### PR DESCRIPTION
Closes #1050

## What

The Performance Monitor automation was measuring bundle sizes by eyeballing `pnpm build` console output, which uses raw/uncompressed sizes. The CI bundle check (`scripts/check-bundle.mjs`) reads `route-bundle-stats.json` and gzips each chunk individually — a different methodology that produces lower, accurate numbers. This caused the weekly report to flag all 12 pages as over-budget while CI passed on the same commit.

## How

Updated `.ona/automations/performance-monitor.yaml` to:
1. Instruct the agent to run `pnpm test:bundle` after `pnpm build` instead of parsing build console output
2. Parse the structured table from `pnpm test:bundle` stdout (same script CI uses)
3. Explicitly warn against estimating sizes from build console output
4. Updated the report template to match the script's output format (Route, First Load JS (gzip), Budget, Status)

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 139 files, 1877 tests passed
- No code changes (YAML-only), so no E2E tests needed
- W21 report will use the aligned methodology; sizes will match CI output within 1kB tolerance