### PR TITLE
chore: daily metrics snapshot 2026-05-15

### DIFF
--- a/metrics/daily/2026-05-15.json
+++ b/metrics/daily/2026-05-15.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-05-15",
+  "day_number": 33,
+  "loc": {
+    "total": 75615,
+    "delta": 749,
+    "by_language": {
+      "TypeScript": 73790,
+      "SQL": 1544,
+      "CSS": 281
+    }
+  },
+  "files": {
+    "total": 254,
+    "delta": 2
+  },
+  "prs": {
+    "total": 635,
+    "delta": 13,
+    "currently_open": 0
+  },
+  "commits": {
+    "total": 658,
+    "delta": 13
+  },
+  "issues": {
+    "backlog": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 441,
+    "opened_today": 1,
+    "closed_today": 2
+  },
+  "tests": {
+    "unit": 1911,
+    "e2e": 401
+  },
+  "ci": {
+    "runs_total": 10,
+    "runs_passed": 10,
+    "pass_rate_pct": 100.0
+  },
+  "test_coverage_pct": 37.14,
+  "autonomous_pct": 88,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
Daily metrics snapshot for 2026-05-15 (Day 33).

| Metric | Value | Delta |
|---|---|---|
| LOC | 75,615 | +749 |
| Files | 254 | +2 |
| PRs merged | 635 | +13 |
| Commits | 658 | +13 |
| Unit tests | 1,911 | +24 |
| E2E tests | 401 | +17 |
| Test coverage | 37.14% | +0.10 |
| CI pass rate | 100.0% | — |
| Issues done | 441 | +9 |
| Autonomous % | 88% | — |
