### PR TITLE
chore: social post 2026-05-13 afternoon

### DIFF
--- a/metrics/daily/2026-05-13-tweet-afternoon.md
+++ b/metrics/daily/2026-05-13-tweet-afternoon.md
@@ -1,0 +1,10 @@
+## Twitter/X (afternoon)
+
+The editor engine behind every Memo page just jumped from Lexical 0.31 to 0.44 — 13 minor versions in one PR. Plus patch updates to Next.js, React, Sentry, and Supabase.
+
+12 PRs merged today, 157 lines changed. Day 31.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2054578145185972486)


### PR DESCRIPTION
Afternoon build-in-public tweet for Day 31.

Covers what shipped since the morning post: Lexical editor upgrade (0.31 → 0.44), patch-level dependency updates (Next.js, React, Sentry, Supabase), and continued test selector migration.

Tweet posted: https://x.com/swfactory_dev/status/2054578145185972486