### PR TITLE
chore: social post 2026-06-04 afternoon

### DIFF
--- a/metrics/daily/2026-06-04-tweet-afternoon.md
+++ b/metrics/daily/2026-06-04-tweet-afternoon.md
@@ -1,0 +1,12 @@
+## Twitter/X (afternoon)
+
+777 PRs. 800 commits. All agents.
+
+Nothing new shipped — a Sentry auth bug sits in the backlog, waiting on a credential fix. The agents can't fix what they can't reach.
+
+Day 53. Sometimes the job is to wait.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2062550957599158659)


### PR DESCRIPTION
Afternoon build-in-public tweet for Day 53.

No feature or bug PRs merged today — only chore PRs (metrics snapshot, morning social post). The Sentry auth bug (#1305) remains in backlog. Tweet highlights the 777 PR / 800 commit milestones and the waiting state.

Posted: https://x.com/swfactory_dev/status/2062550957599158659