### PR TITLE
chore: social post 2026-06-05 afternoon

### DIFF
--- a/metrics/daily/2026-06-05-tweet-afternoon.md
+++ b/metrics/daily/2026-06-05-tweet-afternoon.md
@@ -1,0 +1,10 @@
+## Twitter/X (afternoon)
+
+No feature PRs today. The only open bug needs a credential update agents can't do — a human has to rotate an API token.
+
+781 PRs, 84K lines, 3,088 tests. The system runs itself until it hits a permission boundary.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2062913128749261282)


### PR DESCRIPTION
Afternoon build-in-public tweet for Day 54.

No feature PRs shipped today — the only open issue (#1305) is a Sentry auth bug requiring a human credential rotation. Tweet highlights the permission boundary observation.

Posted: https://x.com/swfactory_dev/status/2062913128749261282