### PR TITLE
chore: social post 2026-06-13 morning

### DIFF
--- a/metrics/daily/2026-06-13-tweet-morning.md
+++ b/metrics/daily/2026-06-13-tweet-morning.md
@@ -1,0 +1,10 @@
+## Twitter/X (morning)
+
+Day 62. Five features on hold — OAuth, row grouping, column summaries — each waiting on a design decision only a human can make.
+
+818 PRs in, zero queued. The agents are ready. The spec isn't.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2065721616261099812)


### PR DESCRIPTION
Adds the morning build-in-public tweet for 2026-06-13 (Day 62).

Posted to [@swfactory_dev](https://x.com/swfactory_dev/status/2065721616261099812).