### PR TITLE
fix: filter browser extension noise from Sentry (#1400)

### DIFF
--- a/.agents/quality.md
+++ b/.agents/quality.md
@@ -33,9 +33,9 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 
 | Category | Files | Tests |
 |---|---|---|
-| Unit/Integration (Vitest) | 154 | 2147 |
+| Unit/Integration (Vitest) | 154 | 2160 |
 | E2E (Playwright) | 103 | 480 |
-| **Total** | **257** | **2627** |
+| **Total** | **257** | **2640** |
 
 ### Test files by domain
 
@@ -51,7 +51,7 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 - **Feedback**: `feedback/route.test.ts` (22 tests), `feedback-form-design-spec.test.ts` (5 tests), `use-screenshot.test.ts` (2 tests), `e2e/feedback.spec.ts` (6 tests)
 - **API**: `health/route.test.ts` (13 tests), `search/route.test.ts` (14 tests), `account/route.test.ts` (9 tests), `cron/purge-trash/route.test.ts` (10 tests), `feedback/route.test.ts` (22 tests), `pages/[pageId]/versions/route.test.ts` (17 tests), `pages/[pageId]/versions/route.rate-limit.test.ts` (3 tests), `pages/[pageId]/versions/[versionId]/route.test.ts` (14 tests), `pages/[pageId]/versions/[versionId]/route.rate-limit.test.ts` (3 tests), `e2e/account-deletion.spec.ts` (4 tests), `e2e/account-settings.spec.ts` (5 tests)
 - **UI**: `overlay-opacity.test.ts` (2 tests), `toast-error-duration.test.ts` (1 test), `dialog-design-spec.test.ts` (3 tests), `design-spec-compliance.test.ts` (14 tests), `relative-time.test.ts` (7 tests), `reduced-motion.test.ts` (6 tests), `e2e/visual-regression.spec.ts` (1 test), `e2e/live-visual-regression.spec.ts` (1 test)
-- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (180 tests), `classification-edge-cases.test.ts` (42 tests), `api-route-consistency.test.ts` (6 tests), `retry.test.ts` (16 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (9 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests), `use-roving-tabindex.test.ts` (13 tests)
+- **Lib**: `sentry.test.ts` (4 tests), `sentry.unit.test.ts` (193 tests), `classification-edge-cases.test.ts` (42 tests), `api-route-consistency.test.ts` (6 tests), `retry.test.ts` (16 tests), `rate-limit.test.ts` (17 tests), `track-event-server.test.ts` (9 tests), `track-event.test.ts` (4 tests), `usage-tracking-guard.test.ts` (5 tests), `use-roving-tabindex.test.ts` (13 tests)
 - **Infrastructure**: `migrations.test.ts` (33 tests), `build-timeseries.test.mjs` (6 tests), `supabase/client.test.ts` (7 tests), `supabase/proxy.test.ts` (2 tests), `security-headers.test.ts` (18 tests)
 
 ## Known Gaps
@@ -215,4 +215,5 @@ Tracks code quality per domain. Updated by automations as a side effect of featu
 | 2026-06-11 | Add empty state to slash command menu (#1349). Updated `e2e/editor-slash-commands.spec.ts` (6→8): 2 new tests for empty state display and recovery. Updated Storybook `EmptyFilterResult` story with data-testid attributes. Test totals: 153 Vitest files (2138 tests), 103 E2E specs (480 tests). |
 | 2026-06-11 | Show parent breadcrumb context in sidebar search results (#1350). Added 1 new Vitest file: `breadcrumb.test.ts` (9 tests). Extracted `buildBreadcrumbMap` and `getParentBreadcrumb` from `command-palette.tsx` into shared `src/lib/breadcrumb.ts`. Added `WithBreadcrumbs` Storybook story. Test totals: 154 Vitest files (2147 tests), 103 E2E specs (480 tests). |
 | 2026-06-15 | Add ARIA live region roles to app-side form feedback messages (#1372). Updated existing tests in `workspace-settings-form.test.tsx` and `create-workspace-dialog.test.tsx` to assert `role="alert"` on error messages and `role="status"` on success messages. No new test files. Test totals unchanged: 154 Vitest files (2147 tests), 103 E2E specs (480 tests). |
+| 2026-06-20 | Filter browser extension noise from Sentry (#1400). Updated `sentry.unit.test.ts` (180→193): 13 new tests for `isBrowserExtensionNoise` covering MetaMask inpage.js errors, chrome/moz/safari-extension frame detection, mixed extension sources, chained exceptions, and negative cases. Test totals: 154 Vitest files (2160 tests), 103 E2E specs (480 tests). |
 

--- a/src/lib/sentry/index.ts
+++ b/src/lib/sentry/index.ts
@@ -27,6 +27,7 @@ export {
   isReactLexicalDomConflict,
   isTransientSupabaseNetworkEvent,
   isSupabaseAuthLockContention,
+  isBrowserExtensionNoise,
   NOISE_REGISTRY,
 } from "./noise-registry";
 

--- a/src/lib/sentry/noise-registry.ts
+++ b/src/lib/sentry/noise-registry.ts
@@ -121,6 +121,52 @@ function matchTransientSupabaseNetworkEvent(event: ErrorEvent): boolean {
   );
 }
 
+/** Filenames that indicate a browser extension injected script. */
+const EXTENSION_PATH_PATTERNS = [
+  "chrome-extension://",
+  "moz-extension://",
+  "safari-extension://",
+  "app:///scripts/inpage.js",
+];
+
+/** Known error messages from browser extensions that are not actionable. */
+const EXTENSION_ERROR_MESSAGES = [
+  "Failed to connect to MetaMask",
+  "MetaMask extension not found",
+];
+
+function matchBrowserExtensionNoise(event: ErrorEvent): boolean {
+  const values = event.exception?.values;
+  if (!values || values.length === 0) return false;
+
+  // Match if any exception value contains a known extension error message
+  const hasExtensionMessage = values.some((ex) =>
+    EXTENSION_ERROR_MESSAGES.some(
+      (msg) => typeof ex.value === "string" && ex.value.includes(msg),
+    ),
+  );
+  if (hasExtensionMessage) return true;
+
+  // Match if ALL exceptions have stack frames exclusively from extension paths
+  const allFramesFromExtensions = values.every((ex) => {
+    const frames = ex.stacktrace?.frames;
+    if (!frames || frames.length === 0) return true;
+    return frames.every((frame) => {
+      const filename = frame.filename ?? frame.abs_path ?? "";
+      return EXTENSION_PATH_PATTERNS.some((pattern) =>
+        filename.includes(pattern),
+      );
+    });
+  });
+
+  // Only match if there are actual frames to check (avoid matching frameless events)
+  const hasAnyFrames = values.some(
+    (ex) => ex.stacktrace?.frames && ex.stacktrace.frames.length > 0,
+  );
+
+  return hasAnyFrames && allFramesFromExtensions;
+}
+
 function matchSupabaseAuthLockContention(event: ErrorEvent): boolean {
   const values = event.exception?.values;
   if (!values || values.length === 0) return false;
@@ -173,6 +219,14 @@ export const NOISE_REGISTRY: NoisePattern[] = [
       "from Supabase operations. Not actionable — caused by client connectivity.",
   },
   {
+    name: "browser-extension-noise",
+    scope: "client",
+    match: matchBrowserExtensionNoise,
+    reason:
+      "Errors from browser extensions (MetaMask, etc.) injected into the page. " +
+      "No application code involved — all stack frames originate from extension scripts.",
+  },
+  {
     name: "supabase-auth-lock-contention",
     scope: "both",
     match: matchSupabaseAuthLockContention,
@@ -196,3 +250,4 @@ export const isNextjsInternalNoise = matchNextjsInternalNoise;
 export const isReactLexicalDomConflict = matchReactLexicalDomConflict;
 export const isTransientSupabaseNetworkEvent = matchTransientSupabaseNetworkEvent;
 export const isSupabaseAuthLockContention = matchSupabaseAuthLockContention;
+export const isBrowserExtensionNoise = matchBrowserExtensionNoise;

--- a/src/lib/sentry/sentry.unit.test.ts
+++ b/src/lib/sentry/sentry.unit.test.ts
@@ -31,6 +31,7 @@ import {
   captureApiError,
   isNextjsInternalNoise,
   isReactLexicalDomConflict,
+  isBrowserExtensionNoise,
   isE2ETestSession,
   isE2ETestRequest,
   shouldDropServerEvent,
@@ -1854,5 +1855,185 @@ describe("shouldDropServerEvent", () => {
     } as unknown as ErrorEvent;
     expect(shouldDropServerEvent(event)).toBe(true);
     mockScopeData = {};
+  });
+});
+
+describe("isBrowserExtensionNoise", () => {
+  it("detects MetaMask 'Failed to connect' error from inpage.js (MEMO-2M)", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "MetaMask extension not found",
+            stacktrace: {
+              frames: [
+                { filename: "app:///scripts/inpage.js", lineno: 4 },
+              ],
+            },
+          },
+          {
+            type: "i",
+            value: "i: Failed to connect to MetaMask",
+            stacktrace: {
+              frames: [
+                { filename: "app:///scripts/inpage.js", lineno: 7 },
+              ],
+            },
+          },
+        ],
+      },
+    } as unknown as ErrorEvent;
+    expect(isBrowserExtensionNoise(event)).toBe(true);
+  });
+
+  it("detects error by message alone without stack frames", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "i: Failed to connect to MetaMask" },
+    ]);
+    expect(isBrowserExtensionNoise(event)).toBe(true);
+  });
+
+  it("detects 'MetaMask extension not found' message", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "MetaMask extension not found" },
+    ]);
+    expect(isBrowserExtensionNoise(event)).toBe(true);
+  });
+
+  it("detects errors with all frames from chrome-extension://", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Some extension error",
+            stacktrace: {
+              frames: [
+                { filename: "chrome-extension://abc123/content.js" },
+                { filename: "chrome-extension://abc123/background.js" },
+              ],
+            },
+          },
+        ],
+      },
+    } as unknown as ErrorEvent;
+    expect(isBrowserExtensionNoise(event)).toBe(true);
+  });
+
+  it("detects errors with all frames from moz-extension://", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Some extension error",
+            stacktrace: {
+              frames: [
+                { filename: "moz-extension://abc123/content.js" },
+              ],
+            },
+          },
+        ],
+      },
+    } as unknown as ErrorEvent;
+    expect(isBrowserExtensionNoise(event)).toBe(true);
+  });
+
+  it("detects errors with all frames from safari-extension://", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Some extension error",
+            stacktrace: {
+              frames: [
+                { filename: "safari-extension://abc123/content.js" },
+              ],
+            },
+          },
+        ],
+      },
+    } as unknown as ErrorEvent;
+    expect(isBrowserExtensionNoise(event)).toBe(true);
+  });
+
+  it("returns false when frames include first-party code", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Some error",
+            stacktrace: {
+              frames: [
+                { filename: "chrome-extension://abc123/content.js" },
+                { filename: "webpack-internal:///src/app/page.tsx" },
+              ],
+            },
+          },
+        ],
+      },
+    } as unknown as ErrorEvent;
+    expect(isBrowserExtensionNoise(event)).toBe(false);
+  });
+
+  it("returns false for unrelated errors without extension frames", () => {
+    const event = makeSentryEvent([
+      { type: "TypeError", value: "Cannot read properties of undefined" },
+    ]);
+    expect(isBrowserExtensionNoise(event)).toBe(false);
+  });
+
+  it("returns false when exception values are empty", () => {
+    const event = makeSentryEvent([]);
+    expect(isBrowserExtensionNoise(event)).toBe(false);
+  });
+
+  it("returns false when exception is missing", () => {
+    const event = { type: undefined } as ErrorEvent;
+    expect(isBrowserExtensionNoise(event)).toBe(false);
+  });
+
+  it("returns false for frameless events without extension messages", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Some random error" },
+    ]);
+    expect(isBrowserExtensionNoise(event)).toBe(false);
+  });
+
+  it("detects chained exceptions where one has extension message", () => {
+    const event = makeSentryEvent([
+      { type: "Error", value: "Wrapper error" },
+      { type: "Error", value: "MetaMask extension not found" },
+    ]);
+    expect(isBrowserExtensionNoise(event)).toBe(true);
+  });
+
+  it("detects mixed extension frame sources (chrome + inpage.js)", () => {
+    const event = {
+      type: undefined,
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Some error",
+            stacktrace: {
+              frames: [
+                { filename: "app:///scripts/inpage.js" },
+                { filename: "chrome-extension://def456/inject.js" },
+              ],
+            },
+          },
+        ],
+      },
+    } as unknown as ErrorEvent;
+    expect(isBrowserExtensionNoise(event)).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #1400

## What

MetaMask's injected `inpage.js` script throws unhandled promise rejections (`Failed to connect to MetaMask`, `MetaMask extension not found`) that Sentry captures via `onunhandledrejection`. All stack frames originate from extension code — zero frames reference our application source. This creates noise in Sentry with no actionable signal.

## How

Added a `browser-extension-noise` entry to `NOISE_REGISTRY` in `src/lib/sentry/noise-registry.ts`. The filter drops events matching either condition:
1. Any exception value contains a known extension error message (e.g., "Failed to connect to MetaMask")
2. All stack frames across all exceptions originate from extension paths (`chrome-extension://`, `moz-extension://`, `safari-extension://`, `app:///scripts/inpage.js`)

The filter is scoped to `client` only and will also catch future noise from other browser extensions that inject scripts and throw unhandled errors.

## Testing

Added 13 regression tests in `sentry.unit.test.ts` covering:
- Exact MetaMask error shape from Sentry issue MEMO-2M (chained exceptions with inpage.js frames)
- Message-only detection (no stack frames)
- Frame-only detection for chrome/moz/safari extension paths
- Mixed extension frame sources
- Negative cases: first-party frames mixed in, unrelated errors, empty/missing exceptions, frameless events without extension messages