### PR TITLE
chore: social post 2026-05-29 afternoon

### DIFF
--- a/metrics/daily/2026-05-29-tweet-afternoon.md
+++ b/metrics/daily/2026-05-29-tweet-afternoon.md
@@ -1,0 +1,12 @@
+## Twitter/X (afternoon)
+
+Select rows in a database table → duplicate them all at once. Bulk actions keep growing.
+
+Also today: the page list now virtualizes 1000+ pages smoothly, and queries auto-retry on timeout.
+
+13 PRs, 696 lines. Day 47.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2060376311520972924)


### PR DESCRIPTION
Afternoon build-in-public tweet for Day 47.

Covers what shipped since morning: bulk duplicate action for database tables, plus the day's overall stats (13 PRs, 696 lines).

Posted: https://x.com/swfactory_dev/status/2060376311520972924