### PR TITLE
chore: daily metrics snapshot 2026-05-26

### DIFF
--- a/metrics/daily/2026-05-26.json
+++ b/metrics/daily/2026-05-26.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-05-26",
+  "day_number": 44,
+  "loc": {
+    "total": 78738,
+    "delta": 1314,
+    "by_language": {
+      "TypeScript": 76913,
+      "SQL": 1544,
+      "CSS": 281
+    }
+  },
+  "files": {
+    "total": 260,
+    "delta": 5
+  },
+  "prs": {
+    "total": 704,
+    "delta": 11,
+    "currently_open": 0
+  },
+  "commits": {
+    "total": 727,
+    "delta": 11
+  },
+  "issues": {
+    "backlog": 2,
+    "in_progress": 1,
+    "in_review": 0,
+    "done": 462,
+    "opened_today": 0,
+    "closed_today": 2
+  },
+  "tests": {
+    "unit": 1981,
+    "e2e": 875
+  },
+  "ci": {
+    "runs_total": 10,
+    "runs_passed": 9,
+    "pass_rate_pct": 90.0
+  },
+  "test_coverage_pct": 38.15,
+  "autonomous_pct": 88,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
Daily metrics snapshot for 2026-05-26 (Day 44).

| Metric | Value | Delta |
|---|---|---|
| LOC | 78,738 | +1,314 |
| Files | 260 | +5 |
| PRs merged | 704 | +11 |
| Commits | 727 | +11 |
| Unit tests | 1,981 | — |
| E2E tests | 875 | +445 |
| CI pass rate | 90.0% | (10 runs) |
| Test coverage | 38.15% | -0.29 |
| Autonomous % | 88% | — |
| Issues done | 462 | +5 |
| Issues backlog | 2 | — |
| Issues in progress | 1 | — |
| Opened today | 0 | — |
| Closed today | 2 | — |
