### PR TITLE
feat: add focus-visible styles to sidebar page tree items and action buttons (#1052)

### DIFF
--- a/src/components/sidebar/favorites-section.tsx
+++ b/src/components/sidebar/favorites-section.tsx
@@ -164,7 +164,7 @@ export function FavoritesSection({ userId }: FavoritesSectionProps) {
             </span>
 
             <button
-              className="flex-1 truncate text-left"
+              className="flex-1 truncate text-left focus-visible:bg-overlay-active focus-visible:outline-none"
               onClick={() =>
                 router.push(`/${workspaceSlug}/${fav.page_id}`)
               }
@@ -173,7 +173,7 @@ export function FavoritesSection({ userId }: FavoritesSectionProps) {
             </button>
 
             <button
-              className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground opacity-0 hover:text-foreground group-hover:opacity-100"
+              className="flex h-5 w-5 shrink-0 items-center justify-center text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100"
               onClick={() => handleRemoveFavorite(fav.id)}
               aria-label="Remove from favorites"
             >

--- a/src/components/sidebar/page-tree-item.tsx
+++ b/src/components/sidebar/page-tree-item.tsx
@@ -124,7 +124,7 @@ export function PageTreeItem({
         </span>
 
         <button
-          className="flex h-4 w-4 shrink-0 items-center justify-center"
+          className="flex h-4 w-4 shrink-0 items-center justify-center focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           onClick={(e) => {
             e.stopPropagation();
             if (hasChildren) {
@@ -154,7 +154,7 @@ export function PageTreeItem({
         </span>
 
         <button
-          className="flex-1 truncate text-left"
+          className="flex-1 truncate text-left focus-visible:bg-overlay-active focus-visible:outline-none"
           onClick={() => onNavigate(page.id)}
           title={page.title || "Untitled"}
         >

--- a/src/components/sidebar/trash-section.tsx
+++ b/src/components/sidebar/trash-section.tsx
@@ -218,7 +218,7 @@ export function TrashSection() {
   return (
     <div className="flex flex-col gap-0.5">
       <button
-        className="flex items-center gap-2 px-2 py-0.5 text-xs tracking-widest uppercase text-label-faint hover:text-label-muted"
+        className="flex items-center gap-2 px-2 py-0.5 text-xs tracking-widest uppercase text-label-faint hover:text-label-muted focus-visible:bg-overlay-active focus-visible:outline-none"
         onClick={() => setExpanded((prev) => !prev)}
         aria-expanded={expanded}
       >


### PR DESCRIPTION
Closes #1052

## What

Adds `focus-visible` styles to bare `<button>` elements in the sidebar so keyboard users can see which element is focused when tabbing through the page tree, favorites, and trash sections.

## How

Added Tailwind `focus-visible:` classes to 5 bare `<button>` elements across 3 files:

- **`page-tree-item.tsx`** — page navigation button gets `focus-visible:bg-overlay-active focus-visible:outline-none`; expand/collapse chevron gets `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring`
- **`favorites-section.tsx`** — page navigation button gets `focus-visible:bg-overlay-active focus-visible:outline-none`; remove-favorite button gets `focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring` (also becomes visible on focus)
- **`trash-section.tsx`** — trash toggle button gets `focus-visible:bg-overlay-active focus-visible:outline-none`

Follows the pattern established in #1027 for workspace home page items. shadcn/ui `Button` components (Add sub-page, Page actions, Restore, Delete) already have built-in focus styles and were not modified.

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 139 files, 1877 tests passed
- Pure style addition — no behavior changes, no new interactions