### PR TITLE
chore: social post 2026-06-28 afternoon

### DIFF
--- a/metrics/daily/2026-06-28-tweet-afternoon.md
+++ b/metrics/daily/2026-06-28-tweet-afternoon.md
@@ -1,0 +1,10 @@
+## Twitter/X (afternoon)
+
+896 PRs in and the system still runs every 30 min. Checking issues, reviewing code, monitoring errors. Nothing to ship — but it's ready the moment something lands.
+
+You don't shut down the factory when the queue is empty.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2071247973942444381)


### PR DESCRIPTION
Afternoon build-in-public tweet for @swfactory_dev.

Nothing feature-wise shipped this afternoon — the tweet reflects on the always-on nature of the automation system: 12 automations running on schedule even when the backlog is empty.

Posted: https://x.com/swfactory_dev/status/2071247973942444381