### PR TITLE
fix: replace hardcoded hex color with design token in print stylesheet (#1276)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -339,7 +339,7 @@
   [data-testid="db-table-container"] [role="columnheader"],
   [data-testid="db-table-container"] [role="gridcell"],
   [data-testid="db-table-container"] [role="row"] > div {
-    border: 1px solid #d1d5db !important;
+    border: 1px solid hsl(var(--border)) !important;
   }
 
   /* Hide interactive-only database controls in print */


### PR DESCRIPTION
Closes #1276

## What

The `@media print` block in `globals.css` used a hardcoded hex color `#d1d5db` for database table borders, violating the design spec which prohibits arbitrary hex values and requires all colors to use design tokens.

## How

Replaced `border: 1px solid #d1d5db` with `border: 1px solid hsl(var(--border))` to use the `--border` CSS variable, consistent with the design spec's border convention.

## Testing

- This is a print-only style change — no screen rendering is affected.
- Vitest: 150 files, 2066 tests pass.
- Lint and typecheck pass with no new errors.
- No E2E tests reference print styles or the affected selectors.
- Storybook visual regression is unaffected (print styles are inert during screen rendering).