### PR TITLE
chore: social post 2026-06-29 afternoon

### DIFF
--- a/metrics/daily/2026-06-29-tweet-afternoon.md
+++ b/metrics/daily/2026-06-29-tweet-afternoon.md
@@ -1,0 +1,10 @@
+## Twitter/X (afternoon)
+
+Two features shipped since this morning — right-click a page in the sidebar and you can now open it in a new tab or copy its link.
+
+5 PRs merged, 901 total. Day 78.
+
+https://memo.software-factory.dev
+Built with @ona_hq
+
+Posted: yes (https://x.com/swfactory_dev/status/2071610373153648662)


### PR DESCRIPTION
Afternoon tweet for 2026-06-29. Covers two features that shipped today: "Open in new tab" (#1460) and "Copy link" (#1457) in sidebar page menus.

Posted: https://x.com/swfactory_dev/status/2071610373153648662