### PR TITLE
chore: weekly recap 2026-W23

### DIFF
--- a/metrics/weekly/2026-W23.md
+++ b/metrics/weekly/2026-W23.md
@@ -1,0 +1,94 @@
+# Week 23 Recap — May 25–31, 2026
+
+Seventh week. The busiest week yet — the agents shipped command palette, table of contents blocks, CSV import, print stylesheets, five database table enhancements, and virtualized both the sidebar and workspace home list. The previously empty backlog refilled with 30 new issues from automation-generated enhancements and bugs, and 35 issues were closed.
+
+## Highlights
+
+- **Command palette (⌘+K) shipped.** Users can now search and switch between pages instantly without touching the sidebar. PR #1197.
+- **Database tables gained five new column actions.** Number formatting, date formatting, quick sort, column duplication, and bulk row duplication — all from the column header menu. PRs #1253, #1259, #1265, #1269, #1246.
+- **Table of contents block via /toc.** Long documents now get a live-updating, clickable outline of all headings. PR #1278.
+- **Sidebar and workspace home are virtualized.** Large workspaces no longer lag — both lists render only visible items. PRs #1191, #1237.
+
+## By the Numbers
+
+| Metric | This Week | Cumulative | Delta |
+|---|---|---|---|
+| Lines of code | +6,799 | 84,223 | +8.8% |
+| PRs merged | 61 | 754 | |
+| Test coverage | 37.25% | | -1.19pp |
+| Tests (unit + E2E) | +629 | 3,040 | +26.1% |
+| Issues completed | 35 | 492 done, 5 open | |
+| CI pass rate | 91.7% | | (66/72 runs) |
+| Human time | not yet recorded | not yet recorded | |
+| Agent time | not yet recorded | not yet recorded | |
+
+## Features Shipped
+
+### Command Palette & Navigation (Day 44)
+- **Command palette (⌘+K)** — search pages by title and switch instantly. PR #1197.
+- **Keyboard shortcut tooltips** — sidebar action buttons now show their shortcuts on hover. PR #1192.
+- **Page count in workspace home** — the All Pages section header shows the total count. PR #1193.
+
+### Database Enhancements (Days 46–49)
+- **Number format picker** — choose between plain, currency, percent, and compact formats from the column header menu. PR #1253.
+- **Date format picker** — select date display format (relative, short, long, ISO) per column. PR #1259.
+- **Quick sort actions** — "Sort ascending" and "Sort descending" added to the column header dropdown. PR #1265.
+- **Duplicate property** — copy a column's type, config, and options without copying cell values. PR #1269.
+- **Bulk duplicate** — select multiple rows and duplicate them all at once from the bulk action bar. PR #1246.
+- **Structural keyboard shortcuts** — Tab/Shift+Tab to move between cells, Enter to edit, Escape to cancel, Delete to clear, ⌘+Backspace to delete rows with confirmation dialog. PR #1260.
+- **Cell text wrapping toggle** — toolbar button to toggle between truncated and wrapped cell content. PR #1232.
+- **Row height toggle** — switch between compact, default, and tall row heights. PR #1224.
+- **Card size and cover toggles** — gallery view toolbar gained card size (small/medium/large) and cover image property selection. PR #1228.
+- **Property visibility toggle** — show/hide columns from a toolbar dropdown. PR #1221.
+- **Column auto-fit** — double-click a column border to auto-size it to content width. PR #1236.
+- **aria-sort on column headers** — screen readers now announce sort state. PR #1271.
+
+### Editor (Day 49)
+- **Table of contents block** — `/toc` slash command inserts a live outline of H1/H2/H3 headings with click-to-scroll. PR #1278.
+
+### Workspace Home (Days 45–46)
+- **Context menu on page items** — right-click for Open, Rename, Duplicate, Move to Trash. PR #1210.
+- **Keyboard navigation** — arrow keys, Home, End, Enter to navigate and open pages. PR #1209.
+- **Virtualized All Pages list** — large page lists render only visible items via @tanstack/react-virtual. PR #1237.
+- **CSV import for databases** — import .csv files as new database rows from workspace home. PR #1218.
+
+### Sidebar (Day 44)
+- **Virtualized page tree** — sidebar renders only visible tree nodes for large workspaces. PR #1191.
+
+### Print (Days 48–49)
+- **Print stylesheet** — File → Print now produces a clean document with just the page content, no app chrome. PR #1275.
+- **Print E2E tests** — emulated print media tests verify sidebar hidden, content expanded, table borders visible. PR #1284.
+
+### Performance (Day 44)
+- **First-load JS reduced** — lazy-loaded markdown-utils cut shared bundle size. PR #1201.
+- **Health endpoint diagnostics** — concurrent sampling and latency breakdown for the DB health check. PR #1200.
+
+### Bug Fixes (Days 44–49)
+- **Hardcoded hex in print stylesheet** — replaced `#d1d5db` with design token `var(--border)`. PR #1277.
+- **Destructive variant on delete dialog** — keyboard-triggered delete confirmation now uses the correct red button. PR #1267.
+- **Missing aria-label on icon button** — RowHeightToggle gained an accessible label. PR #1230.
+- **Mobile touch targets** — enforced 44px minimum on wrap row heights. PR #1234.
+- **Statement timeout on pages query** — added retry logic and a covering index. PR #1241.
+- **Keyboard nav End key in virtualized list** — fixed wrap-around in the All Pages list. PR #1239.
+- **Workspace slug deduplication** — shared context eliminates redundant slug→ID lookups. PR #1205.
+
+### Test Infrastructure (Days 44–49)
+- **Firefox E2E project** — Playwright config now includes a Firefox project. PR #1196.
+- **Deterministic E2E waits** — replaced remaining `waitForTimeout` calls with condition-based waits. PR #1261.
+- **Design-spec compliance extended** — icon-button aria-label and destructive variant checks added. PR #1273. CSS file scanning added. PR #1283.
+- **Sentry classification edge-case tests** — 42 tests covering production error shapes from 9 prior bug reports. PR #1288.
+
+### Maintenance (Days 43–49)
+- **Sentry noise filter refactor** — consolidated ad-hoc filters into a declarative registry. PR #1204.
+- **7 daily metrics snapshots**, **17 social posts**, **1 automation audit**, **1 performance report**.
+
+## What's Next
+
+- **Sticky title column** — freeze the first column during horizontal scroll in wide database tables. Issue #1262 (awaiting human approval).
+- **Row grouping in table view** — collapsible sections grouped by a select/status property. Issue #1252 (awaiting human approval).
+- **Column calculation summary row** — sum, average, count at the bottom of each column. Issue #1245 (awaiting human approval).
+
+## Challenges & Learnings
+
+- **Test coverage dropped 1.19pp despite adding 629 tests.** The 6,799 new lines of production code (largest weekly delta so far) outpaced test additions. The E2E test count nearly doubled from 430 to 965, but Vitest line coverage only measures unit tests — E2E coverage isn't reflected in the percentage. The coverage metric is becoming less meaningful as the E2E suite grows.
+- **All 5 open issues are blocked on human approval.** The automation system correctly gates high-risk changes (OAuth enablement, sticky columns, row grouping, calculation rows, live visual regression) behind human review. The agents will idle again once the current backlog clears unless these are approved.


### PR DESCRIPTION
Weekly recap for Week 23 (May 25–31, 2026).

Covers 61 merged PRs, 35 issues completed, +6,799 lines of code, and +629 tests.

Key highlights:
- Command palette (⌘+K) shipped
- Five database column actions (number format, date format, quick sort, duplicate, bulk duplicate)
- Table of contents block via /toc slash command
- Sidebar and workspace home virtualized for large workspaces
- Print stylesheet for clean page printing