### PR TITLE
test: replace waitForTimeout calls in E2E specs with deterministic waits (#1078)

### DIFF
--- a/e2e/database-board.spec.ts
+++ b/e2e/database-board.spec.ts
@@ -350,6 +350,17 @@ test.describe("Database board view", () => {
       return;
     }
 
+    // Helper: yield to React's render cycle by waiting two animation frames.
+    // React flushes synchronous state updates before the next paint, so two
+    // rAF callbacks guarantee the update is committed to the DOM.
+    const waitForReactRender = () =>
+      page.evaluate(
+        () =>
+          new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+          ),
+      );
+
     // Step 1: dragstart on the card — sets React dragState
     await page.evaluate((el) => {
       const dt = new DataTransfer();
@@ -365,7 +376,7 @@ test.describe("Database board view", () => {
     }, cardHandle);
 
     // Allow React to process the dragstart and update state
-    await page.waitForTimeout(300);
+    await waitForReactRender();
 
     // Step 2: dragover on the Done column — sets drop target
     await page.evaluate((el) => {
@@ -380,7 +391,7 @@ test.describe("Database board view", () => {
       );
     }, colHandle);
 
-    await page.waitForTimeout(100);
+    await waitForReactRender();
 
     // Step 3: drop on the Done column — triggers the card move
     await page.evaluate((el) => {
@@ -394,7 +405,7 @@ test.describe("Database board view", () => {
       );
     }, colHandle);
 
-    await page.waitForTimeout(100);
+    await waitForReactRender();
 
     // Step 4: dragend on the card — cleanup
     await page.evaluate((el) => {

--- a/e2e/database-csv-export.spec.ts
+++ b/e2e/database-csv-export.spec.ts
@@ -103,8 +103,10 @@ test.describe("Database CSV Export", () => {
     await page.keyboard.type("Test Row Beta");
     await page.keyboard.press("Escape");
 
-    // Wait for auto-save
-    await page.waitForTimeout(1000);
+    // Wait for auto-save: verify the cell displays committed text outside edit mode
+    await expect(secondTitleCell).toContainText("Test Row Beta", {
+      timeout: 5_000,
+    });
 
     // Find and click the CSV export button
     const exportBtn = page.getByTestId("csv-export-button");

--- a/e2e/database-search.spec.ts
+++ b/e2e/database-search.spec.ts
@@ -203,8 +203,13 @@ test.describe("Database search filter", () => {
     await expect(boardOption).toBeVisible({ timeout: 5_000 });
     await boardOption.click();
 
-    // Wait for the new view to load
-    await page.waitForTimeout(500);
+    // Wait for the board view to render (shows either the board container
+    // or a "Group by" prompt when no select property is configured)
+    await expect(
+      page
+        .locator('[data-testid="db-board-container"], :text("Group by")')
+        .first(),
+    ).toBeVisible({ timeout: 5_000 });
 
     // Search input should be reset
     const newSearchInput = page.getByTestId("db-search-input");

--- a/e2e/demo-editor.spec.ts
+++ b/e2e/demo-editor.spec.ts
@@ -109,15 +109,16 @@ test.describe("Demo editor on landing page", () => {
     await editable.click();
     await page.keyboard.type("Persistent content test");
 
-    // Wait for debounced save (500ms + buffer)
-    await page.waitForTimeout(1000);
-
-    // Verify sessionStorage has content
-    const stored = await page.evaluate(() =>
-      sessionStorage.getItem("memo-demo-editor-content"),
-    );
-    expect(stored).toBeTruthy();
-    expect(stored).toContain("Persistent content test");
+    // Wait for the debounced save to persist content to sessionStorage
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() =>
+            sessionStorage.getItem("memo-demo-editor-content"),
+          ),
+        { timeout: 5_000, message: "sessionStorage should contain typed content" },
+      )
+      .toContain("Persistent content test");
 
     // Reload the page
     await page.reload();
@@ -166,8 +167,17 @@ test.describe("Demo editor on landing page", () => {
     await editable.click();
     await page.keyboard.type("Testing no supabase calls");
 
-    // Wait for any potential debounced saves
-    await page.waitForTimeout(1500);
+    // Wait for the debounced save to fire (content appears in sessionStorage),
+    // which proves the save cycle completed without needing an arbitrary timeout.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() =>
+            sessionStorage.getItem("memo-demo-editor-content"),
+          ),
+        { timeout: 5_000, message: "sessionStorage should contain typed content" },
+      )
+      .toContain("Testing no supabase calls");
 
     // Filter out auth-related calls (getUser on page load is expected)
     const nonAuthCalls = supabaseRequests.filter(

--- a/e2e/keyboard-shortcuts.spec.ts
+++ b/e2e/keyboard-shortcuts.spec.ts
@@ -177,11 +177,12 @@ test.describe("Keyboard shortcuts dialog", () => {
         }
       });
 
-      // Dialog should NOT open when an input is focused
+      // Dialog should NOT open when an input is focused.
+      // Confirm the input still has focus (positive signal that the event was processed),
+      // then verify no dialog appeared.
+      await expect(searchInput).toBeFocused();
       const dialog = page.getByRole("dialog");
-      // Wait briefly to ensure the dialog doesn't appear
-      await page.waitForTimeout(500);
-      await expect(dialog).toBeHidden();
+      await expect(dialog).not.toBeVisible();
     }
   });
 });

--- a/e2e/public-routes.spec.ts
+++ b/e2e/public-routes.spec.ts
@@ -39,7 +39,8 @@ test.describe("Sign-in form validation", () => {
     await page.goto("/sign-in");
     // Wait for hydration so controlled inputs are ready
     await page.locator('input[type="email"]').waitFor({ state: "visible" });
-    await page.waitForTimeout(300);
+    // Ensure the submit button is also rendered and enabled (signals hydration complete)
+    await expect(page.getByRole("button", { name: /sign in/i })).toBeEnabled();
   });
 
   test("empty submit is blocked by browser validation", async ({ page }) => {
@@ -76,7 +77,8 @@ test.describe("Sign-up form validation", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/sign-up");
     await page.locator('input[type="email"]').waitFor({ state: "visible" });
-    await page.waitForTimeout(300);
+    // Ensure the submit button is also rendered and enabled (signals hydration complete)
+    await expect(page.getByRole("button", { name: /sign up/i })).toBeEnabled();
   });
 
   test("empty submit is blocked by browser validation", async ({ page }) => {


### PR DESCRIPTION
Closes #1078

## What

Replaces all 10 `page.waitForTimeout()` calls across 6 E2E spec files with deterministic Playwright wait conditions. This eliminates arbitrary sleeps that slow tests and cause flakiness.

## How

Each replacement was chosen based on what the test was actually waiting for:

| File | Old | New | Rationale |
|---|---|---|---|
| `public-routes.spec.ts` (×2) | `waitForTimeout(300)` after input visible | `expect(button).toBeEnabled()` | Waits for React hydration by checking the submit button is interactive |
| `keyboard-shortcuts.spec.ts` | `waitForTimeout(500)` before checking dialog hidden | `expect(searchInput).toBeFocused()` then `expect(dialog).not.toBeVisible()` | Positive signal (input retained focus after event) confirms event was processed |
| `demo-editor.spec.ts` | `waitForTimeout(1000)` for debounced save | `expect.poll(() => sessionStorage.getItem(...))` | Polls sessionStorage until the debounced save completes |
| `demo-editor.spec.ts` | `waitForTimeout(1500)` for no-Supabase-calls check | `expect.poll(() => sessionStorage.getItem(...))` | Waits for save cycle to complete (positive signal), then checks no Supabase calls |
| `database-csv-export.spec.ts` | `waitForTimeout(1000)` for auto-save | `expect(cell).toContainText(...)` | Waits for cell to display committed text after exiting edit mode |
| `database-board.spec.ts` (×3) | `waitForTimeout(100-300)` between drag events | `requestAnimationFrame` double-frame yield | Yields to React's render cycle between synthetic drag events |
| `database-search.spec.ts` | `waitForTimeout(500)` for view load | `expect(locator).toBeVisible()` | Waits for board view container or "Group by" prompt to render |

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passed
- `pnpm test` — 1877 tests passed
- All 6 modified E2E spec files verified individually with `pnpm test:e2e --grep`
- `grep -rn "waitForTimeout" e2e/` returns no results

## Note

`database-csv-export.spec.ts:98` has a pre-existing failure (`toHaveCount(2)` receives 8 gridcells) that reproduces on `main` — unrelated to this change.