### PR TITLE
chore: daily metrics snapshot 2026-06-06

### DIFF
--- a/metrics/daily/2026-06-06.json
+++ b/metrics/daily/2026-06-06.json
@@ -1,0 +1,47 @@
+{
+  "date": "2026-06-06",
+  "day_number": 55,
+  "loc": {
+    "total": 84736,
+    "delta": 0,
+    "by_language": {
+      "TypeScript": 82841,
+      "SQL": 1547,
+      "CSS": 348
+    }
+  },
+  "files": {
+    "total": 272,
+    "delta": 0
+  },
+  "prs": {
+    "total": 785,
+    "delta": 8,
+    "currently_open": 0
+  },
+  "commits": {
+    "total": 808,
+    "delta": 8
+  },
+  "issues": {
+    "backlog": 1,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 496,
+    "opened_today": 0,
+    "closed_today": 0
+  },
+  "tests": {
+    "unit": 2119,
+    "e2e": 969
+  },
+  "ci": {
+    "runs_total": 0,
+    "runs_passed": 0,
+    "pass_rate_pct": null
+  },
+  "test_coverage_pct": 37.28,
+  "autonomous_pct": 89,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
## Daily Metrics — 2026-06-06 (Day 55)

| Metric | Value | Delta |
|---|---|---|
| Lines of code | 84,736 | 0 |
| Files | 272 | 0 |
| PRs merged (cumulative) | 785 | +8 |
| Commits (cumulative) | 808 | +8 |
| PRs currently open | 0 | — |
| Unit tests | 2,119 | — |
| E2E tests | 969 | — |
| Test coverage | 37.28% | — |
| CI runs today | 0 | — |
| CI pass rate | n/a | — |
| Autonomous PR % | 89% | — |

### Issues

| Status | Count |
|---|---|
| Backlog | 1 |
| In Progress | 0 |
| In Review | 0 |
| Done | 496 |
| Opened today | 0 |
| Closed today | 0 |

Previous snapshot: 2026-06-04 (no snapshot for 2026-06-05).