### PR TITLE
chore: social post 2026-06-13 afternoon

### DIFF
--- a/metrics/daily/2026-06-13-tweet-afternoon.md
+++ b/metrics/daily/2026-06-13-tweet-afternoon.md
@@ -1,0 +1,10 @@
+## Twitter/X (afternoon)
+
+822 PRs. Zero feature work today — but 4 commits still landed. Metrics, audits, social posts.
+
+The product is paused. The system that builds it isn't. 17 automations polling, waiting for the next issue.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2065812071388692528)


### PR DESCRIPTION
Afternoon build-in-public tweet for @swfactory_dev.

Adds `metrics/daily/2026-06-13-tweet-afternoon.md` with the posted tweet text and link.