### PR TITLE
chore: daily metrics snapshot 2026-05-27

### DIFF
--- a/metrics/daily/2026-05-27.json
+++ b/metrics/daily/2026-05-27.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-05-27",
+  "day_number": 45,
+  "loc": {
+    "total": 79833,
+    "delta": 1095,
+    "by_language": {
+      "TypeScript": 78008,
+      "SQL": 1544,
+      "CSS": 281
+    }
+  },
+  "files": {
+    "total": 264,
+    "delta": 4
+  },
+  "prs": {
+    "total": 714,
+    "delta": 10,
+    "currently_open": 0
+  },
+  "commits": {
+    "total": 737,
+    "delta": 10
+  },
+  "issues": {
+    "backlog": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 468,
+    "opened_today": 0,
+    "closed_today": 2
+  },
+  "tests": {
+    "unit": 2000,
+    "e2e": 903
+  },
+  "ci": {
+    "runs_total": 10,
+    "runs_passed": 9,
+    "pass_rate_pct": 90.0
+  },
+  "test_coverage_pct": 38.05,
+  "autonomous_pct": 88,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
Daily metrics snapshot for 2026-05-27 (Day 45).

| Metric | Value | Delta |
|---|---|---|
| LOC | 79,833 | +1,095 |
| Files | 264 | +4 |
| PRs merged | 714 | +10 |
| Commits | 737 | +10 |
| Unit tests | 2,000 | +19 |
| E2E tests | 903 | +28 |
| CI pass rate | 90.0% | — |
| Test coverage | 38.05% | -0.10 |
| Autonomous % | 88% | — |
| Issues done | 468 | +6 |
| Issues opened today | 0 | — |
| Issues closed today | 2 | — |
| Backlog | 0 | — |
