### PR TITLE
chore: add data-testid attributes to workspace home, sidebar, and app shell (#1044)

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -123,7 +123,7 @@ authTest.describe("Accessibility: page editor", () => {
         // Empty workspace — that's fine, we'll create a page
       }
 
-      const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+      const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
       await newPageBtn.waitFor({ state: "visible", timeout: 10_000 });
       await newPageBtn.click();
 

--- a/e2e/database-add-property-types.spec.ts
+++ b/e2e/database-add-property-types.spec.ts
@@ -55,7 +55,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-bulk-select.spec.ts
+++ b/e2e/database-bulk-select.spec.ts
@@ -42,7 +42,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-crud.spec.ts
+++ b/e2e/database-crud.spec.ts
@@ -52,7 +52,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-csv-export.spec.ts
+++ b/e2e/database-csv-export.spec.ts
@@ -42,7 +42,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-duplicate-row.spec.ts
+++ b/e2e/database-duplicate-row.spec.ts
@@ -73,7 +73,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-duplicate.spec.ts
+++ b/e2e/database-duplicate.spec.ts
@@ -42,7 +42,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-error-recovery.spec.ts
+++ b/e2e/database-error-recovery.spec.ts
@@ -43,7 +43,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-filter-keyboard.spec.ts
+++ b/e2e/database-filter-keyboard.spec.ts
@@ -41,7 +41,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-filter-types.spec.ts
+++ b/e2e/database-filter-types.spec.ts
@@ -41,7 +41,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-inline.spec.ts
+++ b/e2e/database-inline.spec.ts
@@ -49,7 +49,7 @@ async function waitForSidebarTree(page: Page) {
 async function createDatabaseFromSidebar(page: Page): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 
@@ -87,7 +87,7 @@ async function addRowToDatabase(page: Page) {
 async function navigateToNewPage(page: Page): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+  const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
   await expect(newPageBtn).toBeVisible({ timeout: 5_000 });
   await newPageBtn.click();
 

--- a/e2e/database-row-page.spec.ts
+++ b/e2e/database-row-page.spec.ts
@@ -49,7 +49,7 @@ async function createDatabaseWithRow(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-search.spec.ts
+++ b/e2e/database-search.spec.ts
@@ -42,7 +42,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-table-editor-portal.spec.ts
+++ b/e2e/database-table-editor-portal.spec.ts
@@ -42,7 +42,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-table-keyboard.spec.ts
+++ b/e2e/database-table-keyboard.spec.ts
@@ -42,7 +42,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/database-views.spec.ts
+++ b/e2e/database-views.spec.ts
@@ -42,7 +42,7 @@ async function createDatabaseFromSidebar(
 ): Promise<string> {
   const sidebar = await waitForSidebarTree(page);
 
-  const newDbBtn = sidebar.getByRole("button", { name: /new database/i });
+  const newDbBtn = sidebar.getByTestId("sb-new-database-btn");
   await expect(newDbBtn).toBeVisible({ timeout: 5_000 });
   await newDbBtn.click();
 

--- a/e2e/favorites.spec.ts
+++ b/e2e/favorites.spec.ts
@@ -26,7 +26,7 @@ test.describe("Sidebar Favorites", () => {
     title: string,
   ): Promise<string> {
     const sidebar = page.getByRole("complementary");
-    const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+    const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
     await newPageBtn.click();
 
     await page.waitForURL(

--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -236,7 +236,7 @@ test.describe("Mobile viewport responsive behavior", () => {
     await page.setViewportSize(MOBILE_VIEWPORT);
 
     // Open the mobile sidebar sheet
-    const toggleButton = page.getByRole("button", { name: "Toggle sidebar" });
+    const toggleButton = page.getByTestId("as-sidebar-toggle");
     await expect(toggleButton).toBeVisible({ timeout: 10_000 });
     await toggleButton.click();
 
@@ -250,7 +250,7 @@ test.describe("Mobile viewport responsive behavior", () => {
     await expect(treeLoaded).toBeVisible({ timeout: 10_000 });
 
     // Create a new page via the sidebar
-    const newPageBtn = sheetContent.getByRole("button", { name: /new page/i });
+    const newPageBtn = sheetContent.getByTestId("sb-new-page-btn");
     await expect(newPageBtn).toBeVisible({ timeout: 5_000 });
     await newPageBtn.click();
 

--- a/e2e/page-crud.spec.ts
+++ b/e2e/page-crud.spec.ts
@@ -18,7 +18,7 @@ test.describe("Page CRUD", () => {
       // Tree loaded but empty — that's fine
     }
 
-    const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+    const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
     if ((await newPageBtn.count()) === 0) {
       test.skip(true, "New page button not found");
       return;
@@ -138,7 +138,7 @@ test.describe("Page CRUD", () => {
     }
 
     // Create a page first so we have something to delete
-    const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+    const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
     if ((await newPageBtn.count()) === 0) {
       test.skip(true, "New page button not found");
       return;

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -27,7 +27,7 @@ async function createPageWithTitle(
   title: string
 ): Promise<string> {
   const sidebar = page.getByRole("complementary");
-  const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+  const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
   await newPageBtn.click();
 
   await page.waitForURL(
@@ -84,7 +84,7 @@ test.describe("Sidebar search", () => {
     authenticatedPage: page,
   }) => {
     const sidebar = page.getByRole("complementary");
-    const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+    const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
     if ((await newPageBtn.count()) === 0) {
       test.skip(true, "New page button not found — cannot set up search test");
       return;
@@ -99,7 +99,7 @@ test.describe("Sidebar search", () => {
   }) => {
     // First create a page so we have something to search for
     const sidebar = page.getByRole("complementary");
-    const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+    const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
     if ((await newPageBtn.count()) === 0) {
       test.skip(true, "New page button not found");
       return;
@@ -135,7 +135,7 @@ test.describe("Sidebar search", () => {
   }) => {
     // Create a page to search for
     const sidebar = page.getByRole("complementary");
-    const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+    const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
     if ((await newPageBtn.count()) === 0) {
       test.skip(true, "New page button not found");
       return;
@@ -213,7 +213,7 @@ test.describe("Sidebar search", () => {
   }) => {
     // Create a page in the current workspace with a unique identifier
     const sidebar = page.getByRole("complementary");
-    const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+    const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
     if ((await newPageBtn.count()) === 0) {
       test.skip(true, "New page button not found");
       return;

--- a/e2e/sidebar-responsive.spec.ts
+++ b/e2e/sidebar-responsive.spec.ts
@@ -21,7 +21,7 @@ test.describe("Responsive sidebar behavior", () => {
     await expect(sheetContent).toBeHidden();
 
     // Mobile header with hamburger button should be visible
-    const toggleButton = page.getByRole("button", { name: "Toggle sidebar" });
+    const toggleButton = page.getByTestId("as-sidebar-toggle");
     await expect(toggleButton).toBeVisible({ timeout: 5_000 });
 
     // Click the hamburger to open the Sheet sidebar
@@ -53,7 +53,7 @@ test.describe("Responsive sidebar behavior", () => {
     expect(box!.width).toBeGreaterThan(0);
 
     // The mobile hamburger toggle should NOT be visible on desktop
-    const toggleButton = page.getByRole("button", { name: "Toggle sidebar" });
+    const toggleButton = page.getByTestId("as-sidebar-toggle");
     await expect(toggleButton).toBeHidden();
 
     // Sheet overlay should not be present
@@ -104,7 +104,7 @@ test.describe("Responsive sidebar behavior", () => {
     await expect(sheetContent).toBeHidden();
 
     // Open the sidebar Sheet
-    const toggleButton = page.getByRole("button", { name: "Toggle sidebar" });
+    const toggleButton = page.getByTestId("as-sidebar-toggle");
     await expect(toggleButton).toBeVisible({ timeout: 5_000 });
     await toggleButton.click();
     await expect(sheetContent).toBeVisible({ timeout: 5_000 });
@@ -115,7 +115,7 @@ test.describe("Responsive sidebar behavior", () => {
       await expect(treeItem).toBeVisible({ timeout: 10_000 });
     } catch {
       // No pages exist — create one so we can navigate
-      const newPageBtn = sheetContent.getByRole("button", { name: /new page/i });
+      const newPageBtn = sheetContent.getByTestId("sb-new-page-btn");
       if ((await newPageBtn.count()) > 0) {
         await newPageBtn.click();
         // Wait for navigation to the new page

--- a/e2e/trash.spec.ts
+++ b/e2e/trash.spec.ts
@@ -21,7 +21,7 @@ async function createPage(page: import("@playwright/test").Page) {
   const sidebar = page.getByRole("complementary");
   await waitForTreeLoaded(page);
 
-  const newPageBtn = sidebar.getByRole("button", { name: /new page/i });
+  const newPageBtn = sidebar.getByTestId("sb-new-page-btn");
   await newPageBtn.click();
 
   // Wait for navigation to the new page

--- a/e2e/workspace-home-mobile-header.spec.ts
+++ b/e2e/workspace-home-mobile-header.spec.ts
@@ -13,15 +13,12 @@ test.describe("Workspace home — mobile header layout", () => {
     await page.goto("/");
     const main = page.locator("#main-content");
 
-    // Wait for the workspace home to load — look for a heading
-    const heading = main.locator("h1").first();
-    await expect(heading).toBeVisible({ timeout: 15_000 });
+    // Wait for the workspace home to load — look for the header
+    const header = main.getByTestId("wh-header");
+    await expect(header).toBeVisible({ timeout: 15_000 });
 
-    // Scope to the header row (the container that holds the h1) to avoid
-    // matching sidebar page buttons like "Untitled Database just now".
-    const headerRow = heading.locator("..");
-    const dbButton = headerRow.getByRole("button", { name: /database/i });
-    const pageButton = headerRow.getByRole("button", { name: /page/i });
+    const dbButton = main.getByTestId("wh-new-database-btn");
+    const pageButton = main.getByTestId("wh-new-page-btn");
     await expect(dbButton).toBeVisible({ timeout: 5_000 });
     await expect(pageButton).toBeVisible({ timeout: 5_000 });
 

--- a/e2e/workspace-home-new-database.spec.ts
+++ b/e2e/workspace-home-new-database.spec.ts
@@ -8,7 +8,7 @@ test.describe("Workspace home — New Database button", () => {
     const main = page.locator("#main-content");
 
     // Wait for the workspace home page to load (the heading and buttons)
-    const newDbButton = main.getByRole("button", { name: /new database/i });
+    const newDbButton = main.getByTestId("wh-new-database-btn");
     await expect(newDbButton).toBeVisible({ timeout: 15_000 });
 
     // Click the "New Database" button

--- a/e2e/workspace-home.spec.ts
+++ b/e2e/workspace-home.spec.ts
@@ -2,15 +2,10 @@ import { test, expect } from "./fixtures/auth";
 import type { Locator } from "@playwright/test";
 
 /**
- * Returns the "All Pages" container — the div.mt-6 that holds the heading,
- * filter/sort toolbar, and the page list.
+ * Returns the "All Pages" container using its data-testid attribute.
  */
 function getAllPagesSection(main: Locator): Locator {
-  // The "All Pages" heading is inside a div.mt-6. Use the filter input's
-  // ancestor to scope precisely — the filter input only exists in "All Pages".
-  return main.locator("div.mt-6").filter({
-    hasText: /All Pages/,
-  });
+  return main.locator('[data-testid="wh-all-pages"]');
 }
 
 /**
@@ -42,7 +37,7 @@ async function collectTitles(
  * Waits for the workspace home page to fully load inside #main-content.
  */
 async function waitForWorkspaceHome(main: Locator): Promise<void> {
-  const filterInput = main.getByRole("textbox", { name: /filter pages/i });
+  const filterInput = main.getByTestId("wh-filter-input");
   await expect(filterInput).toBeVisible({ timeout: 15_000 });
 }
 
@@ -52,7 +47,7 @@ test.describe("Workspace home page interactions", () => {
   }) => {
     const main = page.locator("#main-content");
 
-    const newPageButton = main.getByRole("button", { name: /new page/i });
+    const newPageButton = main.getByTestId("wh-new-page-btn");
     await expect(newPageButton).toBeVisible({ timeout: 15_000 });
 
     await newPageButton.click();
@@ -76,7 +71,7 @@ test.describe("Workspace home page interactions", () => {
     const main = page.locator("#main-content");
     await waitForWorkspaceHome(main);
 
-    const filterInput = main.getByRole("textbox", { name: /filter pages/i });
+    const filterInput = main.getByTestId("wh-filter-input");
     const pageItems = getPageListItems(main);
 
     await expect(pageItems.first()).toBeVisible({ timeout: 10_000 });
@@ -130,7 +125,7 @@ test.describe("Workspace home page interactions", () => {
     const main = page.locator("#main-content");
     await waitForWorkspaceHome(main);
 
-    const sortTrigger = main.getByRole("combobox", { name: /sort pages/i });
+    const sortTrigger = main.getByTestId("wh-sort-dropdown");
     const pageItems = getPageListItems(main);
 
     await expect(pageItems.first()).toBeVisible({ timeout: 10_000 });
@@ -231,7 +226,7 @@ test.describe("Workspace home page interactions", () => {
     const main = page.locator("#main-content");
     await waitForWorkspaceHome(main);
 
-    const filterInput = main.getByRole("textbox", { name: /filter pages/i });
+    const filterInput = main.getByTestId("wh-filter-input");
     const pageItems = getPageListItems(main);
 
     await expect(pageItems.first()).toBeVisible({ timeout: 10_000 });

--- a/src/components/sidebar/app-shell.tsx
+++ b/src/components/sidebar/app-shell.tsx
@@ -44,7 +44,7 @@ function AppShellInner({
   children,
 }: AppShellProps) {
   return (
-    <div className="flex h-screen overflow-hidden">
+    <div className="flex h-screen overflow-hidden" data-testid="as-shell">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:bg-background focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-foreground focus:ring-2 focus:ring-ring focus:outline-none"

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -76,6 +76,7 @@ export function AppSidebar(props: AppSidebarProps) {
   return (
     <aside
       className="h-full w-60 shrink-0 border-r border-overlay-border bg-muted transition-[width,opacity] duration-200 ease-out"
+      data-testid="as-sidebar"
       style={{
         width: open ? 240 : 0,
         opacity: open ? 1 : 0,
@@ -99,6 +100,7 @@ export function SidebarToggle() {
       className="shrink-0"
       onClick={toggle}
       aria-label="Toggle sidebar"
+      data-testid="as-sidebar-toggle"
     >
       <Menu className="h-4 w-4" />
     </Button>

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -335,6 +335,7 @@ export function PageSearch() {
           aria-expanded={showResults}
           role="combobox"
           aria-controls="search-results"
+          data-testid="as-search-input"
           aria-activedescendant={
             showResults && results[selectedIndex]
               ? `search-result-${results[selectedIndex].id}`

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -213,7 +213,7 @@ export function PageTree({ userId }: PageTreeProps) {
   if (!workspaceSlug) return null;
 
   return (
-    <div className="flex flex-1 flex-col gap-1 overflow-y-auto">
+    <div className="flex flex-1 flex-col gap-1 overflow-y-auto" data-testid="sb-page-tree">
       <p className="px-2 text-xs tracking-widest uppercase text-label-faint">
         Pages
       </p>
@@ -276,6 +276,7 @@ export function PageTree({ userId }: PageTreeProps) {
         className="mt-1 w-full justify-start gap-2 px-2 text-muted-foreground"
         size="sm"
         onClick={() => actions.handleCreate(null)}
+        data-testid="sb-new-page-btn"
       >
         <Plus className="h-4 w-4" />
         New Page
@@ -285,6 +286,7 @@ export function PageTree({ userId }: PageTreeProps) {
         className="w-full justify-start gap-2 px-2 text-muted-foreground"
         size="sm"
         onClick={actions.handleCreateDatabase}
+        data-testid="sb-new-database-btn"
       >
         <Table2 className="h-4 w-4" />
         New Database

--- a/src/components/sidebar/user-menu.tsx
+++ b/src/components/sidebar/user-menu.tsx
@@ -80,6 +80,7 @@ export function UserMenu({ displayName, email }: UserMenuProps) {
             variant="ghost"
             className="w-full justify-start gap-2 px-2"
             size="sm"
+            data-testid="as-user-menu"
           />
         }
       >

--- a/src/components/sidebar/workspace-switcher.tsx
+++ b/src/components/sidebar/workspace-switcher.tsx
@@ -78,6 +78,7 @@ export function WorkspaceSwitcher({ userId }: WorkspaceSwitcherProps) {
             className="w-full justify-between gap-2 px-2"
             size="sm"
             aria-label="Switch workspace"
+            data-testid="as-workspace-switcher"
           />
         }
       >

--- a/src/components/workspace-home.tsx
+++ b/src/components/workspace-home.tsx
@@ -183,15 +183,15 @@ export function WorkspaceHome({
 
   return (
     <div className="mx-auto max-w-3xl p-6">
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2" data-testid="wh-header">
         <h1 className="min-w-0 text-2xl font-semibold">{workspace.name}</h1>
         <div className="flex shrink-0 items-center gap-2">
-          <Button size="sm" variant="outline" onClick={handleCreateDatabase}>
+          <Button size="sm" variant="outline" onClick={handleCreateDatabase} data-testid="wh-new-database-btn">
             <Table2 className="h-4 w-4" />
             <span className="hidden sm:inline">New Database</span>
             <span className="sm:hidden">Database</span>
           </Button>
-          <Button size="sm" onClick={handleCreatePage}>
+          <Button size="sm" onClick={handleCreatePage} data-testid="wh-new-page-btn">
             <Plus className="h-4 w-4" />
             <span className="hidden sm:inline">New Page</span>
             <span className="sm:hidden">Page</span>
@@ -199,7 +199,7 @@ export function WorkspaceHome({
         </div>
       </div>
       {recentVisits.length > 0 && (
-        <div className="mt-6">
+        <div className="mt-6" data-testid="wh-recently-visited">
           <h2 className="mb-2 text-xs uppercase tracking-widest text-label-faint">
             Recently Visited
           </h2>
@@ -207,6 +207,7 @@ export function WorkspaceHome({
             {recentVisits.map((visit) => (
               <button
                 key={visit.page_id}
+                data-testid={`wh-recent-item-${visit.page_id}`}
                 className="flex items-center gap-2 px-3 py-2 text-left text-sm transition-none hover:bg-overlay-hover focus-visible:bg-overlay-active focus-visible:outline-none"
                 onClick={() =>
                   router.push(`/${workspace.slug}/${visit.page_id}`)
@@ -233,7 +234,7 @@ export function WorkspaceHome({
           </div>
         </div>
       )}
-      <div className="mt-6">
+      <div className="mt-6" data-testid="wh-all-pages">
         <h2 className="mb-2 text-xs uppercase tracking-widest text-label-faint">
           All Pages
         </h2>
@@ -246,6 +247,7 @@ export function WorkspaceHome({
               onChange={(e) => setFilter(e.target.value)}
               className="pl-8"
               aria-label="Filter pages by title"
+              data-testid="wh-filter-input"
             />
           </div>
           <Select
@@ -256,6 +258,7 @@ export function WorkspaceHome({
               size="sm"
               className="w-auto shrink-0"
               aria-label="Sort pages"
+              data-testid="wh-sort-dropdown"
             >
               <SelectValue>
                 {(value: string) => SORT_LABELS[value as SortOption] ?? value}
@@ -288,6 +291,7 @@ export function WorkspaceHome({
             {filteredAndSorted.map((page) => (
               <button
                 key={page.id}
+                data-testid={`wh-page-item-${page.id}`}
                 className="flex items-center gap-2 px-3 py-2 text-left text-sm transition-none hover:bg-overlay-hover focus-visible:bg-overlay-active focus-visible:outline-none"
                 onClick={() =>
                   router.push(`/${workspace.slug}/${page.id}`)


### PR DESCRIPTION
Closes #1044

## What

Adds `data-testid` attributes to key interactive elements in workspace home, sidebar, and app shell components. Updates 25 E2E test files to prefer `data-testid` selectors over broad `getByRole` selectors.

## Why

E2E tests outside the database domain relied on role-based selectors without scoping to a specific container. When new UI elements were added, these selectors matched multiple elements causing "strict mode violation" errors (root cause of #1042, #998, #916, #835, #780).

## Changes

**Component attributes added:**

- `workspace-home.tsx` — `wh-header`, `wh-new-page-btn`, `wh-new-database-btn`, `wh-filter-input`, `wh-sort-dropdown`, `wh-recently-visited`, `wh-all-pages`, `wh-page-item-{id}`, `wh-recent-item-{id}`
- `sidebar/page-tree.tsx` — `sb-page-tree`, `sb-new-page-btn`, `sb-new-database-btn`
- `sidebar/app-sidebar.tsx` — `as-sidebar`, `as-sidebar-toggle`
- `sidebar/app-shell.tsx` — `as-shell`
- `sidebar/workspace-switcher.tsx` — `as-workspace-switcher`
- `sidebar/page-search.tsx` — `as-search-input`
- `sidebar/user-menu.tsx` — `as-user-menu`

**E2E test updates (25 files):**

Replaced `getByRole("button", { name: /new page/i })` → `getByTestId("sb-new-page-btn")` and similar for all workspace-home and sidebar selectors across: workspace-home, workspace-home-mobile-header, workspace-home-new-database, page-crud, favorites, trash, search, accessibility, sidebar-responsive, mobile-responsive, and 15 database test files.

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 1877 tests passed (139 files)
- E2E tests using new selectors pass; intermittent auth timeout failures are pre-existing and unrelated to this change
- No behavior changes — pure attribute addition + selector migration