### PR TITLE
fix(api): handle FK violation in version restore endpoint

### DIFF
--- a/src/app/api/pages/[pageId]/versions/[versionId]/route.test.ts
+++ b/src/app/api/pages/[pageId]/versions/[versionId]/route.test.ts
@@ -56,6 +56,9 @@ const captureApiErrorMock = vi.fn();
 vi.mock("@/lib/sentry", () => ({
   captureApiError: (...args: unknown[]) => captureApiErrorMock(...args),
   captureSupabaseError: vi.fn(),
+  isForeignKeyViolationError: (err: Error & { code?: string }) =>
+    err.code === "23503" ||
+    err.message?.includes("violates foreign key constraint"),
   isInsufficientPrivilegeError: (err: Error & { code?: string }) =>
     err.code === "42501" ||
     err.message?.includes("violates row-level security policy"),
@@ -319,5 +322,32 @@ describe("POST /api/pages/[pageId]/versions/[versionId] (restore)", () => {
     expect(body.error).toBe(
       "Version restore temporarily unavailable, please try again",
     );
+  });
+
+  it("returns 404 when snapshot insert hits FK violation (page deleted, #1114)", async () => {
+    mockGetUser.mockReset();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    getVersionResult = { data: { content: { root: {} } }, error: null };
+    getPageResult = { data: { content: { root: {} } }, error: null };
+    insertVersionResult = {
+      data: null,
+      error: {
+        code: "23503",
+        message: 'insert or update on table "page_versions" violates foreign key constraint "page_versions_page_id_fkey"',
+        details: "Key (page_id)=(40cd1f0a-63a0-4b11-aee6-6fc5b6dab600) is not present in table \"pages\".",
+        hint: null,
+      },
+    };
+
+    const res = await POST(
+      makeRequest("/api/pages/page-123/versions/version-456", {
+        method: "POST",
+        body: JSON.stringify({ action: "restore" }),
+      }),
+      { params: mockParams },
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Page not found");
   });
 });

--- a/src/app/api/pages/[pageId]/versions/[versionId]/route.ts
+++ b/src/app/api/pages/[pageId]/versions/[versionId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { captureApiError, captureSupabaseError, isInsufficientPrivilegeError, isTransientNetworkError } from "@/lib/sentry";
+import { captureApiError, captureSupabaseError, isForeignKeyViolationError, isInsufficientPrivilegeError, isTransientNetworkError } from "@/lib/sentry";
 import { retryOnNetworkError } from "@/lib/retry";
 import { withRateLimit, getClientIp } from "@/lib/rate-limit";
 
@@ -158,6 +158,9 @@ async function postHandler(
     );
 
     if (snapshotError) {
+      if (isForeignKeyViolationError(snapshotError)) {
+        return NextResponse.json({ error: "Page not found" }, { status: 404 });
+      }
       captureSupabaseError(snapshotError, "page-versions:restore-snapshot");
       return NextResponse.json(
         { error: "Failed to save current version before restore" },
@@ -184,6 +187,9 @@ async function postHandler(
   } catch (error) {
     if (error instanceof Error && isInsufficientPrivilegeError(error)) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    if (error instanceof Error && isForeignKeyViolationError(error)) {
+      return NextResponse.json({ error: "Page not found" }, { status: 404 });
     }
     captureApiError(error, "page-versions:restore");
 


### PR DESCRIPTION
## Summary

The version restore endpoint (`POST /api/pages/[pageId]/versions/[versionId]`) was missing `isForeignKeyViolationError` handling when inserting a pre-restore snapshot into `page_versions`. When the referenced page was deleted between the auth check and the insert (race condition), PostgreSQL rejected the insert with a `23503` FK constraint violation, which was sent to Sentry via `captureSupabaseError` instead of returning a clean 404.

Sentry issue: https://ona-2j.sentry.io/issues/118825153/ (MEMO-2F) — 3 events, 2 users.

## Root cause

The sibling creation endpoint (`POST /api/pages/[pageId]/versions`) already handled this correctly with `isForeignKeyViolationError`, returning 404. The restore endpoint was missing the same check in both the `snapshotError` handler and the outer `catch` block.

All 3 Sentry events originated from E2E test sessions where workspace teardown cascaded to page deletion mid-restore, but the same race condition could occur if a user deletes a page while another tab attempts a restore.

## Changes

- **`src/app/api/pages/[pageId]/versions/[versionId]/route.ts`**: Added `isForeignKeyViolationError` to imports. Added FK violation check before `captureSupabaseError` in the snapshot-insert error handler (returns 404). Added same check in the outer catch block.
- **`src/app/api/pages/[pageId]/versions/[versionId]/route.test.ts`**: Added `isForeignKeyViolationError` to the sentry mock. Added regression test for FK violation during restore returning 404.

## Verification

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 142 files, 1912 tests passed

Closes #1114