### PR TITLE
fix: guard proxy cookie values against null and add HeadlessChrome fallback to E2E filter (#1083)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -164,6 +164,21 @@ The `updateSession` function in `src/lib/supabase/proxy.ts` creates a server cli
 that reads cookies from the request and writes refreshed cookies to the response.
 It calls `supabase.auth.getUser()` to trigger the refresh.
 
+### Cookie null-safety (required for ALL Supabase client creation sites)
+
+`@supabase/ssr`'s client-side `combineChunks` → `getItem` path calls
+`chunkedCookie.startsWith()` without a `typeof` guard. During session teardown
+(account deletion, auth expiry, HTTP 500 from Supabase), cookie values can be
+`null`. Every `getAll` callback in every Supabase client creation site must apply
+`value ?? ""` to prevent `TypeError: Cannot read properties of null`.
+
+This applies to all three files:
+- `src/lib/supabase/server.ts` — `cookieStore.getAll().map(…)`
+- `src/lib/supabase/client.ts` — `document.cookie` parsing
+- `src/lib/supabase/proxy.ts` — `request.cookies.getAll().map(…)`
+
+When adding a new Supabase client creation site, always include the null guard.
+
 ## Async State in Effects
 
 When a `useCallback` closes over async state (e.g. a resolved ID), putting that
@@ -447,8 +462,13 @@ E2E tests (Playwright with HeadlessChrome) can trigger server-side errors that
 are not application bugs. Both client-side and server-side Sentry configs must
 filter these out:
 
-- **Client-side** — Playwright's auth fixture sets `window.__SENTRY_DISABLED__`
-  via `addInitScript`. The `beforeSend` filter checks `isE2ETestSession()`.
+- **Client-side** — `isE2ETestSession()` uses two synchronous checks:
+  1. `window.__SENTRY_DISABLED__` flag set by Playwright's `addInitScript`.
+  2. `navigator.userAgent` containing `HeadlessChrome/` — fallback that works
+     even if the flag hasn't been set yet during early page load.
+  Both checks are synchronous, eliminating race conditions with async Sentry
+  initialization (the SDK is loaded via dynamic `import()` in
+  `instrumentation-client.ts`).
 - **Server-side** — `sentry.server.config.ts` and `sentry.edge.config.ts` use
   `isE2ETestRequest(event)` which checks two sources:
   1. `event.request.headers` for `HeadlessChrome/` in the User-Agent — works for

--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 141 | 1883 |
+| Unit/Integration (Vitest) | 142 | 1887 |
 | E2E (Playwright) | 78 | 386 |
-| **Total** | **219** | **2269** |
+| **Total** | **220** | **2273** |
 
 ### Test files by domain
 
@@ -51,8 +51,8 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **Feedback**: `feedback/route.test.ts` (17 tests), `feedback-form-design-spec.test.ts` (5 tests), `use-screenshot.test.ts` (2 tests), `e2e/feedback.spec.ts` (6 tests)
 - **API**: `health/route.test.ts` (9 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (6 tests), `cron/purge-trash/route.test.ts` (8 tests), `feedback/route.test.ts` (17 tests), `pages/[pageId]/versions/route.test.ts` (15 tests), `pages/[pageId]/versions/route.rate-limit.test.ts` (3 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (11 tests), `pages/[pageId]/versions/[versionId]/route.rate-limit.test.ts` (3 tests), `e2e/account-deletion.spec.ts` (4 tests), `e2e/account-settings.spec.ts` (5 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `design-spec-compliance.test.ts` (9 tests), `relative-time.test.ts` (7 tests), `reduced-motion.test.ts` (6 tests), `e2e/visual-regression.spec.ts` (1 test)
-- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (163 tests), `retry.test.ts` (9 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (6 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
-- **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests)
+- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (165 tests), `retry.test.ts` (9 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (6 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
+- **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests), `supabase/proxy.test.ts` (2 tests)
 
 ## Known Gaps
 
@@ -146,5 +146,6 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-13 | Migrate row-page, relation, and files E2E specs to data-testid selectors (#1065). Replaced 10 fragile `locator("text=...")` and CSS-class selectors across `database-row-page.spec.ts`, `database-relation.spec.ts`, and `database-files.spec.ts` with `getByTestId` targeting existing `db-row-property-*` and `db-cell-editor-*` testids. No new testids needed — all existing attributes were sufficient. No new test files. Test totals unchanged: 139 Vitest files (1877 tests), 78 E2E specs (381 tests). |
 | 2026-05-13 | Expand import/export E2E coverage (#1076). Added 5 new tests to `e2e/import-export.spec.ts` (2→7): unsupported elements graceful handling, empty file import, code block special characters export, nested list export, round-trip export-then-import. Test totals: 139 Vitest files (1877 tests), 78 E2E specs (386 tests). |
 | 2026-05-14 | Add rate limiting to page versions API routes (#1080). Added 2 new Vitest files: `pages/[pageId]/versions/route.rate-limit.test.ts` (3 tests), `pages/[pageId]/versions/[versionId]/route.rate-limit.test.ts` (3 tests). Updated API Routes domain: page versions endpoints 22→28 tests, added rate limits for version create (20/min) and restore (10/min). Test totals: 141 Vitest files (1883 tests), 78 E2E specs (386 tests). |
+| 2026-05-14 | Fix Supabase SSR cookie null-safety in proxy and Sentry E2E filter race condition (#1083). Added `supabase/proxy.test.ts` (2 tests) for proxy cookie null guard. Added 2 tests to `sentry.unit.test.ts` (163→165) for HeadlessChrome userAgent fallback in `isE2ETestSession`. Test totals: 142 Vitest files (1887 tests), 78 E2E specs (386 tests). |
 
 

--- a/src/lib/sentry/e2e-detection.ts
+++ b/src/lib/sentry/e2e-detection.ts
@@ -2,15 +2,33 @@ import type { ErrorEvent } from "@sentry/nextjs";
 
 /**
  * Returns true when the current browser session is an E2E test run.
- * Playwright's auth fixture sets `window.__SENTRY_DISABLED__` via
- * `addInitScript` to prevent simulated errors from generating real
- * Sentry events in production.
+ *
+ * Two detection methods (both synchronous, no race conditions):
+ * 1. `window.__SENTRY_DISABLED__` — set by Playwright's `addInitScript`
+ * 2. `navigator.userAgent` containing "HeadlessChrome/" — fallback that
+ *    works even if the flag hasn't been set yet (e.g. during early page
+ *    load before addInitScript executes on a navigation)
  */
 export function isE2ETestSession(): boolean {
-  return (
-    typeof window !== "undefined" &&
+  if (typeof window === "undefined") return false;
+
+  if (
     (window as unknown as Record<string, unknown>).__SENTRY_DISABLED__ === true
-  );
+  ) {
+    return true;
+  }
+
+  // Synchronous fallback: HeadlessChrome is only used by Playwright/Puppeteer.
+  // This eliminates the race condition where the __SENTRY_DISABLED__ flag may
+  // not be set before Sentry initializes and captures an early error.
+  if (
+    typeof navigator !== "undefined" &&
+    navigator.userAgent.includes("HeadlessChrome/")
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/src/lib/sentry/sentry.unit.test.ts
+++ b/src/lib/sentry/sentry.unit.test.ts
@@ -1511,9 +1511,17 @@ describe("captureApiError", () => {
 
 describe("isE2ETestSession", () => {
   const win = window as unknown as Record<string, unknown>;
+  let originalUserAgent: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalUserAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+  });
 
   afterEach(() => {
     delete win.__SENTRY_DISABLED__;
+    if (originalUserAgent) {
+      Object.defineProperty(navigator, "userAgent", originalUserAgent);
+    }
   });
 
   it("returns true when __SENTRY_DISABLED__ is set on window", () => {
@@ -1528,6 +1536,24 @@ describe("isE2ETestSession", () => {
 
   it("returns false when __SENTRY_DISABLED__ is a non-true value", () => {
     win.__SENTRY_DISABLED__ = "true";
+    expect(isE2ETestSession()).toBe(false);
+  });
+
+  it("returns true when navigator.userAgent contains HeadlessChrome/ (race condition fallback)", () => {
+    delete win.__SENTRY_DISABLED__;
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/147.0.0.0 Safari/537.36",
+      configurable: true,
+    });
+    expect(isE2ETestSession()).toBe(true);
+  });
+
+  it("returns false for normal Chrome userAgent without __SENTRY_DISABLED__", () => {
+    delete win.__SENTRY_DISABLED__;
+    Object.defineProperty(navigator, "userAgent", {
+      value: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+      configurable: true,
+    });
     expect(isE2ETestSession()).toBe(false);
   });
 });

--- a/src/lib/supabase/proxy.test.ts
+++ b/src/lib/supabase/proxy.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+type CookieEntry = { name: string; value: string };
+type SetCookieEntry = {
+  name: string;
+  value: string;
+  options?: Record<string, unknown>;
+};
+type CookieOptions = {
+  getAll: () => CookieEntry[];
+  setAll: (cookies: SetCookieEntry[]) => void;
+};
+
+let capturedCookies: CookieOptions | null = null;
+
+// Mock @supabase/ssr to capture the cookie options passed to createServerClient
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: (
+    _url: string,
+    _key: string,
+    opts?: { cookies?: CookieOptions },
+  ) => {
+    capturedCookies = opts?.cookies ?? null;
+    return {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null } }),
+      },
+    };
+  },
+}));
+
+// Mock next/server with minimal NextRequest/NextResponse implementations
+const mockCookiesGetAll = vi.fn<() => CookieEntry[]>().mockReturnValue([]);
+const mockCookiesSet = vi.fn();
+
+vi.mock("next/server", () => {
+  class MockNextRequest {
+    cookies = {
+      getAll: mockCookiesGetAll,
+      set: mockCookiesSet,
+    };
+    nextUrl: { pathname: string; clone: () => { pathname: string } };
+
+    constructor(url: string) {
+      const pathname = new URL(url).pathname;
+      this.nextUrl = {
+        pathname,
+        clone: () => ({ pathname }),
+      };
+    }
+  }
+
+  return {
+    NextRequest: MockNextRequest,
+    NextResponse: {
+      next: vi.fn().mockReturnValue({
+        cookies: { set: vi.fn() },
+      }),
+      redirect: vi.fn().mockReturnValue({
+        cookies: { set: vi.fn() },
+      }),
+    },
+  };
+});
+
+import { NextRequest } from "next/server";
+import { updateSession } from "./proxy";
+
+describe("proxy cookie null-safety", () => {
+  beforeEach(() => {
+    capturedCookies = null;
+    mockCookiesGetAll.mockReset();
+    mockCookiesSet.mockReset();
+  });
+
+  it("getAll coerces null cookie values to empty strings", async () => {
+    // Simulate cookies with null values during session teardown
+    mockCookiesGetAll.mockReturnValue([
+      { name: "sb-auth-token", value: "valid-token" },
+      { name: "sb-auth-token.0", value: null as unknown as string },
+      { name: "sb-auth-token.1", value: undefined as unknown as string },
+    ]);
+
+    const request = new NextRequest("http://localhost/sign-in");
+    await updateSession(request as never);
+
+    expect(capturedCookies).not.toBeNull();
+    const cookies = capturedCookies!.getAll();
+
+    // Every value must be a string — never null/undefined
+    for (const cookie of cookies) {
+      expect(typeof cookie.value).toBe("string");
+      // This is the exact operation that crashes in @supabase/ssr's
+      // combineChunks without the null guard
+      expect(() => cookie.value.startsWith("base64-")).not.toThrow();
+    }
+
+    expect(cookies).toEqual([
+      { name: "sb-auth-token", value: "valid-token" },
+      { name: "sb-auth-token.0", value: "" },
+      { name: "sb-auth-token.1", value: "" },
+    ]);
+  });
+
+  it("getAll preserves valid cookie values unchanged", async () => {
+    mockCookiesGetAll.mockReturnValue([
+      { name: "session", value: "abc123" },
+      { name: "theme", value: "dark" },
+    ]);
+
+    const request = new NextRequest("http://localhost/sign-in");
+    await updateSession(request as never);
+
+    const cookies = capturedCookies!.getAll();
+    expect(cookies).toEqual([
+      { name: "session", value: "abc123" },
+      { name: "theme", value: "dark" },
+    ]);
+  });
+});

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -17,7 +17,14 @@ export async function updateSession(request: NextRequest) {
     {
       cookies: {
         getAll() {
-          return request.cookies.getAll();
+          // Guard against null cookie values during session teardown.
+          // @supabase/ssr's client-side combineChunks calls startsWith()
+          // without a typeof guard, causing a TypeError when cookies are
+          // partially deleted. Matches the guard in server.ts and client.ts.
+          return request.cookies.getAll().map(({ name, value }) => ({
+            name,
+            value: value ?? "",
+          }));
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value }) =>


### PR DESCRIPTION
Closes #1083

## What

`TypeError: Cannot read properties of null (reading 'startsWith')` recurs in Sentry from E2E test sessions. Previous fixes (#836, #938) added `value ?? ""` null guards to `server.ts` and `client.ts`, but missed `proxy.ts` — the middleware that runs on every request. Additionally, the client-side Sentry E2E filter relied solely on `window.__SENTRY_DISABLED__` which has a race condition with the async Sentry SDK initialization via dynamic `import()`.

## How

Two root-cause fixes:

1. **Proxy cookie null guard** — Added `value ?? ""` to `proxy.ts`'s `getAll` callback, matching the existing pattern in `server.ts` and `client.ts`. This is the third and final Supabase client creation site that needed the guard.

2. **Synchronous HeadlessChrome detection** — Added `navigator.userAgent.includes("HeadlessChrome/")` as a fallback in `isE2ETestSession()`. Unlike the `window.__SENTRY_DISABLED__` flag (which depends on Playwright's `addInitScript` timing), the userAgent check is synchronous and available immediately, eliminating the race condition with async Sentry initialization.

Also updated `.agents/conventions.md` to document that all Supabase client creation sites must include the cookie null guard, and that the E2E filter uses two synchronous detection methods.

## Testing

- Added `src/lib/supabase/proxy.test.ts` (2 tests): verifies `getAll` coerces null/undefined cookie values to empty strings, and preserves valid values.
- Added 2 tests to `src/lib/sentry/sentry.unit.test.ts`: verifies `isE2ETestSession()` returns true for HeadlessChrome userAgent (race condition fallback), and false for normal Chrome.
- All 142 Vitest files (1887 tests) pass. Lint and typecheck clean.