### PR TITLE
refactor: extend typed-queries to cover remaining as-unknown-as casts (#1059)

### DIFF
--- a/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
@@ -2,7 +2,13 @@ import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { MembersPageClient } from "@/components/members/members-page-client";
-import type { MemberWithProfile, WorkspaceInviteWithInviter } from "@/lib/types";
+import type { WorkspaceInviteWithInviter } from "@/lib/types";
+import {
+  membersWithFullProfile,
+  asMemberWithProfileRows,
+  invitesWithInviter,
+  asInviteWithInviterRows,
+} from "@/lib/supabase/typed-queries";
 
 export async function generateMetadata({
   params,
@@ -62,17 +68,12 @@ export default async function WorkspaceMembersPage({
     notFound();
   }
 
-  // Fetch all members with profile info.
-  // Disambiguate the profiles join: members has two FKs to profiles
-  // (user_id and invited_by). We want the user's profile.
-  const { data: membersRaw } = await supabase
-    .from("members")
-    .select("*, profiles!members_user_id_fkey(email, display_name, avatar_url)")
+  // Fetch all members with profile info (email, display_name, avatar_url).
+  const { data: membersRaw } = await membersWithFullProfile(supabase)
     .eq("workspace_id", workspace.id)
     .order("created_at", { ascending: true });
 
-  // Supabase join returns the relation as an opaque type; cast is unavoidable
-  const members = (membersRaw ?? []) as unknown as MemberWithProfile[];
+  const members = asMemberWithProfileRows(membersRaw);
 
   // Extract current user's display name for optimistic invite UI
   const currentUserProfile = members.find((m) => m.user_id === user.id);
@@ -86,15 +87,12 @@ export default async function WorkspaceMembersPage({
   let pendingInvites: WorkspaceInviteWithInviter[] = [];
 
   if (isAdmin) {
-    const { data: invites } = await supabase
-      .from("workspace_invites")
-      .select("*, profiles:invited_by(display_name)")
+    const { data: invites } = await invitesWithInviter(supabase)
       .eq("workspace_id", workspace.id)
       .is("accepted_at", null)
       .order("created_at", { ascending: false });
 
-    // Supabase join returns the relation as an opaque type; cast is unavoidable
-    pendingInvites = (invites ?? []) as unknown as WorkspaceInviteWithInviter[];
+    pendingInvites = asInviteWithInviterRows(invites);
   }
 
   return (

--- a/src/components/auth/oauth-buttons.tsx
+++ b/src/components/auth/oauth-buttons.tsx
@@ -61,7 +61,7 @@ export function OAuthButtons() {
 
     if (oauthError) {
       import("@/lib/sentry").then(({ captureSupabaseError }) =>
-        captureSupabaseError(oauthError as unknown as Error, `oauth.signIn.${provider}`),
+        captureSupabaseError(oauthError, `oauth.signIn.${provider}`),
       );
       setError(oauthError.message);
       setLoadingProvider(null);

--- a/src/components/page-backlinks.tsx
+++ b/src/components/page-backlinks.tsx
@@ -1,20 +1,15 @@
 import Link from "next/link";
 import { FileText, ArrowUpLeft } from "lucide-react";
 import { createClient } from "@/lib/supabase/server";
+import {
+  pageLinksWithSourcePage,
+  asBacklinkRows,
+} from "@/lib/supabase/typed-queries";
 
 interface PageBacklinksProps {
   pageId: string;
   workspaceId: string;
   workspaceSlug: string;
-}
-
-interface BacklinkRow {
-  source_page_id: string;
-  pages: {
-    id: string;
-    title: string;
-    icon: string | null;
-  };
 }
 
 export async function PageBacklinks({
@@ -24,9 +19,7 @@ export async function PageBacklinks({
 }: PageBacklinksProps) {
   const supabase = await createClient();
 
-  const { data, error } = await supabase
-    .from("page_links")
-    .select("source_page_id, pages!page_links_source_page_id_fkey(id, title, icon)")
+  const { data, error } = await pageLinksWithSourcePage(supabase)
     .eq("target_page_id", pageId)
     .eq("workspace_id", workspaceId);
 
@@ -34,8 +27,7 @@ export async function PageBacklinks({
     return null;
   }
 
-  // Supabase returns joined data; narrow the type
-  const backlinks = data as unknown as BacklinkRow[];
+  const backlinks = asBacklinkRows(data);
 
   return (
     <div className="mt-8 border-t border-overlay-border pt-4">

--- a/src/lib/supabase/typed-queries.ts
+++ b/src/lib/supabase/typed-queries.ts
@@ -5,7 +5,11 @@
 // so call sites get properly typed results without `as unknown as` casts.
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Workspace } from "@/lib/types";
+import type {
+  MemberWithProfile,
+  WorkspaceInviteWithInviter,
+  Workspace,
+} from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Result row types for each join pattern
@@ -58,6 +62,16 @@ export interface PageVisitRow {
   };
 }
 
+/** Row from `page_links` with joined source `pages` via source_page_id FK. */
+export interface BacklinkRow {
+  source_page_id: string;
+  pages: {
+    id: string;
+    title: string;
+    icon: string | null;
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Select strings (single source of truth)
 // ---------------------------------------------------------------------------
@@ -77,6 +91,15 @@ const SELECT_MEMBERS_WORKSPACES_SLUG_PERSONAL =
 
 const SELECT_PAGE_VISITS_PAGES =
   "page_id, visited_at, pages!inner(title, icon, is_database, deleted_at)";
+
+const SELECT_MEMBERS_WITH_PROFILE_FULL =
+  "*, profiles!members_user_id_fkey(email, display_name, avatar_url)";
+
+const SELECT_INVITES_WITH_INVITER =
+  "*, profiles:invited_by(display_name)";
+
+const SELECT_BACKLINKS =
+  "source_page_id, pages!page_links_source_page_id_fkey(id, title, icon)";
 
 // ---------------------------------------------------------------------------
 // Query builders
@@ -117,6 +140,21 @@ export function membersWithWorkspaceSlugPersonal(client: SupabaseClient) {
 /** Page visits with joined page data (title, icon, is_database). */
 export function pageVisitsWithPages(client: SupabaseClient) {
   return client.from("page_visits").select(SELECT_PAGE_VISITS_PAGES);
+}
+
+/** Members with full profile (email, display_name, avatar_url) plus all member fields. */
+export function membersWithFullProfile(client: SupabaseClient) {
+  return client.from("members").select(SELECT_MEMBERS_WITH_PROFILE_FULL);
+}
+
+/** Workspace invites with inviter's display_name. */
+export function invitesWithInviter(client: SupabaseClient) {
+  return client.from("workspace_invites").select(SELECT_INVITES_WITH_INVITER);
+}
+
+/** Page links with source page info (id, title, icon) for backlinks. */
+export function pageLinksWithSourcePage(client: SupabaseClient) {
+  return client.from("page_links").select(SELECT_BACKLINKS);
 }
 
 // ---------------------------------------------------------------------------
@@ -166,4 +204,25 @@ export function asPageVisitRows(
   data: Record<string, unknown>[] | null,
 ): PageVisitRow[] {
   return (data ?? []) as unknown as PageVisitRow[];
+}
+
+/** Cast a raw members→profiles(email, display_name, avatar_url) row array. */
+export function asMemberWithProfileRows(
+  data: Record<string, unknown>[] | null,
+): MemberWithProfile[] {
+  return (data ?? []) as unknown as MemberWithProfile[];
+}
+
+/** Cast a raw workspace_invites→profiles(display_name) row array. */
+export function asInviteWithInviterRows(
+  data: Record<string, unknown>[] | null,
+): WorkspaceInviteWithInviter[] {
+  return (data ?? []) as unknown as WorkspaceInviteWithInviter[];
+}
+
+/** Cast a raw page_links→pages row array to typed backlink rows. */
+export function asBacklinkRows(
+  data: Record<string, unknown>[] | null,
+): BacklinkRow[] {
+  return (data ?? []) as unknown as BacklinkRow[];
 }


### PR DESCRIPTION
Closes #1059

## What

Extends `src/lib/supabase/typed-queries.ts` to cover the four remaining `as unknown as` casts in production code:

1. **`members/page.tsx`** — `MemberWithProfile[]` cast → uses new `membersWithFullProfile()` + `asMemberWithProfileRows()`
2. **`members/page.tsx`** — `WorkspaceInviteWithInviter[]` cast → uses new `invitesWithInviter()` + `asInviteWithInviterRows()`
3. **`page-backlinks.tsx`** — `BacklinkRow[]` cast → uses new `pageLinksWithSourcePage()` + `asBacklinkRows()`
4. **`oauth-buttons.tsx`** — `as unknown as Error` cast → removed entirely since `AuthError` already extends `Error`

## How

- Added three new query builders and three new casting helpers to `typed-queries.ts`, following the existing pattern (co-located select strings + row types + query builders + cast helpers).
- Added `BacklinkRow` interface to `typed-queries.ts` (moved from the local definition in `page-backlinks.tsx`).
- Imported `MemberWithProfile` and `WorkspaceInviteWithInviter` from `@/lib/types` into `typed-queries.ts` for the casting helpers.
- For the OAuth error, simply removed the cast — Supabase's `AuthError` extends `Error`, so no narrowing is needed.

After this change, the only remaining `as unknown as` in production code is `src/lib/sentry/e2e-detection.ts` (window type narrowing, unrelated to Supabase).

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 139 files, 1877 tests passed
- No interactive UI changes, so no E2E tests needed
- Verified with `grep -rn 'as unknown as' src/ --include='*.ts' --include='*.tsx' | grep -v test | grep -v stories | grep -v typed-queries` — only the Sentry e2e-detection window cast remains