### PR TITLE
chore: migrate remaining parent-traversal selectors to data-testid (#1072)

### DIFF
--- a/e2e/database-calendar.spec.ts
+++ b/e2e/database-calendar.spec.ts
@@ -476,13 +476,14 @@ test.describe("Database calendar view", () => {
       hasText: "Untitled",
     }).count();
 
-    // Find the cell for day 20 via its gridcell role and day number
-    const day20Span = page.locator("span").filter({ hasText: /^20$/ }).first();
-    await expect(day20Span).toBeVisible({ timeout: 5_000 });
+    // Find the cell for day 20 via its data-testid (cal-day-YYYY-MM-DD)
+    const day20Cell = page.locator('[data-testid^="cal-day-"]').filter({
+      has: page.locator("span", { hasText: /^20$/ }),
+    }).first();
+    await expect(day20Cell).toBeVisible({ timeout: 5_000 });
 
     // Click the cell — the click may land on a child element (span, div),
     // which is fine since the handler no longer requires e.target === e.currentTarget.
-    const day20Cell = day20Span.locator("..");
     await day20Cell.click({ position: { x: 40, y: 60 } });
 
     // Wait for the async row creation to complete and the new "Untitled"

--- a/e2e/database-row-page.spec.ts
+++ b/e2e/database-row-page.spec.ts
@@ -165,8 +165,10 @@ test.describe("Database Row Page", () => {
     await expect(propertyLabel).toBeVisible({ timeout: 10_000 });
 
     // The value cell should show "Empty" since no value has been set.
-    // Navigate from the name cell to its sibling value cell in the same row.
-    const propertyRow = propertyLabel.locator("..");
+    // Navigate from the name cell to its containing row via the row testid.
+    const propertyRow = propertiesHeader.locator('[data-testid^="db-row-property-"]').filter({
+      has: propertyLabel,
+    });
     const valueCell = propertyRow.locator('[data-testid^="db-row-property-value-"]');
     await expect(valueCell).toContainText("Empty", { timeout: 5_000 });
   });
@@ -224,8 +226,10 @@ test.describe("Database Row Page", () => {
     await expect(statusLabel).toBeVisible({ timeout: 10_000 });
 
     // Click the "Empty" value next to "Status" to open the select editor.
-    // Navigate from the name cell to its sibling value cell in the same row.
-    const statusRow = statusLabel.locator("..");
+    // Navigate from the name cell to its containing row via the row testid.
+    const statusRow = propertiesHeader.locator('[data-testid^="db-row-property-"]').filter({
+      has: statusLabel,
+    });
     const statusValueCell = statusRow.locator('[data-testid^="db-row-property-value-"]');
     await expect(statusValueCell).toContainText("Empty", { timeout: 5_000 });
     // Click the button inside the value cell to trigger editing mode

--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -300,7 +300,7 @@ test.describe("Mobile viewport responsive behavior", () => {
 
     // The table has a horizontal scroll container. Verify it exists and
     // that the table content is wider than the mobile viewport (requires scroll).
-    const scrollContainer = grid.locator("..").first();
+    const scrollContainer = page.getByTestId("db-table-scroll");
     const scrollBox = await scrollContainer.boundingBox();
     expect(scrollBox).not.toBeNull();
 

--- a/e2e/theme-toggle.spec.ts
+++ b/e2e/theme-toggle.spec.ts
@@ -14,21 +14,7 @@ test.describe("theme toggle", () => {
     authenticatedPage: page,
   }) => {
     // Open user menu (bottom of sidebar)
-    const userMenuTrigger = page.locator(
-      '[data-slot="dropdown-menu-trigger"]',
-      { has: page.locator("text=Settings").first().locator("..").locator("..") },
-    );
-    // Find the user menu button — it's the one with the User icon in the sidebar
-    const sidebarUserButton = page
-      .locator("aside")
-      .locator('button:has-text("")')
-      .last();
-
-    // Click the user menu trigger at the bottom of the sidebar
-    await page
-      .locator("aside button")
-      .filter({ has: page.locator('svg.lucide-user') })
-      .click();
+    await page.getByTestId("as-user-menu").click();
 
     // Wait for the dropdown to appear
     await page.locator('[data-slot="dropdown-menu-content"]').waitFor();

--- a/e2e/workspace-home.spec.ts
+++ b/e2e/workspace-home.spec.ts
@@ -314,8 +314,8 @@ test.describe("Workspace home page interactions", () => {
     // The visited page should appear in the recently visited list
     if (visitedTitle && visitedTitle.trim()) {
       const trimmedTitle = visitedTitle.trim();
-      // The recently visited section is the parent div of the heading
-      const recentContainer = recentHeading.locator("..").first();
+      // The recently visited section container (has data-testid)
+      const recentContainer = page.getByTestId("wh-recently-visited");
       const recentItem = recentContainer.locator("button", {
         hasText: trimmedTitle,
       });

--- a/src/components/database/views/calendar-view.tsx
+++ b/src/components/database/views/calendar-view.tsx
@@ -388,6 +388,7 @@ function CalendarDayCell({
       aria-label={cell.date}
       tabIndex={isFocused ? 0 : -1}
       data-calendar-index={cellIndex}
+      data-testid={`cal-day-${cell.date}`}
       className={cn(
         "relative min-h-24 border border-overlay-border p-1 outline-none",
         "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -350,7 +350,7 @@ export const TableView = memo(function TableView({
         aria-hidden="true"
       />
 
-      <div ref={scrollRef} className="w-full overflow-x-auto">
+      <div ref={scrollRef} className="w-full overflow-x-auto" data-testid="db-table-scroll">
         <div
           ref={gridRef}
           className="w-max min-w-full"


### PR DESCRIPTION
Closes #1072

## What

Eliminates all remaining `locator("..")` parent-traversal selectors from the E2E test suite. These are the most fragile selector pattern — they break when DOM structure changes and were responsible for recurring E2E failures.

## How

**E2E spec changes (5 files):**
- `theme-toggle.spec.ts` — replaced `locator("text=Settings").first().locator("..").locator("..")` with `getByTestId("as-user-menu")` (testid already existed). Also removed dead-code variables `userMenuTrigger` and `sidebarUserButton`.
- `workspace-home.spec.ts` — replaced `recentHeading.locator("..").first()` with `getByTestId("wh-recently-visited")` (testid already existed).
- `database-calendar.spec.ts` — replaced `day20Span.locator("..")` with a `[data-testid^="cal-day-"]` filter that finds the cell containing the day span.
- `database-row-page.spec.ts` — replaced two `propertyLabel.locator("..")` / `statusLabel.locator("..")` traversals with `propertiesHeader.locator('[data-testid^="db-row-property-"]').filter({ has: label })`.
- `mobile-responsive.spec.ts` — replaced `grid.locator("..").first()` with `getByTestId("db-table-scroll")`.

**Component changes (2 files):**
- `calendar-view.tsx` — added `data-testid={`cal-day-${cell.date}`}` to the gridcell div.
- `table-view.tsx` — added `data-testid="db-table-scroll"` to the scroll container div.

## Testing

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — passes
- `pnpm test` — 139 files, 1877 tests pass
- E2E tests require Supabase and will be validated by CI
- No behavior changes — pure selector migration
- Zero `locator("..")` patterns remain in the entire `e2e/` directory