### PR TITLE
chore: weekly recap 2026-W22

### DIFF
--- a/metrics/weekly/2026-W22.md
+++ b/metrics/weekly/2026-W22.md
@@ -1,0 +1,61 @@
+# Week 22 Recap — May 18–24, 2026
+
+Sixth week. A quieter week focused on polish and reliability. The agents shipped sidebar inline rename, undo on page delete, slash command export/import, and several accessibility improvements — then spent most of the week idle with an empty backlog, waiting on human decisions for the remaining open issues.
+
+## Highlights
+
+- **Sidebar pages can be renamed inline.** Right-click → Rename converts the title to an editable input. No navigation required. PR #1167.
+- **Deleting a page now offers Undo.** The trash toast includes an Undo button that restores the page and navigates back to it. PR #1166.
+- **Export and Import are discoverable via slash commands.** Typing `/export` or `/import` in the editor now surfaces those actions directly. PR #1168.
+- **ThemeProvider no longer crashes in restricted browsers.** A Sentry-detected SecurityError on localStorage access was fixed within 24 hours of detection. PR #1178.
+
+## By the Numbers
+
+| Metric | This Week | Cumulative | Delta |
+|---|---|---|---|
+| Lines of code | +1,619 | 77,424 | +2.1% |
+| PRs merged | 42 | 688 | |
+| Test coverage | 38.44% | | +1.29pp |
+| Tests (unit + E2E) | +89 | 2,411 | +3.8% |
+| Issues completed | 12 | 457 done, 5 remaining | |
+| CI pass rate | 88.9% | | (16/18 runs) |
+| Human time | not yet recorded | not yet recorded | |
+| Agent time | not yet recorded | not yet recorded | |
+
+## Features Shipped
+
+### Editor & Pages (Days 36–39)
+- **Mobile header shows page title** — the mobile top bar now displays the current page name. PR #1140.
+- **Enter in title focuses editor body** — pressing Enter or Tab in the page title moves focus to the editor content. PR #1146.
+- **Slash command export/import** — `/export` and `/import` options in the editor's typeahead menu. PR #1168.
+- **Undo page delete** — toast notification includes an Undo button that restores the page via `restore_page` RPC. PR #1166.
+
+### Sidebar (Day 37–39)
+- **Keyboard navigation in page tree** — Arrow keys, Home, End, and Enter navigate and select pages in the sidebar. PR #1151.
+- **Inline rename from context menu** — Rename action in the right-click menu opens an inline text input. PR #1167.
+
+### Accessibility (Day 36)
+- **aria-live on save status** — screen readers announce save state changes in the editor. PR #1148.
+
+### Bug Fixes (Days 36–42)
+- **11 E2E test failures resolved** — account-deletion, database-bulk-select, column-reorder, and csv-export specs fixed. PR #1143.
+- **TransformStream Sentry noise filtered** — `on_request_error` events and TransformStream errors no longer reach Sentry. PR #1145.
+- **Supabase CLI pinned to v2.98.2** — prevents breaking changes from unpinned CLI updates. PR #1141.
+- **ThemeProvider localStorage guard** — try-catch around localStorage calls prevents crashes in restricted browser contexts. PR #1178.
+
+### Maintenance (Days 36–42)
+- **7 daily metrics snapshots** — PRs #1134, #1153, #1158, #1162, #1171, #1174, #1180.
+- **17 social posts** — build-in-public tweets across morning, afternoon, and evening slots.
+- **Weekly automation audit** — all 17 automations at 100% success rate. PR #1183.
+- **Performance report W21** — PR #1139.
+
+## What's Next
+
+- **Command palette (⌘+P)** — quick page switching by title. Issue #1107 (awaiting human approval).
+- **Bundle size reduction** — pages exceed the 200 kB budget after the Lexical upgrade. Issue #1121 (awaiting human approval).
+- **DB latency investigation** — health endpoint latency above 500ms for three consecutive weeks now. Issue #1123 (awaiting human approval).
+
+## Challenges & Learnings
+
+- **The backlog was empty for 5 of 7 days.** All feature work (7 PRs) landed on Days 36–39. From Day 40 onward, the agents had nothing to build — every remaining issue is blocked on `needs-human`. The automation system works as designed, but the bottleneck has shifted from code to product decisions.
+- **CI pass rate dropped to 88.9% from 93.2% last week.** May 22 had a 50% pass rate (1 failure out of 2 runs). The failures were transient and resolved without code changes, but the small sample size (18 total runs, down from 74 last week) makes the percentage volatile. Fewer PRs means fewer CI runs, which amplifies noise.


### PR DESCRIPTION
Weekly recap for Week 22 (May 18–24, 2026).

## Summary

- 42 PRs merged (7 feat, 4 fix, 31 chore)
- 12 issues completed, 5 remaining (all `needs-human`)
- +1,619 lines of code, +89 tests
- Test coverage: 38.44% (+1.29pp)

## Features shipped

- Sidebar inline rename (PR #1167)
- Undo on page delete (PR #1166)
- Slash command export/import (PR #1168)
- Keyboard navigation in sidebar page tree (PR #1151)
- Mobile header page title (PR #1140)
- Enter-in-title focuses editor (PR #1146)
- aria-live on save status (PR #1148)

## Bug fixes

- ThemeProvider localStorage SecurityError guard (PR #1178)
- 11 E2E test failures resolved (PR #1143)
- TransformStream Sentry noise filtered (PR #1145)
- Supabase CLI pinned (PR #1141)