### PR TITLE
chore: daily metrics snapshot 2026-06-16

### DIFF
--- a/metrics/daily/2026-06-16.json
+++ b/metrics/daily/2026-06-16.json
@@ -1,0 +1,22 @@
+{
+  "date": "2026-06-16",
+  "day_number": 65,
+  "loc": { "total": 85520, "delta": 784, "by_language": { "TypeScript": 83625, "SQL": 1547, "CSS": 348 } },
+  "files": { "total": 274, "delta": 2 },
+  "prs": { "total": 838, "delta": 53, "currently_open": 0 },
+  "commits": { "total": 861, "delta": 53 },
+  "issues": {
+    "backlog": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 505,
+    "opened_today": 0,
+    "closed_today": 0
+  },
+  "tests": { "unit": 2147, "e2e": 994 },
+  "ci": { "runs_total": 0, "runs_passed": 0, "pass_rate_pct": null },
+  "test_coverage_pct": 37.7,
+  "autonomous_pct": 90,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
## Daily Metrics — 2026-06-16 (Day 65)

| Metric | Value | Delta |
|---|---|---|
| Lines of code | 85,520 | +784 |
| Files | 274 | +2 |
| PRs merged (cumulative) | 838 | +53 |
| PRs open | 0 | — |
| Commits | 861 | +53 |
| Unit tests | 2,147 | +28 |
| E2E tests | 994 | +25 |
| Test coverage | 37.7% | +0.42pp |
| Autonomous PR % | 90% | +1pp |
| CI runs today | 0 | — |

### Issues

| Status | Count |
|---|---|
| Backlog | 0 |
| In Progress | 0 |
| In Review | 0 |
| Done | 505 |
| Opened today | 0 |
| Closed today | 0 |

Deltas computed from previous snapshot (2026-06-06).