### PR TITLE
chore: social post 2026-06-26 afternoon

### DIFF
--- a/metrics/daily/2026-06-26-tweet-afternoon.md
+++ b/metrics/daily/2026-06-26-tweet-afternoon.md
@@ -1,0 +1,12 @@
+## Twitter/X (afternoon)
+
+Empty backlog, empty PR queue. Agents have nothing to do.
+
+888 PRs. 911 commits. Zero open issues. All autonomous.
+
+No one warned us about the hardest part: deciding what to build after agents finish everything you asked for.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2070523131819667961)


### PR DESCRIPTION
Afternoon build-in-public tweet for Day 75.

Nothing shipped feature-wise today — backlog and PR queue are both empty. Tweet reflects on the "what now" moment when agents outrun the backlog.

Posted: https://x.com/swfactory_dev/status/2070523131819667961