### PR TITLE
feat: add consistent tab navigation between settings and members pages (#1389)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -575,6 +575,7 @@ src/
 │   ├── page-count-announcer.tsx  # Screen-reader live region for page count changes (mirrors RowCountAnnouncer)
 │   ├── settings-page-client.tsx  # Client wrapper: lazy-loads SettingsPageContent via next/dynamic
 │   ├── settings-page-content.tsx # Settings page layout: form + change password + danger zone
+│   ├── settings-tab-nav.tsx      # Shared tab nav (General | Members) for settings sub-pages
 │   ├── workspace-settings-form.tsx # Edit workspace name/slug, lazy-loads delete workspace section
 │   ├── delete-workspace-section.tsx # Workspace deletion danger zone with AlertDialog confirmation
 │   ├── danger-zone-settings.tsx # Client wrapper: lazy-loads DeleteAccountSection via next/dynamic

--- a/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
+++ b/src/app/(app)/[workspaceSlug]/settings/members/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { MembersPageClient } from "@/components/members/members-page-client";
+import { SettingsTabNav } from "@/components/settings-tab-nav";
 import type { WorkspaceInviteWithInviter } from "@/lib/types";
 import {
   membersWithFullProfile,
@@ -101,6 +102,9 @@ export default async function WorkspaceMembersPage({
       <p className="mt-1 text-sm text-muted-foreground">
         Manage who has access to this workspace.
       </p>
+      <div className="mt-4">
+        <SettingsTabNav workspaceSlug={workspace.slug} />
+      </div>
       <div className="mt-6">
         <MembersPageClient
           workspace={workspace}

--- a/src/components/settings-page-client.stories.tsx
+++ b/src/components/settings-page-client.stories.tsx
@@ -35,24 +35,32 @@ export const Loading: Story = {
   ),
 };
 
-/** Loaded state — full settings page content. */
+/** Loaded state — full settings page content with tab navigation. */
 export const Loaded: Story = {
   render: () => (
     <div className="mx-auto max-w-xl p-6">
-      <div className="flex items-center gap-4">
-        <h1 className="text-2xl font-semibold text-foreground">
-          Workspace settings
-        </h1>
-        <a
-          href="#"
-          className="text-sm text-accent underline-offset-4 hover:underline"
-        >
-          Members
-        </a>
-      </div>
+      <h1 className="text-2xl font-semibold text-foreground">
+        Workspace settings
+      </h1>
       <p className="mt-1 text-sm text-muted-foreground">
         Manage your workspace name, URL, and other settings.
       </p>
+      <div className="mt-4">
+        <nav className="flex border-b border-overlay-border">
+          <a
+            href="#"
+            className="border-b-2 border-accent px-3 pb-2 text-sm text-foreground"
+          >
+            General
+          </a>
+          <a
+            href="#"
+            className="px-3 pb-2 text-sm text-muted-foreground hover:text-foreground"
+          >
+            Members
+          </a>
+        </nav>
+      </div>
       <div className="mt-6 space-y-4">
         <div className="space-y-2">
           <label className="text-sm font-medium text-foreground">

--- a/src/components/settings-page-content.tsx
+++ b/src/components/settings-page-content.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import Link from "next/link";
 import { WorkspaceSettingsForm } from "@/components/workspace-settings-form";
+import { SettingsTabNav } from "@/components/settings-tab-nav";
 import { Separator } from "@/components/ui/separator";
 import type { Workspace } from "@/lib/types";
 
@@ -33,18 +33,13 @@ export function SettingsPageContent({
 }: SettingsPageContentProps) {
   return (
     <div className="mx-auto max-w-xl p-6">
-      <div className="flex items-center gap-4">
-        <h1 className="text-2xl font-semibold">Workspace settings</h1>
-        <Link
-          href={`/${workspace.slug}/settings/members`}
-          className="text-sm text-accent underline underline-offset-4"
-        >
-          Members
-        </Link>
-      </div>
+      <h1 className="text-2xl font-semibold">Workspace settings</h1>
       <p className="mt-1 text-sm text-muted-foreground">
         Manage your workspace name, URL, and other settings.
       </p>
+      <div className="mt-4">
+        <SettingsTabNav workspaceSlug={workspace.slug} />
+      </div>
       <div className="mt-6">
         <WorkspaceSettingsForm workspace={workspace} userId={userId} />
       </div>

--- a/src/components/settings-tab-nav.stories.tsx
+++ b/src/components/settings-tab-nav.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Link from "next/link";
+
+/**
+ * SettingsTabNav provides tab-style navigation between the General and Members
+ * settings pages. Because the real component relies on `usePathname()` (mocked
+ * to `"/"` in Storybook), these stories render the visual states directly so
+ * every variant is visible without route changes.
+ */
+
+const meta: Meta = {
+  title: "Components/SettingsTabNav",
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export { meta as default };
+
+type Story = StoryObj;
+
+function TabNav({
+  activeTab,
+}: {
+  activeTab: "general" | "members" | "none";
+}) {
+  const tabs = [
+    { label: "General", active: activeTab === "general" },
+    { label: "Members", active: activeTab === "members" },
+  ];
+
+  return (
+    <nav className="flex border-b border-overlay-border">
+      {tabs.map((tab) => (
+        <Link
+          key={tab.label}
+          href="#"
+          className={`px-3 pb-2 text-sm ${
+            tab.active
+              ? "border-b-2 border-accent text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}
+
+/** General tab active — shown on the settings page. */
+export const GeneralActive: Story = {
+  render: () => <TabNav activeTab="general" />,
+};
+
+/** Members tab active — shown on the members page. */
+export const MembersActive: Story = {
+  render: () => <TabNav activeTab="members" />,
+};
+
+/** No tab active — fallback when pathname doesn't match either route. */
+export const NoneActive: Story = {
+  render: () => <TabNav activeTab="none" />,
+};
+
+/** Tab nav in context — placed between a heading and content, matching the settings page layout. */
+export const InPageContext: Story = {
+  render: () => (
+    <div className="mx-auto max-w-xl p-6">
+      <h1 className="text-2xl font-semibold text-foreground">
+        Workspace settings
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Manage your workspace name, URL, and other settings.
+      </p>
+      <div className="mt-4">
+        <TabNav activeTab="general" />
+      </div>
+      <div className="mt-6">
+        <div className="h-32 rounded-sm border border-overlay-border bg-muted/30 p-4 text-sm text-muted-foreground">
+          Page content area
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/settings-tab-nav.tsx
+++ b/src/components/settings-tab-nav.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface SettingsTabNavProps {
+  workspaceSlug: string;
+}
+
+const tabs = [
+  { label: "General", segment: "" },
+  { label: "Members", segment: "/members" },
+] as const;
+
+export function SettingsTabNav({ workspaceSlug }: SettingsTabNavProps) {
+  const pathname = usePathname();
+  const basePath = `/${workspaceSlug}/settings`;
+
+  return (
+    <nav className="flex border-b border-overlay-border">
+      {tabs.map((tab) => {
+        const href = `${basePath}${tab.segment}`;
+        const isActive =
+          tab.segment === ""
+            ? pathname === basePath
+            : pathname === `${basePath}${tab.segment}`;
+
+        return (
+          <Link
+            key={tab.label}
+            href={href}
+            className={`px-3 pb-2 text-sm ${
+              isActive
+                ? "border-b-2 border-accent text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
Closes #1389

## What

Adds a shared `SettingsTabNav` component that renders a tab bar (General | Members) on both the settings and members pages, replacing the one-way "Members" text link in the settings page header.

## How

- New `SettingsTabNav` client component uses `usePathname()` to determine the active tab and renders Next.js `<Link>` elements with the view-tabs design pattern (`border-b-2 border-accent text-foreground` for active, `text-muted-foreground` for inactive).
- Integrated into `settings-page-content.tsx` (General settings) and `settings/members/page.tsx` (Members page), placed between the heading/description and the page content.
- Removed the old inline "Members" link from the settings page header.
- Updated `settings-page-client.stories.tsx` to reflect the new tab nav layout.

## Testing

- `pnpm lint` — 0 errors (pre-existing warnings only)
- `pnpm typecheck` — passes
- `pnpm test` — 154 files, 2147 tests passed
- New Storybook stories: `settings-tab-nav.stories.tsx` with 4 stories (GeneralActive, MembersActive, NoneActive, InPageContext)
- Visual regression baselines for new stories will be generated on first CI run
- No E2E tests required — component uses standard `<Link>` navigation with no interactive handlers