### PR TITLE
chore: daily metrics snapshot 2026-06-26

### DIFF
--- a/metrics/daily/2026-06-26.json
+++ b/metrics/daily/2026-06-26.json
@@ -1,0 +1,22 @@
+{
+  "date": "2026-06-26",
+  "day_number": 75,
+  "loc": { "total": 86179, "delta": 334, "by_language": { "TypeScript": 84284, "SQL": 1547, "CSS": 348 } },
+  "files": { "total": 275, "delta": 0 },
+  "prs": { "total": 888, "delta": 6, "currently_open": 0 },
+  "commits": { "total": 911, "delta": 6 },
+  "issues": {
+    "backlog": 0,
+    "in_progress": 0,
+    "in_review": 0,
+    "done": 513,
+    "opened_today": 0,
+    "closed_today": 0
+  },
+  "tests": { "unit": 2177, "e2e": 994 },
+  "ci": { "runs_total": 0, "runs_passed": 0, "pass_rate_pct": null },
+  "test_coverage_pct": 37.91,
+  "autonomous_pct": 91,
+  "human_minutes": null,
+  "agent_minutes": null
+}


### PR DESCRIPTION
## Daily Metrics — 2026-06-26 (Day 75)

| Metric | Value | Delta |
|---|---|---|
| Lines of code | 86,179 | +334 |
| Files | 275 | 0 |
| PRs merged (cumulative) | 888 | +6 |
| PRs open | 0 | — |
| Commits | 911 | +6 |
| Unit tests | 2,177 | +17 |
| E2E tests | 994 | 0 |
| Test coverage | 37.91% | +0.14 |
| CI runs today | 0 | — |
| Autonomous % | 91% | +1 |

### Issues
| Status | Count |
|---|---|
| Backlog | 0 |
| In Progress | 0 |
| In Review | 0 |
| Done | 513 |
| Opened today | 0 |
| Closed today | 0 |
