### PR TITLE
feat: add focus-visible styles to app shell and utility component buttons (#1414)

### DIFF
--- a/src/components/account-settings-form.tsx
+++ b/src/components/account-settings-form.tsx
@@ -198,7 +198,7 @@ export function AccountSettingsForm({
             type="button"
             onClick={handleAvatarClick}
             disabled={uploading}
-            className="group relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+            className="group relative flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             aria-label="Change avatar"
             data-testid="avatar-upload-button"
           >

--- a/src/components/editor/database-node.tsx
+++ b/src/components/editor/database-node.tsx
@@ -274,7 +274,7 @@ function InlineDatabaseComponent({
                       e.stopPropagation();
                       handleViewChange(view.id);
                     }}
-                    className={`flex items-center gap-1 px-1.5 py-0.5 text-xs ${
+                    className={`flex items-center gap-1 px-1.5 py-0.5 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
                       view.id === activeViewId
                         ? "text-foreground"
                         : "text-muted-foreground hover:text-foreground"
@@ -291,7 +291,7 @@ function InlineDatabaseComponent({
 
         <button
           onClick={handleNavigate}
-          className="shrink-0 text-muted-foreground hover:text-foreground"
+          className="shrink-0 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label="Open full database"
         >
           <Maximize2 className="h-3.5 w-3.5" />

--- a/src/components/editor/database-plugin.tsx
+++ b/src/components/editor/database-plugin.tsx
@@ -382,7 +382,7 @@ export function DatabasePlugin(): JSX.Element | null {
       <div className="max-h-[260px] overflow-y-auto p-1">
         {/* Create new database option — always first */}
         <button
-          className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none ${
+          className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none focus-visible:bg-overlay-active focus-visible:outline-none ${
             selectedIndex === 0
               ? "bg-overlay-active text-foreground"
               : "text-muted-foreground hover:bg-overlay-hover"
@@ -408,7 +408,7 @@ export function DatabasePlugin(): JSX.Element | null {
         {results.map((db, index) => (
           <button
             key={db.id}
-            className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none ${
+            className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none focus-visible:bg-overlay-active focus-visible:outline-none ${
               selectedIndex === index + 1
                 ? "bg-overlay-active text-foreground"
                 : "text-muted-foreground hover:bg-overlay-hover"

--- a/src/components/editor/page-link-plugin.tsx
+++ b/src/components/editor/page-link-plugin.tsx
@@ -467,7 +467,7 @@ export function PageLinkPlugin(): JSX.Element | null {
             key={page.id}
             id={`page-link-option-${page.id}`}
             data-testid="pls-result-item"
-            className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none ${
+            className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm outline-none focus-visible:bg-overlay-active focus-visible:outline-none ${
               selectedIndex === index
                 ? "bg-overlay-active text-foreground"
                 : "text-muted-foreground hover:bg-overlay-hover"

--- a/src/components/emoji-picker.tsx
+++ b/src/components/emoji-picker.tsx
@@ -197,7 +197,7 @@ export function EmojiPicker({
           {hasIcon && onRemove && (
             <button
               onClick={handleRemove}
-              className="mb-2 w-full px-2 py-1 text-left text-xs text-muted-foreground hover:bg-overlay-hover"
+              className="mb-2 w-full px-2 py-1 text-left text-xs text-muted-foreground hover:bg-overlay-hover focus-visible:bg-overlay-active focus-visible:outline-none"
             >
               Remove icon
             </button>
@@ -213,7 +213,7 @@ export function EmojiPicker({
                     <button
                       key={emoji}
                       onClick={() => handleSelect(emoji)}
-                      className="flex min-h-11 min-w-11 items-center justify-center text-lg hover:bg-overlay-hover sm:min-h-8 sm:min-w-8"
+                      className="flex min-h-11 min-w-11 items-center justify-center text-lg hover:bg-overlay-hover sm:min-h-8 sm:min-w-8 focus-visible:bg-overlay-active focus-visible:outline-none"
                       aria-label={`Select ${emoji}`}
                     >
                       {emoji}

--- a/src/components/feedback/feedback-form.tsx
+++ b/src/components/feedback/feedback-form.tsx
@@ -275,7 +275,7 @@ export function FeedbackFormContent({
             <button
               type="button"
               onClick={screenshot.remove}
-              className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center bg-destructive text-destructive-foreground opacity-0 transition-opacity before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] group-hover:opacity-100"
+              className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center bg-destructive text-destructive-foreground opacity-0 transition-opacity before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] group-hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:opacity-100"
               aria-label="Remove screenshot"
             >
               <X className="h-3 w-3" />
@@ -285,7 +285,7 @@ export function FeedbackFormContent({
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="flex h-20 items-center justify-center gap-2 border border-dashed border-overlay-border text-muted-foreground transition-colors hover:border-overlay-strong hover:text-foreground"
+            className="flex h-20 items-center justify-center gap-2 border border-dashed border-overlay-border text-muted-foreground transition-colors hover:border-overlay-strong hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             <ImagePlus className="h-4 w-4" />
             <span className="text-xs">Upload screenshot</span>
@@ -303,7 +303,7 @@ export function FeedbackFormContent({
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="self-start text-xs text-muted-foreground transition-colors hover:text-foreground"
+            className="self-start text-xs text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           >
             Replace image
           </button>

--- a/src/components/page-cover.tsx
+++ b/src/components/page-cover.tsx
@@ -179,7 +179,7 @@ export function PageCover({ pageId, initialCoverUrl }: PageCoverProps) {
       ) : (
         <div className="mb-1 max-sm:opacity-100 opacity-0 group-hover/page-header:opacity-100">
           <button
-            className="flex min-h-11 items-center gap-1 rounded-sm px-1.5 text-xs text-muted-foreground hover:bg-overlay-hover sm:min-h-7"
+            className="flex min-h-11 items-center gap-1 rounded-sm px-1.5 text-xs text-muted-foreground hover:bg-overlay-hover sm:min-h-7 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             aria-label="Add cover image"
             onClick={openFilePicker}
             disabled={uploading}

--- a/src/components/page-icon.tsx
+++ b/src/components/page-icon.tsx
@@ -60,7 +60,7 @@ export function PageIcon({ pageId, initialIcon }: PageIconProps) {
           hasIcon
         >
           <button
-            className="flex min-h-11 min-w-11 items-center justify-center rounded-sm text-4xl leading-none hover:bg-overlay-hover sm:min-h-10 sm:min-w-10"
+            className="flex min-h-11 min-w-11 items-center justify-center rounded-sm text-4xl leading-none hover:bg-overlay-hover sm:min-h-10 sm:min-w-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             aria-label={`Page icon: ${icon}. Click to change`}
           >
             {icon}
@@ -80,7 +80,7 @@ export function PageIcon({ pageId, initialIcon }: PageIconProps) {
         hasIcon={false}
       >
         <button
-          className="flex min-h-11 items-center gap-1 rounded-sm px-1.5 text-xs text-muted-foreground hover:bg-overlay-hover sm:min-h-7"
+          className="flex min-h-11 items-center gap-1 rounded-sm px-1.5 text-xs text-muted-foreground hover:bg-overlay-hover sm:min-h-7 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label="Add page icon"
         >
           <SmilePlus className="h-3.5 w-3.5" />

--- a/src/components/sidebar/page-search.tsx
+++ b/src/components/sidebar/page-search.tsx
@@ -351,7 +351,7 @@ export function PageSearch() {
         {query && (
           <button
             onClick={handleClear}
-            className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center justify-center min-h-11 min-w-11 sm:min-h-0 sm:min-w-0 sm:p-1.5 text-muted-foreground hover:text-foreground"
+            className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center justify-center min-h-11 min-w-11 sm:min-h-0 sm:min-w-0 sm:p-1.5 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             aria-label="Clear search"
           >
             <X className="h-3.5 w-3.5" />
@@ -393,7 +393,7 @@ export function PageSearch() {
                 id={`search-result-${result.id}`}
                 role="option"
                 aria-selected={index === selectedIndex}
-                className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left transition-none ${
+                className={`flex w-full flex-col gap-0.5 px-3 py-2 text-left transition-none focus-visible:bg-overlay-active focus-visible:outline-none ${
                   index === selectedIndex
                     ? "bg-overlay-active"
                     : "hover:bg-overlay-hover"

--- a/src/components/version-history-panel.tsx
+++ b/src/components/version-history-panel.tsx
@@ -170,7 +170,7 @@ export function VersionHistoryPanel({
                     ? handleDeselect()
                     : handleSelectVersion(version.id)
                 }
-                className={`w-full border-b border-overlay-border px-4 py-3 text-left transition-none hover:bg-overlay-hover ${
+                className={`w-full border-b border-overlay-border px-4 py-3 text-left transition-none hover:bg-overlay-hover focus-visible:bg-overlay-active focus-visible:outline-none ${
                   selectedId === version.id ? "bg-overlay-active" : ""
                 }`}
               >


### PR DESCRIPTION
Closes #1414

## What

Adds `focus-visible` styles to all native `<button>` elements across 10 app shell and utility component files that previously only had `hover:` styles. This is the third part of a systematic fix for keyboard focus indicators (editor: #1412, database: #1413).

## How

Applied the appropriate focus style per button type, following the patterns established in `page-tree-item.tsx` and `trash-section.tsx`:

- **Icon-only buttons** (clear search, remove screenshot, remove icon, view selector tabs, open database): `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring`
- **List-item/option buttons** (search results, emoji items, remove icon menu item, version history items, database picker options, page link options): `focus-visible:bg-overlay-active focus-visible:outline-none`
- **Upload/action buttons** (upload screenshot, replace image, add cover, add icon, page icon display): `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring`
- **account-settings-form.tsx**: Migrated from `focus:` to `focus-visible:` and from `ring-2` to `ring-1` for consistency with the codebase pattern.
- **feedback-form.tsx remove button**: Added `focus-visible:opacity-100` so the button becomes visible when focused via keyboard (it's normally hidden with `opacity-0`).

### Files changed (10)

| File | Buttons | Style |
|---|---|---|
| `feedback-form.tsx` | 3 (remove screenshot, upload screenshot, replace image) | ring |
| `page-search.tsx` | 2 (clear search, search result items) | ring / bg-highlight |
| `page-icon.tsx` | 2 (icon display, add icon) | ring |
| `emoji-picker.tsx` | 2 (remove icon, emoji items) | bg-highlight |
| `page-cover.tsx` | 1 (add cover) | ring |
| `version-history-panel.tsx` | 1 (version item) | bg-highlight |
| `account-settings-form.tsx` | 1 (avatar upload) | ring |
| `database-plugin.tsx` | 2 (create new, existing db items) | bg-highlight |
| `database-node.tsx` | 2 (view tabs, open full db) | ring |
| `page-link-plugin.tsx` | 1 (page link items) | bg-highlight |

## Testing

- `pnpm lint` — 0 errors
- `pnpm typecheck` — passes
- `pnpm test` — 154 files, 2160 tests passed
- No E2E tests needed — CSS-only change with no behavior modifications
- No existing E2E tests affected (verified with grep)