### PR TITLE
feat(a11y): add aria-live region to editor save status indicator (#1138)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 144 | 1953 |
+| Unit/Integration (Vitest) | 144 | 1962 |
 | E2E (Playwright) | 85 | 415 |
-| **Total** | **229** | **2368** |
+| **Total** | **229** | **2377** |
 
 ### Test files by domain
 
@@ -163,5 +163,6 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-18 | Mobile header page title (#1136). Added `mobile-header-title.tsx` component and 1 new E2E spec: `e2e/mobile-header-title.spec.ts` (5 tests) — workspace name on home, title update on navigation, Settings on settings page, hidden on desktop, truncation styles. Added Storybook stories for MobileHeaderTitle (5 stories) and MobileLongTitle story in AppShell. Test totals: 144 Vitest files (1953 tests), 84 E2E specs (412 tests). |
 | 2026-05-18 | Fixed 11 E2E test failures (#1142). Fixed account-deletion tests (hydration timing with retry pattern), database-bulk-select tests (optimistic row ID race condition, aria-checked assertions), database-column-reorder tests (checkbox column offset in getColumnOrder), database-csv-export tests (gridcell count mismatch from checkbox column). Added `data-row-id` attribute to table rows for temp-ID detection. Fixed DeleteAccountSection component to avoid AlertDialogTrigger + controlled open pattern. Updated visual regression baselines. Test totals unchanged: 144 Vitest files (1953 tests), 84 E2E specs (412 tests). |
 | 2026-05-18 | Title Enter/Tab focuses editor (#1137). Added `onAdvance` callback to `PageTitle`, wired in `PageViewClient` to focus Lexical editor on Enter/Tab. Added 1 new E2E spec: `e2e/title-advance.spec.ts` (3 tests). Added `WithAdvance` Storybook story and visual regression baseline. Test totals: 144 Vitest files (1953 tests), 85 E2E specs (415 tests). |
+| 2026-05-18 | Add aria-live region to editor save status indicator (#1138). Added sr-only `role="status"` span to editor save status div so screen readers announce terminal states (Saved, Save failed) without noisy Saving... announcements. No new test files. Test totals: 144 Vitest files (1962 tests), 85 E2E specs (415 tests). |
 
 

--- a/src/components/editor/editor.tsx
+++ b/src/components/editor/editor.tsx
@@ -438,12 +438,19 @@ export function Editor({ pageId, workspaceId, initialContent, editorRef, readOnl
         {editorRef && <EditorRefPlugin editorRef={editorRef} />}
       </LexicalComposer>
       {!readOnly && (
-        <div className="mt-2 h-5 text-xs text-muted-foreground" data-testid="editor-save-status">
+        <div
+          className="mt-2 h-5 text-xs text-muted-foreground"
+          data-testid="editor-save-status"
+        >
           {saveStatus === "saving" && "Saving..."}
           {saveStatus === "saved" && "Saved"}
           {saveStatus === "error" && (
             <span className="text-destructive">Save failed</span>
           )}
+          <span className="sr-only" role="status" data-testid="editor-save-status-live">
+            {saveStatus === "saved" && "Saved"}
+            {saveStatus === "error" && "Save failed"}
+          </span>
         </div>
       )}
       {readOnly && (


### PR DESCRIPTION
Closes #1138

## What

Adds a screen-reader-only `role="status"` live region to the editor save status indicator so screen readers announce save outcomes.

## How

- Added a `sr-only` `<span role="status">` inside the existing save status container div.
- Only terminal states ("Saved" and "Save failed") are rendered in the live region. The transient "Saving..." state is excluded to avoid noisy announcements on every keystroke.
- The visual indicator remains unchanged — sighted users still see "Saving...", "Saved", and "Save failed" as before.
- Follows the existing `RowCountAnnouncer` pattern (`src/components/database/views/row-count-announcer.tsx`) for live regions.

## Acceptance Criteria Verification

- ✅ Save status container includes `role="status"` (implies `aria-live="polite"`) for screen reader announcements
- ✅ "Save failed" errors are announced to screen readers
- ✅ "Saved" confirmations are announced politely
- ✅ "Saving..." transitions do not create excessive announcements (excluded from live region)
- ✅ Accessibility E2E test (`e2e/accessibility.spec.ts` — page editor) passes with no new axe violations
- ✅ `pnpm lint && pnpm typecheck && pnpm test` pass (0 errors, 144 files, 1962 tests)

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — clean
- `pnpm test` — 144 files, 1962 tests passed
- `e2e/accessibility.spec.ts` — page editor accessibility test passed (axe-core found no violations)
- No new E2E tests needed — this is a non-interactive accessibility attribute change