### PR TITLE
chore: daily metrics snapshot 2026-06-02

### DIFF
--- a/metrics/daily/2026-06-02.json
+++ b/metrics/daily/2026-06-02.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-06-02",
+  "day_number": 51,
+  "loc": {
+    "total": 84736,
+    "delta": 20,
+    "by_language": {
+      "TypeScript": 82841,
+      "SQL": 1547,
+      "CSS": 348
+    }
+  },
+  "files": {
+    "total": 272,
+    "delta": 0
+  },
+  "prs": {
+    "total": 769,
+    "delta": 7,
+    "currently_open": 0
+  },
+  "commits": {
+    "total": 792,
+    "delta": 7
+  },
+  "issues": {
+    "backlog": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 496,
+    "opened_today": 0,
+    "closed_today": 0
+  },
+  "tests": {
+    "unit": 2119,
+    "e2e": 969
+  },
+  "ci": {
+    "runs_total": 0,
+    "runs_passed": 0,
+    "pass_rate_pct": null
+  },
+  "test_coverage_pct": 37.28,
+  "autonomous_pct": 89,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
## Daily Metrics — 2026-06-02 (Day 51)

| Metric | Value | Delta |
|---|---|---|
| Lines of code | 84,736 | +20 |
| Files | 272 | 0 |
| PRs merged (cumulative) | 769 | +7 |
| PRs open | 0 | — |
| Commits | 792 | +7 |
| Unit tests | 2,119 | +2 |
| E2E tests | 969 | 0 |
| Test coverage | 37.28% | +0.03 |
| CI runs today | 0 | — |
| CI pass rate | n/a | — |
| Autonomous % | 89% | — |

### Issues

| Status | Count |
|---|---|
| Backlog | 0 |
| In Progress | 0 |
| In Review | 0 |
| Done | 496 |
| Opened today | 0 |
| Closed today | 0 |
