### PR TITLE
chore: social post 2026-06-28 evening

### DIFF
--- a/metrics/daily/2026-06-28-tweet-evening.md
+++ b/metrics/daily/2026-06-28-tweet-evening.md
@@ -1,0 +1,12 @@
+## Twitter/X (evening)
+
+919 commits. 3,171 tests. 3.4 tests per commit.
+
+Agents don't skip tests. There's no "we'll add them later." Every feature ships with unit tests, E2E tests, and Storybook stories — same PR.
+
+Day 77.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2071338415568633921)


### PR DESCRIPTION
Evening build-in-public tweet for Day 77.

Angle: tests-per-commit ratio — 3.4 tests per commit across 919 commits. Highlights that agents never skip tests or defer them.

Posted: https://x.com/swfactory_dev/status/2071338415568633921