### PR TITLE
test: add API route error-handling consistency tests (#1118)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -14,7 +14,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Domain | Grade | Notes |
 |---|---|---|
-| Infrastructure | A | Sentry (client + server + edge), proxy with session refresh, health endpoint with tests (9 tests), PWA manifest, global error boundary, Supabase clients (browser + server + proxy). JetBrains Mono font correctly configured. Dark-only oklch theme tokens. Migration validation tests (33 tests). |
+| Infrastructure | A | Sentry (client + server + edge), proxy with session refresh, health endpoint with tests (9 tests), PWA manifest, global error boundary, Supabase clients (browser + server + proxy). JetBrains Mono font correctly configured. Dark-only oklch theme tokens. Migration validation tests (33 tests). API route error-handling consistency tests (6 tests). |
 | Auth | A | Sign-in, sign-up, invite accept pages. OAuth sign-in with GitHub and Google fully functional. Auth guard in app layout with redirect. Error boundaries on all auth routes (5 error.tsx files, 22 tests). Loading state for invite page. Typography regression test (2 tests). Sign-in unit tests (10 tests): form validation, error handling, redirect logic, loading state. Sign-up unit tests (11 tests): form validation, error handling, redirect logic, loading state. Auth callback route tests (7 tests). Root page tests (4 tests). OAuth buttons unit tests (10 tests). E2E spec covers form rendering, redirect, and sign-in flow (8 tests). |
 | Workspaces | A | Workspace home, settings (name/slug/delete), workspace switcher with create dialog. Slug generation utility with unit tests (12 tests). Settings form unit tests (17 tests): validation, save, slug sanitization, delete confirmation flow, error handling. Create workspace dialog unit tests (5 tests). E2E specs cover workspace creation (3 tests), workspace settings (3 tests), and workspace limit enforcement (2 tests). Max 3 workspace limit enforced via DB trigger. |
 | Pages | A | Page view with title + editor, page tree with CRUD + drag-and-drop + nest/unnest. Page menu with export/import markdown. Page icon picker with emoji support. Cover images, backlinks, version history, favorites, trash/soft-delete, page duplication, inline page link search. Keyboard shortcuts for duplicate (⌘D) and export (⌘⇧E). Tree logic extracted to `src/lib/page-tree.ts` with 37 unit tests covering build, reorder, nest, unnest, and drop computation. Page tree keyboard shortcut tests (5 tests). Page icon design spec tests (1 test). Page visit error handling tests (2 tests). Persisted tree expansion tests (9 tests). 10 E2E specs: page CRUD (5), sidebar drag (2), page icon (4), page cover (5), page duplicate (4), favorites (7), trash (7), version history (5), page link search (4), page shortcuts (4) — 47 tests total. |
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 142 | 1911 |
+| Unit/Integration (Vitest) | 143 | 1918 |
 | E2E (Playwright) | 82 | 406 |
-| **Total** | **224** | **2317** |
+| **Total** | **225** | **2324** |
 
 ### Test files by domain
 
@@ -51,7 +51,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **Feedback**: `feedback/route.test.ts` (22 tests), `feedback-form-design-spec.test.ts` (5 tests), `use-screenshot.test.ts` (2 tests), `e2e/feedback.spec.ts` (6 tests)
 - **API**: `health/route.test.ts` (9 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (9 tests), `cron/purge-trash/route.test.ts` (10 tests), `feedback/route.test.ts` (22 tests), `pages/[pageId]/versions/route.test.ts` (17 tests), `pages/[pageId]/versions/route.rate-limit.test.ts` (3 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (14 tests), `pages/[pageId]/versions/[versionId]/route.rate-limit.test.ts` (3 tests), `e2e/account-deletion.spec.ts` (4 tests), `e2e/account-settings.spec.ts` (5 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `design-spec-compliance.test.ts` (9 tests), `relative-time.test.ts` (7 tests), `reduced-motion.test.ts` (6 tests), `e2e/visual-regression.spec.ts` (1 test)
-- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (171 tests), `retry.test.ts` (9 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (9 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
+- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (171 tests), `api-route-consistency.test.ts` (6 tests), `retry.test.ts` (9 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (9 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests)
 - **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests), `supabase/proxy.test.ts` (2 tests)
 
 ## Known Gaps
@@ -157,5 +157,6 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-14 | Filter HeadlessChrome submissions from feedback API (#1097). Updated `feedback/route.test.ts` (20→22): 2 tests for HeadlessChrome UA filter (silent discard without insert, normal UA inserts normally). Test totals: 142 Vitest files (1911 tests), 81 E2E specs (398 tests). |
 | 2026-05-15 | Add E2E tests for database person property type (#1101). Added 1 new E2E spec: `e2e/database-person.spec.ts` (5 tests): open picker and select member, search filters members by name, clear value by deselecting, person value on row detail page, editor closes on Escape. Test totals: 142 Vitest files (1911 tests), 82 E2E specs (403 tests). |
 | 2026-05-15 | Extend axe-core accessibility audit to account and password reset pages (#1110). Added 3 tests to `e2e/accessibility.spec.ts` (10→13): forgot-password, reset-password, account settings. Test totals: 142 Vitest files (1911 tests), 82 E2E specs (406 tests). |
+| 2026-05-16 | API route error-handling consistency tests (#1118). Added 1 new Vitest file: `api-route-consistency.test.ts` (6 tests) — structural convention tests verifying API routes with Supabase mutations import error classification utilities (captureSupabaseError, captureApiError, isForeignKeyViolationError) and use Sentry capture in catch blocks instead of bare console.error. Test totals: 143 Vitest files (1918 tests), 82 E2E specs (406 tests). |
 
 

--- a/src/lib/sentry/api-route-consistency.test.ts
+++ b/src/lib/sentry/api-route-consistency.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join, relative } from "path";
+
+/**
+ * Structural convention tests for API route error handling (Issue #1118).
+ *
+ * Validates that API routes performing Supabase mutations use the standard
+ * error classification utilities (captureSupabaseError, captureApiError,
+ * isForeignKeyViolationError) instead of bare console.error or unclassified
+ * catch blocks. This prevents the "forgot to add the check in the new
+ * endpoint" pattern that caused repeated Sentry noise bugs.
+ */
+
+const API_DIR = join(__dirname, "..", "..", "app", "api");
+const PROJECT_ROOT = join(__dirname, "..", "..", "..");
+
+/**
+ * Routes that intentionally skip certain checks.
+ * Each entry must have a comment explaining why.
+ */
+const ALLOWLIST: Record<string, string> = {
+  // Health endpoint uses raw fetch (no Supabase client), no mutations,
+  // and is monitored externally — intentionally silent on errors.
+  "src/app/api/health/route.ts": "raw fetch health check, no Supabase client",
+};
+
+/** Mutation method patterns — calls that write data. */
+const MUTATION_PATTERN = /\.(?:insert|update|delete|upsert)\s*\(/;
+
+/** Supabase .from() call pattern — indicates Supabase table access. */
+const FROM_CALL_PATTERN = /\.from\s*\(/;
+
+/** Supabase .rpc() call pattern — indicates Supabase RPC access. */
+const RPC_CALL_PATTERN = /\.rpc\s*\(/;
+
+/** Sentry capture function patterns. */
+const CAPTURE_SUPABASE_ERROR = "captureSupabaseError";
+const CAPTURE_API_ERROR = "captureApiError";
+const IS_FK_VIOLATION = "isForeignKeyViolationError";
+
+/** Bare console.error pattern. */
+const CONSOLE_ERROR_PATTERN = /\bconsole\.error\b/;
+
+/** Catch block pattern — matches `catch (identifier)` or `catch (identifier: type)`. */
+const CATCH_BLOCK_PATTERN = /\bcatch\s*\(\s*\w+/g;
+
+function collectRouteFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  function walk(d: string) {
+    for (const entry of readdirSync(d)) {
+      const full = join(d, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        walk(full);
+      } else if (entry === "route.ts") {
+        files.push(full);
+      }
+    }
+  }
+
+  walk(dir);
+  return files;
+}
+
+function toRelative(absPath: string): string {
+  return relative(PROJECT_ROOT, absPath);
+}
+
+describe("API route error-handling consistency", () => {
+  const routeFiles = collectRouteFiles(API_DIR);
+
+  it("finds at least one API route file", () => {
+    expect(routeFiles.length).toBeGreaterThan(0);
+  });
+
+  it("routes with mutations import captureSupabaseError or captureApiError", () => {
+    const violations: string[] = [];
+
+    for (const file of routeFiles) {
+      const rel = toRelative(file);
+      if (ALLOWLIST[rel]) continue;
+
+      const content = readFileSync(file, "utf-8");
+
+      // Skip routes that don't use Supabase at all
+      const usesSupabase =
+        FROM_CALL_PATTERN.test(content) || RPC_CALL_PATTERN.test(content);
+      if (!usesSupabase) continue;
+
+      const hasMutations =
+        MUTATION_PATTERN.test(content) || RPC_CALL_PATTERN.test(content);
+      if (!hasMutations) continue;
+
+      const hasCaptureSupabase = content.includes(CAPTURE_SUPABASE_ERROR);
+      const hasCaptureApi = content.includes(CAPTURE_API_ERROR);
+
+      if (!hasCaptureSupabase && !hasCaptureApi) {
+        violations.push(
+          `${rel}: performs mutations but does not import ${CAPTURE_SUPABASE_ERROR} or ${CAPTURE_API_ERROR}`,
+        );
+      }
+    }
+
+    expect(
+      violations,
+      `API routes with Supabase mutations must import error capture utilities:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("routes with mutations that use .insert/.update/.delete import isForeignKeyViolationError or captureSupabaseError", () => {
+    const violations: string[] = [];
+
+    for (const file of routeFiles) {
+      const rel = toRelative(file);
+      if (ALLOWLIST[rel]) continue;
+
+      const content = readFileSync(file, "utf-8");
+
+      // Only check routes that perform table mutations (not RPC-only routes)
+      const hasTableMutations = MUTATION_PATTERN.test(content);
+      if (!hasTableMutations) continue;
+
+      // captureSupabaseError already classifies FK violations internally
+      // (downgrades to warning level), so either explicit isForeignKeyViolationError
+      // checks or captureSupabaseError usage satisfies this requirement.
+      const hasFkCheck = content.includes(IS_FK_VIOLATION);
+      const hasCaptureSupabase = content.includes(CAPTURE_SUPABASE_ERROR);
+
+      if (!hasFkCheck && !hasCaptureSupabase) {
+        violations.push(
+          `${rel}: performs table mutations but does not import ${IS_FK_VIOLATION} or ${CAPTURE_SUPABASE_ERROR}`,
+        );
+      }
+    }
+
+    expect(
+      violations,
+      `API routes with table mutations must handle FK violations (via ${IS_FK_VIOLATION} or ${CAPTURE_SUPABASE_ERROR}):\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("catch blocks use captureApiError or captureSupabaseError, not bare console.error", () => {
+    const violations: string[] = [];
+
+    for (const file of routeFiles) {
+      const rel = toRelative(file);
+      if (ALLOWLIST[rel]) continue;
+
+      const content = readFileSync(file, "utf-8");
+      const lines = content.split("\n");
+
+      // Skip routes without catch blocks
+      CATCH_BLOCK_PATTERN.lastIndex = 0;
+      if (!CATCH_BLOCK_PATTERN.test(content)) continue;
+
+      const hasCaptureSupabase = content.includes(CAPTURE_SUPABASE_ERROR);
+      const hasCaptureApi = content.includes(CAPTURE_API_ERROR);
+
+      // If the route has catch blocks but no Sentry capture at all, flag it
+      if (!hasCaptureSupabase && !hasCaptureApi) {
+        violations.push(
+          `${rel}: has catch blocks but does not use ${CAPTURE_API_ERROR} or ${CAPTURE_SUPABASE_ERROR}`,
+        );
+        continue;
+      }
+
+      // Check for bare console.error without accompanying Sentry capture
+      for (let i = 0; i < lines.length; i++) {
+        if (CONSOLE_ERROR_PATTERN.test(lines[i])) {
+          violations.push(
+            `${rel}:${i + 1}: uses console.error — use ${CAPTURE_API_ERROR} or ${CAPTURE_SUPABASE_ERROR} instead`,
+          );
+        }
+      }
+    }
+
+    expect(
+      violations,
+      `API route catch blocks must use Sentry capture utilities, not bare console.error:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("routes with Supabase access have at least one catch block with error capture", () => {
+    const violations: string[] = [];
+
+    for (const file of routeFiles) {
+      const rel = toRelative(file);
+      if (ALLOWLIST[rel]) continue;
+
+      const content = readFileSync(file, "utf-8");
+
+      const usesSupabase =
+        FROM_CALL_PATTERN.test(content) || RPC_CALL_PATTERN.test(content);
+      if (!usesSupabase) continue;
+
+      // Route uses Supabase — it should have error handling
+      CATCH_BLOCK_PATTERN.lastIndex = 0;
+      const hasCatchBlock = CATCH_BLOCK_PATTERN.test(content);
+      const hasCaptureSupabase = content.includes(CAPTURE_SUPABASE_ERROR);
+      const hasCaptureApi = content.includes(CAPTURE_API_ERROR);
+
+      if (!hasCatchBlock || (!hasCaptureSupabase && !hasCaptureApi)) {
+        violations.push(
+          `${rel}: uses Supabase but lacks a catch block with ${CAPTURE_API_ERROR}/${CAPTURE_SUPABASE_ERROR}`,
+        );
+      }
+    }
+
+    expect(
+      violations,
+      `API routes using Supabase must have catch blocks with Sentry error capture:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  it("allowlist entries reference existing route files", () => {
+    const staleEntries: string[] = [];
+
+    for (const rel of Object.keys(ALLOWLIST)) {
+      const absPath = join(PROJECT_ROOT, rel);
+      try {
+        statSync(absPath);
+      } catch {
+        staleEntries.push(`${rel}: ${ALLOWLIST[rel]}`);
+      }
+    }
+
+    expect(
+      staleEntries,
+      `Allowlist contains entries for files that no longer exist — remove them:\n${staleEntries.join("\n")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1118

## What

Adds structural convention tests that scan all API route files and verify each route handler that performs Supabase mutations also uses the standard error classification utilities. This catches the "forgot to add the check in the new endpoint" pattern that caused repeated Sentry noise bugs (#1004, #1013, #1083, #1084, #1114).

## How

New test file `src/lib/sentry/api-route-consistency.test.ts` with 6 tests:

1. **Finds API route files** — sanity check that the scanner discovers routes
2. **Mutation routes import capture utilities** — routes with `.insert()/.update()/.delete()/.upsert()` or `.rpc()` must import `captureSupabaseError` or `captureApiError`
3. **Table mutation routes handle FK violations** — routes with `.insert()/.update()/.delete()` must import `isForeignKeyViolationError` or `captureSupabaseError` (which classifies FK violations internally)
4. **Catch blocks use Sentry capture** — no bare `console.error` in catch blocks; must use `captureApiError` or `captureSupabaseError`
5. **Supabase routes have error capture** — routes using `.from()` or `.rpc()` must have catch blocks with Sentry capture
6. **Allowlist hygiene** — allowlist entries must reference existing files (prevents stale entries)

Allowlist mechanism included for routes that intentionally skip checks (currently only `health/route.ts` which uses raw fetch without the Supabase client).

Follows the same file-scanning pattern as the existing `sentry.test.ts` bare-catch scanner.

## Testing

- `pnpm lint` — no new warnings
- `pnpm typecheck` — passes
- `pnpm test` — 143 files, 1918 tests all passing
- All 6 new tests pass against the current codebase (all existing routes are compliant)