### PR TITLE
chore: weekly recap 2026-W25

### DIFF
--- a/metrics/weekly/2026-W25.md
+++ b/metrics/weekly/2026-W25.md
@@ -1,0 +1,68 @@
+# Week 25 Recap — June 8–14, 2026
+
+Ninth week. After W24's idle stretch with zero feature work, the backlog reopened this week when three high-risk issues received human approval (#1262, #1287, #1348). The agents shipped sticky columns, command palette quick actions, security headers, a bundle size reduction, and three smaller UX improvements — all within 48 hours of approval. The pipeline then returned to idle for the remaining 3 days.
+
+## Highlights
+
+- **Sticky title column in database tables.** The first column now stays visible during horizontal scroll, matching the standard spreadsheet pattern. PR #1338.
+- **Command palette gained quick actions.** New Page, Export, Toggle Theme, and 6 other workspace actions are now accessible via ⌘+P alongside page search. PR #1351.
+- **Security headers added to all responses.** CSP, HSTS, X-Frame-Options, and Permissions-Policy now ship on every page load. PR #1345.
+- **Shared JS bundle reduced to ≤150 kB.** Lazy-loaded the command palette and Sentry SDK, bringing all pages back under the 200 kB first-load budget. PR #1330.
+
+## By the Numbers
+
+| Metric | This Week | Cumulative | Delta |
+|---|---|---|---|
+| Lines of code | +772 | 85,508 | +0.91% |
+| PRs merged | 32 | 826 | |
+| Test coverage | 37.7% | | +0.42pp |
+| Tests (unit + E2E) | +53 | 3,141 | |
+| Issues completed | 8 | 504 done, 5 open | |
+| Human time | not yet recorded | not yet recorded | |
+| Agent time | not yet recorded | not yet recorded | |
+
+## Features Shipped
+
+### Database
+
+- **Sticky title column** — first column stays pinned during horizontal scroll in wide tables. PR #1338 (Issue #1262).
+
+### Command Palette & Navigation
+
+- **Quick actions in command palette** — New Page, New Database, Export, Import, Settings, Members, Toggle Theme/Sidebar/Focus Mode accessible via ⌘+P. PR #1351 (Issue #1348).
+- **Breadcrumb context in sidebar search** — search results now show parent page path to distinguish identically-named pages. PR #1353 (Issue #1350).
+
+### Editor
+
+- **Empty state for slash command menu** — typing a non-matching filter (e.g., `/xyz`) now shows "No matching commands" instead of silently closing. PR #1352 (Issue #1349).
+
+### Security
+
+- **Security response headers** — Content-Security-Policy, Strict-Transport-Security, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy added via `next.config.ts`. PR #1345 (Issue #1343).
+
+### Performance
+
+- **Shared bundle reduction** — lazy-loaded `cmdk` and Sentry browser SDK, reducing the shared JS baseline from 171 kB to ≤150 kB. All 12 pages now under the 200 kB first-load budget. PR #1330 (Issue #1340).
+
+### Test Infrastructure
+
+- **Live-app visual regression tests** — new E2E spec screenshots authenticated pages (workspace home, editor, database table, settings) and compares against committed baselines. PR #1339 (Issue #1287).
+
+### Routine Automation Output
+
+- 21 social posts (3× daily, 7 days)
+- 7 daily metrics snapshots
+- 1 weekly recap (W24, PR #1326)
+- 1 performance report (W24, PR #1329)
+- 1 automation audit (W25, PR #1368)
+
+## What's Next
+
+- **Row grouping in table view** — collapsible sections grouped by a select/status property. Issue #1252 (awaiting human approval).
+- **Column calculation summary row** — sum, average, count pinned at the bottom of each column. Issue #1245 (awaiting human approval).
+- **OAuth sign-in with GitHub and Google** — code is implemented, needs Supabase dashboard configuration. Issue #1216 (awaiting human approval).
+
+## Challenges & Learnings
+
+- **The approval gate is the throughput bottleneck.** All 7 feature PRs shipped within 48 hours of the three approvals on June 10–11. The remaining 3 days of the week were idle. The agents can sustain high output when the backlog is unblocked, but velocity drops to zero between human check-ins. The 5 remaining open issues have been waiting 15–18 days for approval.
+- **CI pass rate dipped to 75% on the busiest day.** June 11 had 8 CI runs with 2 failures — both related to CSP configuration breaking Playwright tests. The security headers PR needed a follow-up commit to allowlist Playwright's test harness domains in the CSP policy. Testing security headers in E2E requires careful coordination between the header config and the test environment.


### PR DESCRIPTION
Weekly recap for Week 25 (June 8–14, 2026).

Covers 32 merged PRs including 7 feature/perf PRs (sticky title column, command palette quick actions, security headers, bundle reduction, sidebar search breadcrumbs, slash menu empty state, live visual regression tests) and 8 issues completed.

All numbers sourced from `metrics/daily/*.json` snapshots and GitHub PR/issue data.