### PR TITLE
fix: retry pages query on statement timeout and add covering index (#1240)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 149 | 2041 |
+| Unit/Integration (Vitest) | 149 | 2049 |
 | E2E (Playwright) | 95 | 465 |
-| **Total** | **244** | **2506** |
+| **Total** | **244** | **2514** |
 
 ### Test files by domain
 
@@ -51,7 +51,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **Feedback**: `feedback/route.test.ts` (22 tests), `feedback-form-design-spec.test.ts` (5 tests), `use-screenshot.test.ts` (2 tests), `e2e/feedback.spec.ts` (6 tests)
 - **API**: `health/route.test.ts` (11 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (9 tests), `cron/purge-trash/route.test.ts` (10 tests), `feedback/route.test.ts` (22 tests), `pages/[pageId]/versions/route.test.ts` (17 tests), `pages/[pageId]/versions/route.rate-limit.test.ts` (3 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (14 tests), `pages/[pageId]/versions/[versionId]/route.rate-limit.test.ts` (3 tests), `e2e/account-deletion.spec.ts` (4 tests), `e2e/account-settings.spec.ts` (5 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `design-spec-compliance.test.ts` (10 tests), `relative-time.test.ts` (7 tests), `reduced-motion.test.ts` (6 tests), `e2e/visual-regression.spec.ts` (1 test)
-- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (171 tests), `api-route-consistency.test.ts` (6 tests), `retry.test.ts` (9 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (9 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests), `use-roving-tabindex.test.ts` (13 tests)
+- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (171 tests), `api-route-consistency.test.ts` (6 tests), `retry.test.ts` (16 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (9 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests), `use-roving-tabindex.test.ts` (13 tests)
 - **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests), `supabase/proxy.test.ts` (2 tests)
 
 ## Known Gaps
@@ -191,3 +191,4 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-05-28 | Add double-click auto-fit for database table column widths (#1223). Added `handleResizeAutoFit` callback to `useColumnResize` hook, `onDoubleClick` handler on resize handle in `TableColumnHeader`, `data-column-id` attributes on table cells and header content for DOM measurement. Added `MAX_COLUMN_WIDTH` (500px) constant. Added 2 new E2E tests to `database-column-resize.spec.ts` (4→6): auto-fit on double-click and minimum width constraint. Added 2 Storybook stories (AutoFitDefaultWidths, AutoFitVariedContent) and visual regression baselines. Test totals: 149 Vitest files (2041 tests), 95 E2E specs (464 tests). |
 | 2026-05-29 | Virtualize workspace home "All Pages" list (#1227). Added `useVirtualizer` to `workspace-home.tsx` for the "All Pages" list, matching the sidebar page-tree pattern. Added `onScrollToItem` callback to `useRovingTabindex` hook for virtualized keyboard navigation. Updated `.agents/conventions.md` with virtualization + roving tabindex integration pattern. No new test files. Test totals unchanged: 149 Vitest files (2041 tests), 95 E2E specs (464 tests). |
 | 2026-05-29 | Fix keyboard navigation End/wrap in virtualized All Pages list (#1238). Fixed `focusItem` in `use-roving-tabindex.ts` to retry DOM queries after virtualizer scroll (element may not be rendered yet). Added `data-item-ids` attribute to virtualized listbox for E2E test access to full item list. Updated `workspace-home-keyboard-nav.spec.ts` to use full item IDs instead of DOM-only snapshot for End/wrap/cross-section tests. Corrected E2E test count for this spec (9→10). Test totals: 149 Vitest files (2041 tests), 95 E2E specs (465 tests). |
+| 2026-05-29 | Fix statement timeout on pages query (#1240). Added `retryOnTransientError` to `retry.ts` (retries on both network errors and statement timeouts). Switched page-tree fetch to use it. Added partial index `pages_workspace_active_position` on `(workspace_id, position) WHERE deleted_at IS NULL`. Updated `retry.test.ts` (9→16): 7 new tests for `retryOnTransientError`. Test totals: 149 Vitest files (2049 tests), 95 E2E specs (465 tests). |

--- a/src/components/sidebar/page-tree.tsx
+++ b/src/components/sidebar/page-tree.tsx
@@ -10,7 +10,7 @@ import {
   captureSupabaseError,
   isSchemaNotFoundError,
 } from "@/lib/sentry";
-import { retryOnNetworkError } from "@/lib/retry";
+import { retryOnNetworkError, retryOnTransientError } from "@/lib/retry";
 import { useWorkspace } from "@/components/sidebar/workspace-context";
 import { usePersistedExpanded } from "@/lib/use-persisted-expanded";
 import { Button } from "@/components/ui/button";
@@ -71,7 +71,7 @@ export function PageTree({ userId }: PageTreeProps) {
     let cancelled = false;
 
     async function fetchPages() {
-      const { data, error } = await retryOnNetworkError(async () => {
+      const { data, error } = await retryOnTransientError(async () => {
         const supabase = await getClient();
         return supabase
           .from("pages")

--- a/src/lib/retry.test.ts
+++ b/src/lib/retry.test.ts
@@ -5,7 +5,7 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: vi.fn(),
 }));
 
-import { retryOnNetworkError } from "./retry";
+import { retryOnNetworkError, retryOnTransientError } from "./retry";
 
 function makePostgrestError(
   overrides: Partial<PostgrestError> = {},
@@ -193,3 +193,131 @@ describe("retryOnNetworkError", () => {
     expect(fn).toHaveBeenCalledOnce();
   });
 });
+
+function statementTimeoutError(): PostgrestError {
+  return makePostgrestError({
+    message: "canceling statement due to statement timeout",
+    code: "57014",
+  });
+}
+
+describe("retryOnTransientError", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("returns immediately on success (no retries)", async () => {
+    const fn = vi.fn().mockResolvedValue({ data: { id: "ws-1" }, error: null });
+
+    const result = await retryOnTransientError(fn, { baseDelayMs: 100 });
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect(result).toEqual({ data: { id: "ws-1" }, error: null });
+  });
+
+  it("returns immediately on non-transient error (no retries)", async () => {
+    const rlsError = makePostgrestError({
+      message: "new row violates row-level security policy",
+      code: "42501",
+    });
+    const fn = vi.fn().mockResolvedValue({ data: null, error: rlsError });
+
+    const result = await retryOnTransientError(fn, { baseDelayMs: 100 });
+
+    expect(fn).toHaveBeenCalledOnce();
+    expect((result.error as PostgrestError | null)?.code).toBe("42501");
+  });
+
+  it("retries on statement timeout error and succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({ data: null, error: statementTimeoutError() })
+      .mockResolvedValueOnce({ data: [{ id: "page-1" }], error: null });
+
+    const promise = retryOnTransientError(fn, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ data: [{ id: "page-1" }], error: null });
+  });
+
+  it("retries on statement timeout up to maxRetries and returns last error", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: statementTimeoutError() });
+
+    const promise = retryOnTransientError(fn, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.advanceTimersByTimeAsync(200);
+
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(result.error?.message).toBe(
+      "canceling statement due to statement timeout",
+    );
+  });
+
+  it("retries on network error (same as retryOnNetworkError)", async () => {
+    const fn = vi
+      .fn()
+      .mockResolvedValueOnce({ data: null, error: networkError() })
+      .mockResolvedValueOnce({ data: { id: "ws-1" }, error: null });
+
+    const promise = retryOnTransientError(fn, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ data: { id: "ws-1" }, error: null });
+  });
+
+  it("retries on thrown statement timeout error", async () => {
+    const timeoutErr = Object.assign(
+      new Error("canceling statement due to statement timeout"),
+      { code: "57014", details: "", hint: "" },
+    );
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(timeoutErr)
+      .mockResolvedValueOnce({ data: [{ id: "page-1" }], error: null });
+
+    const promise = retryOnTransientError(fn, {
+      maxRetries: 1,
+      baseDelayMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ data: [{ id: "page-1" }], error: null });
+  });
+
+  it("does not retry non-transient thrown errors", async () => {
+    const appError = new Error("Something unexpected");
+    const fn = vi.fn().mockRejectedValue(appError);
+
+    const promise = retryOnTransientError(fn, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+    });
+
+    await expect(promise).rejects.toThrow("Something unexpected");
+    expect(fn).toHaveBeenCalledOnce();
+  });
+});
+

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,4 +1,4 @@
-import { isTransientNetworkError } from "@/lib/sentry";
+import { isTransientNetworkError, isStatementTimeoutError } from "@/lib/sentry";
 
 interface RetryOptions {
   /** Maximum number of retry attempts (default: 2). */
@@ -75,4 +75,70 @@ export async function retryOnNetworkError<T extends SupabaseResult>(
   // This path is unreachable — the loop always returns or throws — but
   // TypeScript cannot prove it, so we satisfy the return type.
   throw new Error("retryOnNetworkError: unexpected state");
+}
+
+/**
+ * True when the error is a transient Supabase error that is safe to retry:
+ * network failures (offline, DNS, connection reset) or statement timeouts
+ * (cold connection, momentary database load spike).
+ */
+function isTransientSupabaseError(error: Error): boolean {
+  return isTransientNetworkError(error) || isStatementTimeoutError(error);
+}
+
+/**
+ * Retry a Supabase query when it fails with a transient error.
+ *
+ * Extends `retryOnNetworkError` to also retry on statement timeouts (PostgreSQL
+ * error code 57014). Statement timeouts are transient — they occur on cold
+ * connections or momentary load spikes and typically succeed on retry.
+ *
+ * Behavior is identical to `retryOnNetworkError` except for the broader error
+ * classification. See that function's JSDoc for full details.
+ */
+export async function retryOnTransientError<T extends SupabaseResult>(
+  fn: () => PromiseLike<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { maxRetries = 2, baseDelayMs = 500 } = options;
+
+  let lastThrownError: Error | null = null;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, baseDelayMs * 2 ** (attempt - 1)),
+      );
+    }
+
+    try {
+      const result = await fn();
+
+      // Result-level error: retry only transient errors
+      if (result.error && isTransientSupabaseError(result.error)) {
+        lastThrownError = null;
+        if (attempt < maxRetries) continue;
+      }
+
+      return result;
+    } catch (error) {
+      // Thrown error: retry only transient errors
+      if (error instanceof Error && isTransientSupabaseError(error)) {
+        lastThrownError = error;
+        if (attempt < maxRetries) continue;
+      }
+
+      // Non-transient thrown error — do not retry
+      throw error;
+    }
+  }
+
+  // All retries exhausted with a thrown transient error
+  if (lastThrownError) {
+    throw lastThrownError;
+  }
+
+  // This path is unreachable — the loop always returns or throws — but
+  // TypeScript cannot prove it, so we satisfy the return type.
+  throw new Error("retryOnTransientError: unexpected state");
 }

--- a/supabase/migrations/20260529060443_add_active_pages_position_index.sql
+++ b/supabase/migrations/20260529060443_add_active_pages_position_index.sql
@@ -1,0 +1,10 @@
+-- Optimise the sidebar pages query which filters on workspace_id,
+-- deleted_at IS NULL and orders by position.  The existing
+-- pages_workspace_parent index (workspace_id, parent_id, position) does not
+-- cover this access pattern because parent_id is not in the WHERE clause.
+-- The pages_workspace_deleted_at partial index only covers trashed rows
+-- (WHERE deleted_at IS NOT NULL).
+
+create index concurrently if not exists pages_workspace_active_position
+  on public.pages (workspace_id, position)
+  where deleted_at is null;


### PR DESCRIPTION
Closes #1240

## What

The sidebar pages query (`SELECT ... FROM pages WHERE workspace_id = ? AND deleted_at IS NULL ORDER BY position`) timed out with PostgreSQL error code 57014 on a cold Supabase connection. The existing `retryOnNetworkError` wrapper only retries network failures (fetch errors, DNS timeouts), not database-level statement timeouts, so the error surfaced to the user as a "Failed to load pages" toast with no automatic recovery.

## How

Two-part fix addressing both the query performance and the error recovery:

1. **Database index**: Added a partial composite index `pages_workspace_active_position` on `(workspace_id, position) WHERE deleted_at IS NULL`. The existing `pages_workspace_parent` index includes `parent_id` which isn't in the sidebar query's WHERE clause, so PostgreSQL couldn't use it efficiently. The new index directly covers the sidebar access pattern.

2. **Transient error retry**: Added `retryOnTransientError` to `retry.ts` — extends `retryOnNetworkError` to also retry on statement timeouts (code 57014). Switched the page-tree fetch to use it. Statement timeouts on cold connections are transient and typically succeed on retry.

## Testing

- 7 new unit tests in `retry.test.ts` covering `retryOnTransientError`: success path, non-transient passthrough, statement timeout retry + success, statement timeout retry exhaustion, network error retry (backward compat), thrown statement timeout retry, and non-transient throw passthrough.
- `pnpm lint && pnpm typecheck && pnpm test` all pass (149 files, 2049 tests).