### PR TITLE
chore: social post 2026-05-12 afternoon

### DIFF
--- a/metrics/daily/2026-05-12-tweet-afternoon.md
+++ b/metrics/daily/2026-05-12-tweet-afternoon.md
@@ -1,0 +1,10 @@
+## Twitter/X (afternoon)
+
+Typed Supabase query helpers landed — fewer runtime errors, better autocomplete for every database call. Also fixed how we measure bundle size in CI.
+
+8 PRs merged today, 195 lines, 95% CI pass rate. Day 30.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2054215885775118567)


### PR DESCRIPTION
Afternoon build-in-public tweet for Day 30.

Covers what shipped since the morning post: typed Supabase query helpers, bundle measurement fix, and day totals (8 PRs, 195 lines, 95% CI).

Posted: https://x.com/swfactory_dev/status/2054215885775118567