### PR TITLE
chore: weekly recap 2026-W27

### DIFF
--- a/metrics/weekly/2026-W27.md
+++ b/metrics/weekly/2026-W27.md
@@ -1,0 +1,46 @@
+# Week 27 Recap — June 22–28, 2026
+
+Eleventh week. Two accessibility features shipped on Wednesday, then the system returned to idle. The backlog has been empty for three weeks — all remaining open issues are blocked on human product decisions. The automation pipeline continues running its 12 scheduled jobs, producing metrics and social posts while waiting for new work.
+
+## Highlights
+
+- **Keyboard navigation for database view tabs.** Arrow keys, Home, and End now move between view tabs following the WAI-ARIA Tabs pattern. Screen readers announce which tab is active. PR #1432.
+- **Search results announced to screen readers.** The sidebar search now tells assistive technology how many results matched (e.g., "3 results found"), following the same pattern used on the workspace home page. PR #1433.
+
+## By the Numbers
+
+| Metric | This Week | Cumulative | Delta |
+|---|---|---|---|
+| Lines of code | +346 | 86,179 | +0.40% |
+| PRs merged | 31 | 896 | |
+| Test coverage | 37.91% | | +0.14pp |
+| Tests (unit + E2E) | +17 | 3,171 | |
+| Issues completed | 5 | 513 done, 5 open | |
+| Human time | not yet recorded | not yet recorded | |
+| Agent time | not yet recorded | not yet recorded | |
+
+## Features Shipped
+
+### Accessibility
+
+- **ARIA tab pattern for database views** — view tabs now use `role="tablist"` / `role="tab"` with `aria-selected`, roving `tabIndex`, and arrow key navigation with wrapping. The view content area has `role="tabpanel"` linked to the active tab. 12 new unit tests. PR #1432 (Issue #1430).
+- **Screen reader search result announcer** — an `aria-live="polite"` region announces result counts after search completes, debounced at 300ms. Follows the existing `PageCountAnnouncer` pattern. 5 new unit tests. PR #1433 (Issue #1431).
+
+### Routine Automation Output
+
+- 21 social posts (3× daily, 7 days)
+- 7 daily metrics snapshots
+- 1 weekly recap (W26, PR #1419)
+- 1 performance report (W26, PR #1420)
+- 1 automation audit (W27, PR #1448)
+
+## What's Next
+
+- **Row grouping in table view** — collapsible sections grouped by a select/status property. Issue #1252 (awaiting human approval).
+- **Column calculation summary row** — sum, average, count pinned at the bottom of each column. Issue #1245 (awaiting human approval).
+- **OAuth sign-in with GitHub and Google** — code is implemented, needs Supabase dashboard configuration. Issue #1216 (awaiting human approval).
+
+## Challenges & Learnings
+
+- **Three weeks with an empty backlog.** The automation system has capacity to ship features daily, but all 5 remaining open issues carry the `needs-human` label. The oldest has been waiting 32 days. The bottleneck is product decisions, not engineering.
+- **Sentry integration still broken.** The MCP 401 error (Issue #1305) has blocked the Incident Responder for 26 days. Production error triage is manual-only until a human re-authorizes the OAuth token. This is an infrastructure issue, not a code fix.


### PR DESCRIPTION
Weekly recap for June 22–28, 2026 (Week 27).

Two accessibility features shipped (ARIA tabs for database views, search result announcer). The remaining 5 open issues are all `needs-human`. Backlog has been empty for 3 weeks.

Key numbers:
- 31 PRs merged (2 features, 21 social posts, 7 metrics, 1 audit)
- +346 lines of code (86,179 total)
- +17 unit tests (3,171 total)
- Test coverage: 37.91% (+0.14pp)
- 5 issues completed (513 done, 5 open)