### PR TITLE
fix(automations): pin supabase CLI to v2.98.2

### DIFF
--- a/.github/workflows/deploy-migrations.yml
+++ b/.github/workflows/deploy-migrations.yml
@@ -43,10 +43,12 @@ jobs:
         if: steps.check-secrets.outputs.skip == 'false'
 
       # supabase/setup-cli@v1 still targets node20; keep FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 until they ship a node24 version
+      # Pinned to 2.98.2: v2.99.0 changed asset naming (added version in filename),
+      # breaking setup-cli@v1's download URL construction for `latest`.
       - uses: supabase/setup-cli@v1
         if: steps.check-secrets.outputs.skip == 'false'
         with:
-          version: latest
+          version: 2.98.2
 
       - name: Link staging project
         if: steps.check-secrets.outputs.skip == 'false'
@@ -76,9 +78,10 @@ jobs:
       - uses: actions/checkout@v6
 
       # supabase/setup-cli@v1 still targets node20; keep FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 until they ship a node24 version
+      # Pinned to 2.98.2: v2.99.0 changed asset naming, breaking setup-cli@v1.
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.98.2
 
       - name: Link Supabase project
         run: supabase link --project-ref $SUPABASE_PROJECT_ID


### PR DESCRIPTION
## What

Supabase CLI v2.99.0 (released today) changed release asset naming to include the version number in the filename (`supabase_2.99.0_linux_amd64.tar.gz` instead of `supabase_linux_amd64.tar.gz`). This breaks `supabase/setup-cli@v1`'s download URL construction when using `version: latest`, causing a 404 on all PR staging checks.

All open PRs (#1139, #1140) are blocked by this failure.

## Fix

Pin both the staging and deploy jobs to `version: 2.98.2` until `setup-cli` is updated to handle the new naming convention.

## Verification

- `https://github.com/supabase/cli/releases/download/v2.98.2/supabase_linux_amd64.tar.gz` → 302 ✅
- `https://github.com/supabase/cli/releases/download/v2.99.0/supabase_linux_amd64.tar.gz` → 404 ❌