### PR TITLE
fix: use destructive variant on keyboard delete confirmation button (#1264)

### DIFF
--- a/src/components/database/views/table-view.tsx
+++ b/src/components/database/views/table-view.tsx
@@ -648,6 +648,7 @@ export const TableView = memo(function TableView({
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
+              variant="destructive"
               data-testid="db-keyboard-delete-confirm"
               onClick={() => {
                 const ids = pendingDeleteIds.current;


### PR DESCRIPTION
Closes #1264

## What
The keyboard-triggered delete confirmation dialog (introduced in PR #1260) uses the default button variant for the "Delete" action instead of the `destructive` variant required by the design spec. This makes the delete button appear as a primary action rather than a destructive one, inconsistent with the bulk-action-bar delete dialog which correctly uses `variant="destructive"`.

## How
Added `variant="destructive"` to the `AlertDialogAction` component in the keyboard-triggered delete confirmation dialog in `table-view.tsx`, matching the existing pattern in `bulk-action-bar.tsx`.

## Testing
- Lint: ✅ passes (no new warnings)
- Typecheck: ✅ passes
- Vitest: ✅ 149 files, 2059 tests pass
- E2E: cannot run locally (missing env vars), but the only referencing E2E test (`database-table-shortcuts.spec.ts`) clicks the button by `data-testid` and does not assert on styling — unaffected by this change