### PR TITLE
chore: daily metrics snapshot 2026-05-18

### DIFF
--- a/metrics/daily/2026-05-18.json
+++ b/metrics/daily/2026-05-18.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-05-18",
+  "day_number": 36,
+  "loc": {
+    "total": 76530,
+    "delta": 725,
+    "by_language": {
+      "TypeScript": 74705,
+      "SQL": 1544,
+      "CSS": 281
+    }
+  },
+  "files": {
+    "total": 254,
+    "delta": 0
+  },
+  "prs": {
+    "total": 653,
+    "delta": 7,
+    "currently_open": 0
+  },
+  "commits": {
+    "total": 676,
+    "delta": 7
+  },
+  "issues": {
+    "backlog": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 447,
+    "opened_today": 0,
+    "closed_today": 0
+  },
+  "tests": {
+    "unit": 1953,
+    "e2e": 405
+  },
+  "ci": {
+    "runs_total": 4,
+    "runs_passed": 4,
+    "pass_rate_pct": 100.0
+  },
+  "test_coverage_pct": 38.42,
+  "autonomous_pct": 88,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
## Daily Metrics — 2026-05-18 (Day 36)

| Metric | Value | Delta |
|---|---|---|
| Lines of code | 76,530 | +725 |
| Files | 254 | 0 |
| PRs merged (cumulative) | 653 | +7 |
| PRs open | 0 | — |
| Commits | 676 | +7 |
| Unit tests | 1,953 | +35 |
| E2E tests | 405 | +1 |
| Test coverage | 38.42% | +1.27pp |
| CI pass rate | 100% (4/4) | — |
| Autonomous % | 88% | — |

### Issues
| Status | Count |
|---|---|
| Backlog | 0 |
| In progress | 0 |
| In review | 0 |
| Done | 447 |
| Opened today | 0 |
| Closed today | 0 |
