### PR TITLE
chore: daily metrics snapshot 2026-05-28

### DIFF
--- a/metrics/daily/2026-05-28.json
+++ b/metrics/daily/2026-05-28.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-05-28",
+  "day_number": 46,
+  "loc": {
+    "total": 81795,
+    "delta": 4454,
+    "by_language": {
+      "TypeScript": 79970,
+      "SQL": 1544,
+      "CSS": 281
+    }
+  },
+  "files": {
+    "total": 270,
+    "delta": 15
+  },
+  "prs": {
+    "total": 720,
+    "delta": 40,
+    "currently_open": 1
+  },
+  "commits": {
+    "total": 743,
+    "delta": 40
+  },
+  "issues": {
+    "backlog": 3,
+    "in_progress": 0,
+    "in_review": 1,
+    "done": 470,
+    "opened_today": 7,
+    "closed_today": 2
+  },
+  "tests": {
+    "unit": 2039,
+    "e2e": 913
+  },
+  "ci": {
+    "runs_total": 12,
+    "runs_passed": 10,
+    "pass_rate_pct": 83.3
+  },
+  "test_coverage_pct": 38.19,
+  "autonomous_pct": 88,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
Daily metrics snapshot for 2026-05-28 (Day 46).

| Metric | Value | Delta |
|---|---|---|
| Lines of code | 81,795 | +4,454 |
| Files | 270 | +15 |
| PRs merged (cumulative) | 720 | +40 |
| PRs open | 1 | — |
| Commits | 743 | +40 |
| Unit tests | 2,039 | — |
| E2E tests | 913 | — |
| CI pass rate | 83.3% (10/12) | — |
| Test coverage | 38.19% | — |
| Autonomous % | 88% | — |
| Issues backlog | 3 | — |
| Issues done | 470 | — |
| Opened today | 7 | — |
| Closed today | 2 | — |

Previous snapshot: 2026-05-22 (Day 40).